### PR TITLE
Polishes Hardware/CCI Commands

### DIFF
--- a/SoftLayer/CLI/helpers.py
+++ b/SoftLayer/CLI/helpers.py
@@ -34,7 +34,8 @@ def mb_to_gb(megabytes):
 
 
 def gb(gigabytes):
-    return FormattedItem(gigabytes, "%dG" % float(gigabytes))
+    return FormattedItem(int(float(gigabytes)) * 1024,
+                         "%dG" % int(float(gigabytes)))
 
 
 def blank():

--- a/SoftLayer/CLI/modules/cci.py
+++ b/SoftLayer/CLI/modules/cci.py
@@ -108,16 +108,17 @@ For more on filters see 'sl help filters'
         t.sortby = args.get('--sortby') or 'host'
 
         for guest in guests:
+            guest = NestedDict(guest)
             t.add_row([
                 guest['id'],
-                guest.get('datacenter', {}).get('name', blank()),
+                guest['datacenter']['name'] or blank(),
                 guest['fullyQualifiedDomainName'],
                 guest['maxCpu'],
                 mb_to_gb(guest['maxMemory']),
-                guest.get('primaryIpAddress', blank()),
-                guest.get('primaryBackendIpAddress', blank()),
-                guest.get('activeTransaction', {}).get(
-                    'transactionStatus', {}).get('friendlyName', blank()),
+                guest['primaryIpAddress'] or blank(),
+                guest['primaryBackendIpAddress'] or blank(),
+                guest['activeTransaction']['transactionStatus']
+                ['friendlyName'] or blank(),
             ])
 
         return t
@@ -151,19 +152,18 @@ Options:
         t.add_row(['hostname', result['fullyQualifiedDomainName']])
         t.add_row(['status', result['status']['name']])
         t.add_row(['state', result['powerState']['name']])
-        t.add_row(['datacenter', result['datacenter'].get('name', blank())])
+        t.add_row(['datacenter', result['datacenter']['name'] or blank()])
         t.add_row(['cores', result['maxCpu']])
         t.add_row(['memory', mb_to_gb(result['maxMemory'])])
-        t.add_row(['public_ip', result.get('primaryIpAddress', blank())])
-        t.add_row(
-            ['private_ip', result.get('primaryBackendIpAddress', blank())])
+        t.add_row(['public_ip', result['primaryIpAddress'] or blank()])
+        t.add_row(['private_ip', result['primaryBackendIpAddress'] or blank()])
         t.add_row([
             'os',
             FormattedItem(
                 result['operatingSystem']['softwareLicense']
-                ['softwareDescription'].get('referenceCode', blank()),
+                ['softwareDescription']['referenceCode'] or blank(),
                 result['operatingSystem']['softwareLicense']
-                ['softwareDescription'].get('name', blank())
+                ['softwareDescription']['name'] or blank()
             )])
         t.add_row(['private_only', result['privateNetworkOnlyFlag']])
         t.add_row(['private_cpu', result['dedicatedAccountHostOnlyFlag']])

--- a/SoftLayer/CLI/modules/hardware.py
+++ b/SoftLayer/CLI/modules/hardware.py
@@ -53,14 +53,15 @@ List hardware servers on the acount
             'backend_ip'
         ])
         for server in servers:
+            server = NestedDict(server)
             t.add_row([
                 server['id'],
-                server.get('datacenter', {}).get('name', blank()),
+                server['datacenter']['name'] or blank(),
                 server['fullyQualifiedDomainName'],
                 server['processorCoreAmount'],
                 gb(server['memoryCapacity']),
-                server.get('primaryIpAddress', blank()),
-                server.get('primaryBackendIpAddress', blank()),
+                server['primaryIpAddress'] or blank(),
+                server['primaryBackendIpAddress'] or blank(),
             ])
 
         return t
@@ -93,22 +94,21 @@ Options:
         t.add_row(['id', result['id']])
         t.add_row(['hostname', result['fullyQualifiedDomainName']])
         t.add_row(['status', result['hardwareStatus']['status']])
-        t.add_row(['datacenter', result['datacenter'].get('name', blank())])
+        t.add_row(['datacenter', result['datacenter']['name'] or blank()])
         t.add_row(['cores', result['processorCoreAmount']])
-        t.add_row(['memory', result['memoryCapacity']])
-        t.add_row(['provisionDate', result['provisionDate']])
-        t.add_row(['public_ip', result.get('primaryIpAddress', blank())])
+        t.add_row(['memory', gb(result['memoryCapacity'])])
+        t.add_row(['public_ip', result['primaryIpAddress'] or blank()])
         t.add_row(
-            ['private_ip', result.get('primaryBackendIpAddress', blank())])
-
+            ['private_ip', result['primaryBackendIpAddress'] or blank()])
         t.add_row([
             'os',
             FormattedItem(
                 result['operatingSystem']['softwareLicense']
-                ['softwareDescription'].get('referenceCode', blank()),
+                ['softwareDescription']['referenceCode'] or blank(),
                 result['operatingSystem']['softwareLicense']
-                ['softwareDescription'].get('name', blank())
+                ['softwareDescription']['name'] or blank()
             )])
+        t.add_row(['created', result['provisionDate']])
         if result.get('notes'):
             t.add_row(['notes', result['notes']])
 

--- a/SoftLayer/tests/CLI/helper_tests.py
+++ b/SoftLayer/tests/CLI/helper_tests.py
@@ -121,15 +121,15 @@ class FormattedItemTests(unittest.TestCase):
 
     def test_gb(self):
         item = cli.gb(2)
-        self.assertEqual(2, item.original)
+        self.assertEqual(2048, item.original)
         self.assertEqual('2G', item.formatted)
 
         item = cli.gb('2')
-        self.assertEqual('2', item.original)
+        self.assertEqual(2048, item.original)
         self.assertEqual('2G', item.formatted)
 
         item = cli.gb('2.0')
-        self.assertEqual('2.0', item.original)
+        self.assertEqual(2048, item.original)
         self.assertEqual('2G', item.formatted)
 
     def test_blank(self):


### PR DESCRIPTION
- Makes hardware details look more like CCI (ordering, naming convension, units)
- Fixes several cases where blank() would never be presented when using NestedDict
  `result.get('key', blank())`  vs. `result['key'] or blank()`. I think this covers most of the cases where that happens.

This should complete #54.
