### PR TITLE
Fix typo in CCI VLAN filters

### DIFF
--- a/SoftLayer/CCI.py
+++ b/SoftLayer/CCI.py
@@ -134,11 +134,11 @@ class CCIManager(object):
 
         if public_vlan:
             data.update({
-                'primaryNetworkCompnent':
+                'primaryNetworkComponent':
                     {"networkVlan": {"id": int(public_vlan)}}})
         if private_vlan:
             data.update({
-                "primaryBackendNetworkCompnent":
+                "primaryBackendNetworkComponent":
                     {"networkVlan": {"id": int(private_vlan)}}})
 
         if userdata:

--- a/SoftLayer/tests/API/cci_tests.py
+++ b/SoftLayer/tests/API/cci_tests.py
@@ -211,7 +211,7 @@ class CCITests_unittests(unittest.TestCase):
             'localDiskFlag': True,
             'operatingSystemReferenceCode': "STRING",
             'hourlyBillingFlag': True,
-            'primaryNetworkCompnent': {"networkVlan": {"id": 1}},
+            'primaryNetworkComponent': {"networkVlan": {"id": 1}},
         }
 
         self.assertEqual(data, assert_data)
@@ -234,7 +234,7 @@ class CCITests_unittests(unittest.TestCase):
             'localDiskFlag': True,
             'operatingSystemReferenceCode': "STRING",
             'hourlyBillingFlag': True,
-            'primaryBackendNetworkCompnent': {"networkVlan": {"id": 1}},
+            'primaryBackendNetworkComponent': {"networkVlan": {"id": 1}},
         }
 
         self.assertEqual(data, assert_data)


### PR DESCRIPTION
Fixed a few filter typos for `primaryNetworkCompnent` and `primaryBackendNetworkCompnent` (missing an "o").
