### PR TITLE
Add a CCIManager.get_instance_passwords(id) method

### DIFF
--- a/SoftLayer/CCI.py
+++ b/SoftLayer/CCI.py
@@ -109,6 +109,11 @@ class CCIManager(object):
 
         return self.guest.getObject(mask=mask, id=id)
 
+    def get_instance_passwords(self, id):
+        """ Returns a list of passwords for an instance. """
+        os_info = self.guest.getOperatingSystem(mask='mask.passwords', id=id)
+        return os_info['passwords'] if 'passwords' in os_info else []
+
     def get_create_options(self):
         return self.guest.getCreateObjectOptions()
 

--- a/SoftLayer/tests/API/cci_tests.py
+++ b/SoftLayer/tests/API/cci_tests.py
@@ -58,6 +58,11 @@ class CCITests_unittests(unittest.TestCase):
         f = self.client.__getitem__().reloadCurrentOperatingSystemConfiguration
         f.assert_called_once_with(id=1)
 
+    def test_get_instance_passwords(self):
+        self.cci.get_instance_passwords(id=1)
+        f = self.client.__getitem__().getOperatingSystem
+        f.assert_called_once_with(mask='mask.passwords', id=1)
+
     @patch('SoftLayer.CCI.CCIManager._generate_create_dict')
     def test_create_verify(self, create_dict):
         create_dict.return_value = {'test': 1, 'verify': 1}


### PR DESCRIPTION
Returns a list of passwords attached to the instance, or an empty list if none were found. These don't come back from `get_instance`, for some reason, and the API considers the password part of the `get_instance` object mask to be valid.

Would be helpful to have the same method in the hardware manager too (issue #54), since they both use the same `getOperatingSystem` API call to retrieve passwords.

Includes a test that passes.
