### PR TITLE
Removes Modification to Filter Structure

### DIFF
--- a/SoftLayer/API.py
+++ b/SoftLayer/API.py
@@ -238,8 +238,7 @@ class Client(object):
             headers.update(self.__format_object_mask(objectmask, service))
 
         if objectfilter is not None:
-            headers['%sObjectFilter' % service] = \
-                self.__format_filter_dict(objectfilter)
+            headers['%sObjectFilter' % service] = objectfilter
 
         if limit:
             headers['resultLimit'] = {
@@ -270,16 +269,6 @@ class Client(object):
             objectmask = "mask[%s]" % objectmask
 
         return {mheader: {'mask': objectmask}}
-
-    def __format_filter_dict(self, d):
-        """  Formats given filters to the SL-API header """
-        for key, value in d.iteritems():
-            if isinstance(value, dict):
-                d[key] = self.__format_filter_dict(value)
-                return d
-            else:
-                d[key] = {'operation': value}
-                return d
 
     def __getattr__(self, name):
         """ Attempt a SoftLayer API call

--- a/SoftLayer/tests/API/client_tests.py
+++ b/SoftLayer/tests/API/client_tests.py
@@ -145,7 +145,8 @@ class APICalls(unittest.TestCase):
             1234,
             id=5678,
             mask={'object': {'attribute': ''}},
-            filter={'TYPE': {'obj': {'attribute': '^= prefix'}}},
+            filter={
+                'TYPE': {'obj': {'attribute': {'operation': '^= prefix'}}}},
             limit=9, offset=10)
 
         make_api_call.assert_called_with(
@@ -195,7 +196,8 @@ class APICalls(unittest.TestCase):
             id=5678,
             mask={'object': {'attribute': ''}},
             raw_headers={'RAW': 'HEADER'},
-            filter={'TYPE': {'obj': {'attribute': '^= prefix'}}},
+            filter={
+                'TYPE': {'obj': {'attribute': {'operation': '^= prefix'}}}},
             limit=9, offset=10)
 
         make_api_call.assert_called_with(


### PR DESCRIPTION
- Impacts API when using filters. Has a documentation impact

``` python
client['Account'].getVirtualGuests(
    filter={'virtualGuests': {'domain': 'example.com'}})
```

would become

``` python
client['Account'].getVirtualGuests(
    filter={'virtualGuests': {'domain': {'operation': 'example.com'}}})
```

This more closely matches the API and allows for more complex operations like date range filtering and the 'in' operation.
