### PR TITLE
Removes left padding for raw format

### DIFF
--- a/SoftLayer/CLI/core.py
+++ b/SoftLayer/CLI/core.py
@@ -83,6 +83,8 @@ def format_no_tty(table):
     t.hrules = NONE
     t.border = False
     t.header = False
+    t.left_padding_width = 0
+    t.right_padding_width = 2
     return t
 
 


### PR DESCRIPTION
For raw format, tables had a leading space. This causes some weirdness with awk columns.
Old:

```
$ sl cci list --format=raw
 12345  dal05  something.host.com   4  4096  87.65.43.22  12.34.56.78 
 54321  sjc01  something2.host.com  1  1024  12.34.56.88  87.65.43.21 
```

New:

```
$ sl cci list --format=raw
12345  dal05  something.host.com   4  4096  87.65.43.22  12.34.56.78  
54321  sjc01  something2.host.com  1  1024  12.34.56.88  87.65.43.21  
```
