### PR TITLE
Clarify CCI transaction output

### DIFF
--- a/SoftLayer/CLI/modules/cci.py
+++ b/SoftLayer/CLI/modules/cci.py
@@ -53,7 +53,7 @@ Options:
         t = Table([
             'id', 'datacenter', 'host',
             'cores', 'memory', 'primary_ip',
-            'backend_ip', 'provisioning',
+            'backend_ip', 'active_transaction',
         ])
         t.sortby = args.get('--sortby') or 'host'
 
@@ -77,7 +77,7 @@ Options:
                 guest.get('primaryIpAddress', '-'),
                 guest.get('primaryBackendIpAddress', '-'),
                 guest.get('activeTransaction', {}).get(
-                    'transactionStatus', {}).get('friendlyName', ''),
+                    'transactionStatus', {}).get('friendlyName', '<None>'),
             ])
 
         return t


### PR DESCRIPTION
- Rename the "provisioning" column to "active_transaction"
  It's slightly more accurate, and it's just a preference of mine not to
  introduce new terminology. If users interact with the API in other ways,
  it'll be called a transaction, right? Or is the terminology changing
  globally?
- Display "<None>" for an empty active transaction
  The empty string means that transaction would always have to be the last
  column, because you couldn't count on awk column offsets in selecting
  individual fields. Also, it makes it hard to grep for CCI that _don't_
  currently have an active transaction.
