### PR TITLE
CLI: Adds JSON Output format for most commands

### DIFF
--- a/SoftLayer/CLI/core.py
+++ b/SoftLayer/CLI/core.py
@@ -47,6 +47,8 @@ DEBUG_LOGGING_MAP = {
     '3': logging.DEBUG
 }
 
+VALID_FORMATS = ['raw', 'table', 'json']
+
 
 class CommandParser(object):
     def __init__(self, env):
@@ -164,7 +166,7 @@ def main(args=sys.argv[1:], env=Environment()):
         data = command.execute(client, command_args)
         if data:
             format = command_args.get('--format', 'table')
-            if format not in ['raw', 'table']:
+            if format not in VALID_FORMATS:
                 raise ArgumentError('Invalid format "%s"' % format)
             s = format_output(data, fmt=format)
             if s:

--- a/SoftLayer/CLI/modules/config.py
+++ b/SoftLayer/CLI/modules/config.py
@@ -14,12 +14,13 @@ import os.path
 
 from SoftLayer import (
     Client, SoftLayerAPIError, API_PUBLIC_ENDPOINT, API_PRIVATE_ENDPOINT)
-from SoftLayer.CLI import CLIRunnable, CLIAbort, Table, confirm, format_output
+from SoftLayer.CLI import (
+    CLIRunnable, CLIAbort, KeyValueTable, confirm, format_output)
 import ConfigParser
 
 
 def config_table(env):
-    t = Table(['Name', 'Value'])
+    t = KeyValueTable(['Name', 'Value'])
     t.align['Name'] = 'r'
     t.align['Value'] = 'l'
     config = env.config

--- a/SoftLayer/CLI/modules/image.py
+++ b/SoftLayer/CLI/modules/image.py
@@ -4,7 +4,7 @@ usage: sl image [<command>] [<args>...] [options]
 Manage compute and flex images
 
 The available commands are:
-  list  List active vlans with firewalls
+  list  List images
 """
 # :copyright: (c) 2013, SoftLayer Technologies, Inc. All rights reserved.
 # :license: BSD, see LICENSE for more details.
@@ -17,7 +17,7 @@ class ListImages(CLIRunnable):
     """
 usage: sl image list [--public | --private] [options]
 
-List images on the account
+List images
 
 Options:
   --public   Display only public images

--- a/SoftLayer/CLI/modules/metadata.py
+++ b/SoftLayer/CLI/modules/metadata.py
@@ -24,7 +24,7 @@ The available commands are:
 # :license: BSD, see LICENSE for more details.
 
 from SoftLayer import MetadataManager
-from SoftLayer.CLI import CLIRunnable, Table, listing, CLIAbort
+from SoftLayer.CLI import CLIRunnable, KeyValueTable, listing, CLIAbort
 
 
 class BackendMacAddresses(CLIRunnable):
@@ -200,7 +200,7 @@ Get details about the public or private network
     def execute(client, args):
         meta = MetadataManager()
         if args['<public>']:
-            t = Table(['Name', 'Value'])
+            t = KeyValueTable(['Name', 'Value'])
             t.align['Name'] = 'r'
             t.align['Value'] = 'l'
             network = meta.public_network()
@@ -217,7 +217,7 @@ Get details about the public or private network
             return t
 
         if args['<private>']:
-            t = Table(['Name', 'Value'])
+            t = KeyValueTable(['Name', 'Value'])
             t.align['Name'] = 'r'
             t.align['Value'] = 'l'
             network = meta.private_network()

--- a/SoftLayer/managers/cci.py
+++ b/SoftLayer/managers/cci.py
@@ -52,12 +52,12 @@ class CCIManager(IdentifierMixin, object):
                 'primaryBackendIpAddress',
                 'primaryIpAddress',
                 'lastKnownPowerState.name',
-                'powerState.name',
+                'powerState',
                 'maxCpu',
                 'maxMemory',
-                'datacenter.name',
+                'datacenter',
                 'activeTransaction.transactionStatus[friendlyName,name]',
-                'status.name',
+                'status',
             ])
             kwargs['mask'] = "mask[%s]" % ','.join(items)
 
@@ -136,15 +136,14 @@ class CCIManager(IdentifierMixin, object):
                 'networkComponents[id, status, speed, maxSpeed, name,'
                 'macAddress, primaryIpAddress, port, primarySubnet]',
                 'lastKnownPowerState.name',
-                'powerState.name',
+                'powerState',
                 'maxCpu',
                 'maxMemory',
-                'datacenter.name',
+                'datacenter',
                 'activeTransaction.id',
                 'blockDevices',
                 'blockDeviceTemplateGroup[id, name]',
                 'userData',
-                'status.name',
                 'operatingSystem.softwareLicense.'
                 'softwareDescription[manufacturer,name,version,referenceCode]',
                 'operatingSystem.passwords[username,password]',

--- a/SoftLayer/managers/hardware.py
+++ b/SoftLayer/managers/hardware.py
@@ -101,7 +101,7 @@ class HardwareManager(IdentifierMixin, object):
                 'memoryCapacity',
                 'primaryBackendIpAddress',
                 'primaryIpAddress',
-                'datacenter.name',
+                'datacenter',
             ])
             kwargs['mask'] = "mask[%s]" % ','.join(items)
 
@@ -218,7 +218,7 @@ class HardwareManager(IdentifierMixin, object):
                 'primaryBackendIpAddress',
                 'primaryIpAddress',
                 'userData',
-                'datacenter.name',
+                'datacenter',
                 'networkComponents[id, status, speed, maxSpeed, name,'
                 'ipmiMacAddress, ipmiIpAddress, macAddress, primaryIpAddress,'
                 'port, primarySubnet]',


### PR DESCRIPTION
- Changed format of displaying users/passwords in cci details (nested tables)
- Changed format of displaying cpu/memory options in create-options for cci, hardware and bmetal (nested tables)
- Adds confirmation option to 'sl hardware create'
- Creates a to_python() standard for pythonizable types
- For CCI/Hardware listing/detail datacenters shows as 'San Jose 1' for table output and 'sjc01' for JSON and raw outputs
- For CCI status/state detail shows as 'Active'/'Running' for table output and as 'ACTIVE'/'RUNNING' for JSON and raw outputs
