### PR TITLE
Adds resolve_id helper

### DIFF
--- a/SoftLayer/CLI/helpers.py
+++ b/SoftLayer/CLI/helpers.py
@@ -12,7 +12,7 @@ from prettytable import PrettyTable
 
 __all__ = ['Table', 'CLIRunnable', 'FormattedItem', 'valid_response',
            'confirm', 'no_going_back', 'mb_to_gb', 'gb', 'listing', 'CLIAbort',
-           'NestedDict']
+           'NestedDict', 'resolve_id']
 
 
 class FormattedItem(object):
@@ -27,6 +27,29 @@ class FormattedItem(object):
         return str(self.original)
 
     __repr__ = __str__
+
+
+def resolve_id(resolver, identifier, name='object'):
+    """ Resolves a single id using an id resolver function which returns a list
+        of ids.
+
+    :param resolver: function that resolves ids. Should return None or a list
+                     of ids.
+    :param string identifier: a string identifier used to resolve ids
+    :param string name: the object type, to be used in error messages
+
+    """
+    ids = resolver(identifier)
+
+    if len(ids) == 0:
+        raise CLIAbort("Error: Unable to find %s '%s'" % (name, identifier))
+
+    if len(ids) > 1:
+        raise CLIAbort(
+            "Error: Multiple %s found for '%s': %s" %
+            (name, identifier, ', '.join([str(_id) for _id in ids])))
+
+    return ids[0]
 
 
 def mb_to_gb(megabytes):

--- a/SoftLayer/CLI/modules/cci.py
+++ b/SoftLayer/CLI/modules/cci.py
@@ -30,22 +30,7 @@ from SoftLayer.CLI import (
     CLIRunnable, Table, no_going_back, confirm, mb_to_gb, listing,
     FormattedItem)
 from SoftLayer.CLI.helpers import (
-    CLIAbort, ArgumentError, SequentialOutput,
-    NestedDict, blank)
-
-
-def resolve_id(cci_manager, identifier):
-    cci_ids = cci_manager.resolve_ids(identifier)
-
-    if len(cci_ids) == 0:
-        raise CLIAbort("Error: Unable to find CCI '%s'" % identifier)
-
-    if len(cci_ids) > 1:
-        raise CLIAbort(
-            "Error: Multiple CCIs found for '%s': %s" %
-            (identifier, ', '.join([str(_id) for _id in cci_ids])))
-
-    return cci_ids[0]
+    CLIAbort, ArgumentError, SequentialOutput, NestedDict, blank, resolve_id)
 
 
 class ListCCIs(CLIRunnable):
@@ -143,7 +128,7 @@ Options:
         t.align['Name'] = 'r'
         t.align['Value'] = 'l'
 
-        cci_id = resolve_id(cci, args.get('<identifier>'))
+        cci_id = resolve_id(cci.resolve_ids, args.get('<identifier>'), 'CCI')
         result = cci.get_instance(cci_id)
         result = NestedDict(result)
 
@@ -497,7 +482,7 @@ Optional:
     def execute(client, args):
         cci = CCIManager(client)
 
-        cci_id = resolve_id(cci, args.get('<identifier>'))
+        cci_id = resolve_id(cci.resolve_ids, args.get('<identifier>'), 'CCI')
         ready = cci.wait_for_transaction(cci_id, int(args.get('--wait') or 0))
 
         if ready:
@@ -519,7 +504,7 @@ Reload the OS on a CCI based on its current configuration
     @staticmethod
     def execute(client, args):
         cci = CCIManager(client)
-        cci_id = resolve_id(cci, args.get('<identifier>'))
+        cci_id = resolve_id(cci.resolve_ids, args.get('<identifier>'), 'CCI')
         if args['--really'] or no_going_back(cci_id):
             cci.reload_instance(cci_id)
         else:
@@ -539,7 +524,7 @@ Cancel a CCI
     @staticmethod
     def execute(client, args):
         cci = CCIManager(client)
-        cci_id = resolve_id(cci, args.get('<identifier>'))
+        cci_id = resolve_id(cci.resolve_ids, args.get('<identifier>'), 'CCI')
         if args['--really'] or no_going_back(cci_id):
             cci.cancel_instance(cci_id)
         else:
@@ -580,7 +565,7 @@ Manage active CCI
     def exec_shutdown(client, args):
         vg = client['Virtual_Guest']
         cci = CCIManager(client)
-        cci_id = resolve_id(cci, args.get('<identifier>'))
+        cci_id = resolve_id(cci.resolve_ids, args.get('<identifier>'), 'CCI')
         if args['--soft']:
             result = vg.powerOffSoft(id=cci_id)
         elif args['--cycle']:
@@ -594,28 +579,28 @@ Manage active CCI
     def exec_poweron(client, args):
         vg = client['Virtual_Guest']
         cci = CCIManager(client)
-        cci_id = resolve_id(cci, args.get('<identifier>'))
+        cci_id = resolve_id(cci.resolve_ids, args.get('<identifier>'), 'CCI')
         return vg.powerOn(id=cci_id)
 
     @staticmethod
     def exec_pause(client, args):
         vg = client['Virtual_Guest']
         cci = CCIManager(client)
-        cci_id = resolve_id(cci, args.get('<identifier>'))
+        cci_id = resolve_id(cci.resolve_ids, args.get('<identifier>'), 'CCI')
         return vg.pause(id=cci_id)
 
     @staticmethod
     def exec_resume(client, args):
         vg = client['Virtual_Guest']
         cci = CCIManager(client)
-        cci_id = resolve_id(cci, args.get('<identifier>'))
+        cci_id = resolve_id(cci.resolve_ids, args.get('<identifier>'), 'CCI')
         return vg.resume(id=cci_id)
 
     @staticmethod
     def exec_reboot(client, args):
         vg = client['Virtual_Guest']
         cci = CCIManager(client)
-        cci_id = resolve_id(cci, args.get('<identifier>'))
+        cci_id = resolve_id(cci.resolve_ids, args.get('<identifier>'), 'CCI')
         if args['--cycle']:
             result = vg.rebootHard(id=cci_id)
         elif args['--soft']:
@@ -658,7 +643,7 @@ Options:
             func = vg.setPrivateNetworkInterfaceSpeed
 
         cci = CCIManager(client)
-        cci_id = resolve_id(cci, args.get('<identifier>'))
+        cci_id = resolve_id(cci.resolve_ids, args.get('<identifier>'), 'CCI')
 
         result = func(args['--speed'], id=cci_id)
         if result:
@@ -741,7 +726,7 @@ Options:
                     instance['fullyQualifiedDomainName'],
                     ttl=7200)
 
-        cci_id = resolve_id(cci, args.get('<identifier>'))
+        cci_id = resolve_id(cci.resolve_ids, args.get('<identifier>'), 'CCI')
         instance = cci.get_instance(cci_id)
 
         if not instance['primaryIpAddress']:

--- a/SoftLayer/CLI/modules/hardware.py
+++ b/SoftLayer/CLI/modules/hardware.py
@@ -14,22 +14,8 @@ hostname or the ip address for a piece of hardware.
 """
 from SoftLayer.CLI.helpers import (
     CLIRunnable, Table, FormattedItem, NestedDict, CLIAbort, blank, listing,
-    gb, no_going_back)
+    gb, no_going_back, resolve_id)
 from SoftLayer import HardwareManager
-
-
-def resolve_id(manager, identifier):
-    ids = manager.resolve_ids(identifier)
-
-    if len(ids) == 0:
-        raise CLIAbort("Error: Unable to find hardware '%s'" % identifier)
-
-    if len(ids) > 1:
-        raise CLIAbort(
-            "Error: Multiple hardware found for '%s': %s" %
-            (identifier, ', '.join([str(_id) for _id in ids])))
-
-    return ids[0]
 
 
 class ListHardware(CLIRunnable):
@@ -124,7 +110,8 @@ Options:
         t.align['Name'] = 'r'
         t.align['Value'] = 'l'
 
-        hardware_id = resolve_id(hardware, args.get('<identifier>'))
+        hardware_id = resolve_id(
+            hardware.resolve_ids, args.get('<identifier>'), 'hardware')
         result = hardware.get_hardware(hardware_id)
         result = NestedDict(result)
 
@@ -189,7 +176,8 @@ Reload the OS on a hardware server based on its current configuration
     @staticmethod
     def execute(client, args):
         hardware = HardwareManager(client)
-        hardware_id = resolve_id(hardware, args.get('<identifier>'))
+        hardware_id = resolve_id(
+            hardware.resolve_ids, args.get('<identifier>'), 'hardware')
         if args['--really'] or no_going_back(hardware_id):
             hardware.reload(hardware_id)
         else:

--- a/SoftLayer/managers/dns.py
+++ b/SoftLayer/managers/dns.py
@@ -9,8 +9,7 @@
 from time import strftime
 
 from SoftLayer.exceptions import DNSZoneNotFound
-from SoftLayer.utils import (NestedDict, query_filter,
-                             IdentifierMixin)
+from SoftLayer.utils import NestedDict, query_filter, IdentifierMixin
 
 
 class DNSManager(IdentifierMixin, object):
@@ -135,15 +134,14 @@ class DNSManager(IdentifierMixin, object):
             _filter['resourceRecords']['data'] = query_filter(data)
 
         if type:
-            _filter['resourceRecords']['type'] = \
-                    query_filter(type.lower())
+            _filter['resourceRecords']['type'] = query_filter(type.lower())
 
         results = self.service.getResourceRecords(
             id=zone_id,
             mask='id,expire,domainId,host,minimum,refresh,retry,'
             'mxPriority,ttl,type,data,responsiblePerson',
             filter=_filter.to_dict(),
-            )
+        )
 
         return results
 

--- a/SoftLayer/managers/hardware.py
+++ b/SoftLayer/managers/hardware.py
@@ -117,10 +117,10 @@ class HardwareManager(IdentifierMixin, object):
                 'primaryBackendIpAddress',
                 'primaryIpAddress',
                 'datacenter.name',
-                'networkComponents[id, status, maxSpeed, name,' \
-                'ipmiMacAddress, ipmiIpAddress, macAddress, primaryIpAddress,'\
+                'networkComponents[id, status, maxSpeed, name,'
+                'ipmiMacAddress, ipmiIpAddress, macAddress, primaryIpAddress,'
                 'port, primarySubnet]',
-                'networkComponents.primarySubnet[id, netmask,' \
+                'networkComponents.primarySubnet[id, netmask,'
                 'broadcastAddress, networkIdentifier, gateway]',
                 'activeTransaction.id',
                 'operatingSystem.softwareLicense.'

--- a/SoftLayer/tests/CLI/helper_tests.py
+++ b/SoftLayer/tests/CLI/helper_tests.py
@@ -156,3 +156,22 @@ class CLIRunnableTypeTests(unittest.TestCase):
         self.assertEqual(
             cli.environment.CLIRunnableType.env.plugins,
             {'helper_tests': {'test': TestCommand}})
+
+
+class ResolveIdTests(unittest.TestCase):
+
+    def test_resolve_id_one(self):
+        resolver = lambda r: [12345]
+        id = cli.helpers.resolve_id(resolver, 'test')
+
+        self.assertEqual(id, 12345)
+
+    def test_resolve_id_none(self):
+        resolver = lambda r: []
+        self.assertRaises(
+            cli.helpers.CLIAbort, cli.helpers.resolve_id, resolver, 'test')
+
+    def test_resolve_id_multiple(self):
+        resolver = lambda r: [12345, 54321]
+        self.assertRaises(
+            cli.helpers.CLIAbort, cli.helpers.resolve_id, resolver, 'test')


### PR DESCRIPTION
To stop re-using bits of code, this adds/utilizes a new helper for CLI modules that want to resolve user-input into one (and only one) id for whatever object they're want and related tests.

Also adds the id resolver for the 'sl dns print' command
