### PR TITLE
Fixes the BSD License identifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'Environment :: Web Environment',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
-        'License :: OSI Approved :: BSD License'
+        'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules',


### PR DESCRIPTION
The BSD identifier in setup.py did not match the identifier in http://pypi.python.org/pypi?%3Aaction=list_classifiers
