### PR TITLE
Addition of __repr__ to SoftLayer Python client

### DIFF
--- a/SoftLayer/API.py
+++ b/SoftLayer/API.py
@@ -303,8 +303,8 @@ class Client:
        
         We want to have a string representation of the object that
         is meaningful and gives as much information as possible so that comandline
-        operations make since, and so that the client does not throw needless 
-        exceptions on str()
+        operations make sense, and so that the client does not throw needless 
+        exceptions on repr()
         """
         init_param_key = "%sInitParameters" % (self._service_name,)
         if init_param_key in self._headers and "id" in self._headers[init_param_key]:            


### PR DESCRIPTION
Now you can call repr() on a client object directly, or implicitly via the Python REPL.

``` python
>>> SoftLayer.API.Client("SoftLayer_Ticket", 3779609, user, key)
"<'SoftLayer_Ticket' Instance [ID: 3779609]>"
```

or

``` python
>>> x = SoftLayer.API.Client("SoftLayer_Ticket", 3779609, user, key)
>>> repr(x)
"<'SoftLayer_Ticket' Instance [ID: 3779609]>"
```

also

``` python
>>> x = SoftLayer.API.Client("SoftLayer_Account", None, user, key)
>>> x
<'SoftLayer_Account' Instance>
```

This will provide enhanced ability to use the client on the Python REPL, and prevent needless exceptions being thrown.
