### PR TITLE
Adds Password Auth to CLI Configuration

### DIFF
--- a/SoftLayer/CLI/environment.py
+++ b/SoftLayer/CLI/environment.py
@@ -7,6 +7,7 @@
     :license: BSD, see LICENSE for more details.
 """
 import sys
+import getpass
 from importlib import import_module
 from ConfigParser import SafeConfigParser
 import os
@@ -84,6 +85,9 @@ class Environment(object):
 
     def input(self, prompt):
         return raw_input(prompt)
+
+    def getpass(self, prompt):
+        return getpass.getpass(prompt)
 
     def load_config(self, files):
         config_files = [os.path.expanduser(f) for f in files]

--- a/SoftLayer/tests/CLI/environment_tests.py
+++ b/SoftLayer/tests/CLI/environment_tests.py
@@ -51,6 +51,12 @@ class EnvironmentTests(unittest.TestCase):
         raw_input_mock.assert_called_with('input')
         self.assertEqual(raw_input_mock(), r)
 
+    @patch('getpass.getpass')
+    def test_getpass(self, getpass):
+        r = self.env.getpass('input')
+        getpass.assert_called_with('input')
+        self.assertEqual(getpass(), r)
+
     @patch('os.environ', {})
     def test_parse_config_no_files(self):
         self.env.load_config([])

--- a/SoftLayer/tests/CLI/helper_tests.py
+++ b/SoftLayer/tests/CLI/helper_tests.py
@@ -6,6 +6,7 @@
     :license: BSD, see LICENSE for more details.
 """
 import sys
+import os
 try:
     import unittest2 as unittest
 except ImportError:
@@ -175,3 +176,59 @@ class ResolveIdTests(unittest.TestCase):
         resolver = lambda r: [12345, 54321]
         self.assertRaises(
             cli.helpers.CLIAbort, cli.helpers.resolve_id, resolver, 'test')
+
+
+class TestFormatOutput(unittest.TestCase):
+    def test_format_output_string(self):
+        t = cli.helpers.format_output('just a string', 'raw')
+        self.assertEqual('just a string', t)
+
+        t = cli.helpers.format_output(u'just a string', 'raw')
+        self.assertEqual(u'just a string', t)
+
+    def test_format_output_raw(self):
+        t = cli.Table(['nothing'])
+        t.align['nothing'] = 'c'
+        t.add_row(['testdata'])
+        t.sortby = 'nothing'
+        ret = cli.helpers.format_output(t, 'raw')
+
+        self.assertNotIn('nothing', str(ret))
+        self.assertIn('testdata', str(ret))
+
+    def test_format_output_formatted_item(self):
+        item = cli.FormattedItem('test', 'test_formatted')
+        ret = cli.helpers.format_output(item, 'table')
+        self.assertEqual('test_formatted', ret)
+
+    def test_format_output_list(self):
+        item = ['this', 'is', 'a', 'list']
+        ret = cli.helpers.format_output(item, 'table')
+        self.assertEqual(os.linesep.join(item), ret)
+
+    def test_format_output_table(self):
+        t = cli.Table(['nothing'])
+        t.align['nothing'] = 'c'
+        t.add_row(['testdata'])
+        t.sortby = 'nothing'
+        ret = cli.helpers.format_output(t, 'table')
+
+        self.assertIn('nothing', str(ret))
+        self.assertIn('testdata', str(ret))
+
+    def test_unknown(self):
+        t = cli.helpers.format_output({}, 'raw')
+        self.assertEqual('{}', t)
+
+    def test_sequentialoutput(self):
+        t = cli.helpers.SequentialOutput(blanks=False)
+        self.assertTrue(hasattr(t, 'append'))
+        t.append('This is a test')
+        t.append('')
+        t.append('More tests')
+        output = cli.helpers.format_output(t)
+        self.assertEqual("This is a test\nMore tests", output)
+
+        t.blanks = True
+        output = cli.helpers.format_output(t)
+        self.assertEqual("This is a test\n\nMore tests", output)


### PR DESCRIPTION
This change introduces the ability for 'sl config setup' to be given your
username/password and it will go out and grab your API key or generate one if
one does not exist.
- Moves format_output to SoftLayer.CLI.helpers
- API Key/Password input is masked
- The username/api key is displayed on screen before verifying.

Example Usage:

```
$ sl config setup
Username: someuser
API Key or Password:
Endpoint URL [https://api.softlayer.com/xmlrpc/v3/]:
:..............:..................................................................:
:         Name : Value                                                            :
:..............:..................................................................:
:     Username : someuser                                                         :
:      API Key : oyVmeipYQCNrjVS4rF9bHWV7D75S6pa1fghFl384v7mwRCbHTfuJ8qRORIqoVnha :
: Endpoint URL : https://api.softlayer.com/xmlrpc/v3/                             :
:..............:..................................................................:
Are you sure you want to write settings to "/Users/username/.softlayer"? [Y/n]: y
```

**Pending Question**: Is the verification necessary? It seems like an un-needed step at the moment since the credentials are already verified by the time you get asked if you want to save.
