### PR TITLE
Add in network components to the get_hardware() call

### DIFF
--- a/SoftLayer/managers/hardware.py
+++ b/SoftLayer/managers/hardware.py
@@ -44,6 +44,7 @@ class HardwareManager(IdentifierMixin, object):
             items = set([
                 'id',
                 'hostname',
+                'domain',
                 'globalIdentifier',
                 'fullyQualifiedDomainName',
                 'processorCoreAmount',


### PR DESCRIPTION
This push expands the information available via the get_hardware() call so that information about the hardware's networking components is also included.
