### PR TITLE
Generator

### DIFF
--- a/SoftLayer/API.py
+++ b/SoftLayer/API.py
@@ -209,7 +209,7 @@ class Client(object):
             name = self._prefix + name
         return Service(self, name)
 
-    def __call__(self, service, method, *args, **kwargs):
+    def __call__(self, *args, **kwargs):
         """ Perform a SoftLayer API call.
 
         :param service: the name of the SoftLayer API service
@@ -218,6 +218,12 @@ class Client(object):
         :param dict **kwargs: response-level arguments (limit, offset, etc.)
 
         """
+        if kwargs.get('iter'):
+            return self.iter_call(*args, **kwargs)
+        else:
+            return self.call(*args, **kwargs)
+
+    def call(self, service, method, *args, **kwargs):
         objectid = kwargs.get('id')
         objectmask = kwargs.get('mask')
         objectfilter = kwargs.get('filter')
@@ -264,30 +270,43 @@ class Client(object):
                              verbose=self.verbose)
 
     def iter_call(self, service, method,
-                  chunk=100, limit=None, offset=0, **kwargs):
+                  chunk=100, limit=None, offset=0, *args, **kwargs):
         if chunk <= 0:
             raise AttributeError("Chunk size should be greater than zero.")
 
         if limit:
             chunk = min(chunk, limit)
 
+        result_count = 0
         while True:
-            results = self(service, method,
-                           offset=offset, limit=chunk, **kwargs)
+            if limit:
+                # We've reached the end of the results
+                if result_count >= limit:
+                    break
+
+                # Don't over-fetch past the given limit
+                if chunk + result_count > limit:
+                    chunk = limit - result_count
+            results = self.call(service, method,
+                                offset=offset, limit=chunk, *args, **kwargs)
+
+            # It looks like we ran out results
             if not results:
                 break
 
+            # Apparently this method doesn't return a list.
+            # Why are you even iterating over this?
             if not isinstance(results, list):
                 yield results
                 break
 
             for item in results:
                 yield item
-                offset += 1
-                if offset > limit:
-                    break
+                result_count += 1
 
-            if offset >= limit:
+            offset += chunk
+
+            if len(results) < chunk:
                 break
 
     def __format_object_mask(self, objectmask, service):
@@ -331,16 +350,12 @@ class Client(object):
         if name in ["__name__", "__bases__"]:
             raise AttributeError("'Obj' object has no attribute '%s'" % name)
 
-        def call_handler(iter=False, *args, **kwargs):
+        def call_handler(*args, **kwargs):
             if self._service_name is None:
                 raise SoftLayerError(
                     "Service is not set on Client instance.")
             kwargs['headers'] = self._headers
-            if iter:
-                return self.iter_call(self._service_name, name,
-                                      *args, **kwargs)
-            else:
-                return self(self._service_name, name, *args, **kwargs)
+            return self(self._service_name, name, *args, **kwargs)
         return call_handler
 
     def __repr__(self):


### PR DESCRIPTION
This adds a generator for the API binding. This implements #65

The following bit of code will request all the CCIs 100 at a time until it reaches the end.

``` python
cci_iter = client['Account'].getVirtualGuests(iter=True, chunk=100, ...)
for cci in cci_iter:
    print cci['fullyQualifiedDomainName']
```
