### PR TITLE
DNS server side filtering

### DIFF
--- a/SoftLayer/CLI/core.py
+++ b/SoftLayer/CLI/core.py
@@ -234,8 +234,12 @@ def main(args=sys.argv[1:], env=Environment()):
         exit_status = e.code
     except SystemExit, e:
         exit_status = e.code
-    except (SoftLayerError, Exception), e:
+    except SoftLayerError, e:
         env.err(str(e))
+        exit_status = 1
+    except Exception, e:
+        import traceback
+        env.err(traceback.format_exc())
         exit_status = 1
 
     sys.exit(exit_status)

--- a/SoftLayer/tests/CLI/core_tests.py
+++ b/SoftLayer/tests/CLI/core_tests.py
@@ -118,6 +118,18 @@ class CommandLineTests(unittest.TestCase):
         self.assertRaises(
             KeyError, cli.core.main, args=['cci', 'list'], env=self.env)
 
+    @patch('traceback.format_exc')
+    def test_uncaught_error(self, m):
+        # Exceptions not caught should just Exit
+        errors = [TypeError, RuntimeError, NameError, OSError, SystemError]
+        for err in errors:
+            m.reset_mock()
+            m.return_value = 'testing'
+            self.env.get_module_name.side_effect = err
+            self.assertRaises(
+                SystemExit, cli.core.main, args=['cci', 'list'], env=self.env)
+            m.assert_called_once_with()
+
 
 class TestCommandParser(unittest.TestCase):
     def setUp(self):

--- a/SoftLayer/utils.py
+++ b/SoftLayer/utils.py
@@ -81,16 +81,29 @@ class IdentifierMixin:
 
         :param string identifier: identifying string
 
+        :returns list:
         """
-        # Before doing anything, let's see if this is an integer
-        try:
-            return [int(identifier)]
-        except ValueError:
-            pass  # It was worth a shot
 
-        for resolver in self.resolvers:
-            ids = resolver(identifier)
-            if ids:
-                return ids
+        return resolve_ids(identifier, self.resolvers)
 
-        return []
+
+def resolve_ids(identifier, resolvers):
+    """ Resolves IDs given a list of functions
+
+    :param string identifier: identifier string
+    :param list resolvers: a list of functions
+    :returns list:
+    """
+
+    # Before doing anything, let's see if this is an integer
+    try:
+        return [int(identifier)]
+    except ValueError:
+        pass  # It was worth a shot
+
+    for resolver in resolvers:
+        ids = resolver(identifier)
+        if ids:
+            return ids
+
+    return []


### PR DESCRIPTION
The following methods now rely on server side filters:
- DNSManager.get_zone
- DNSManager.get_records

DNSManager.get_zone now has an optional parameter of `records` which defaults to true
