### PR TITLE
Allow command-less modules

### DIFF
--- a/SoftLayer/CLI/core.py
+++ b/SoftLayer/CLI/core.py
@@ -123,7 +123,9 @@ Standard Options:
         # handle `sl <module> ...`
         module, module_args = self.parse_module_args(
             module_name, main_args['<args>'])
-        command_name = module_args['<command>']
+
+        # get the command argument
+        command_name = module_args.get('<command>')
 
         # handle `sl <module> <command> ...`
         return self.parse_command_args(

--- a/SoftLayer/tests/CLI/core_tests.py
+++ b/SoftLayer/tests/CLI/core_tests.py
@@ -24,6 +24,13 @@ usage: sl cci <command> [<args>...] [options]
 """
 
 
+def module_no_command_fixture():
+    """
+usage: sl cci [<args>...] [options]
+       sl cci [-h | --help]
+"""
+
+
 class submodule_fixture(object):
     """
 usage: sl cci list [options]
@@ -87,6 +94,17 @@ class CommandLineTests(unittest.TestCase):
         self.assertRaises(
             SystemExit, cli.core.main,
             args=['nope', 'list', '--config=path/to/config'], env=self.env)
+
+    def test_module_with_no_command(self):
+        self.env.plugins = {
+            'cci': {'list': submodule_fixture, None: submodule_fixture}
+        }
+        self.env.get_module_name.return_value = 'cci'
+        self.env.load_module = MagicMock()
+        self.env.load_module.return_value = module_no_command_fixture
+        resolver = cli.core.CommandParser(self.env)
+        command, command_args = resolver.parse(['cci', 'list'])
+        self.assertEqual(submodule_fixture, command)
 
     def test_help(self):
         self.env.get_module_name.return_value = 'help'


### PR DESCRIPTION
Changed the command_name to have a default of none and then checked to see if command is specified before using it. This will allow us to have modules without commands specified in the module doc block. This is useful for modules that only have one command or purpose.

Currently, if the a module doc block does not contain `<command>` in the doc block text and a user tries to issue a command for that module the following error will be encountered.

```
Traceback (most recent call last):
  File "/usr/local/bin/sl", line 9, in <module>
    load_entry_point('SoftLayer==2.2.0', 'console_scripts', 'sl')()
  File "/Library/Python/2.6/site-packages/SoftLayer-2.2.0-py2.6.egg/SoftLayer/CLI/core.py", line 198, in main
    command, command_args = resolver.parse(args)
  File "/Library/Python/2.6/site-packages/SoftLayer-2.2.0-py2.6.egg/SoftLayer/CLI/core.py", line 180, in parse
    command_name = module_args['<command>']
KeyError: '<command>'
```
