### PR TITLE
Adding support for ordering private network only CCIs.

### DIFF
--- a/SoftLayer/CLI/modules/cci.py
+++ b/SoftLayer/CLI/modules/cci.py
@@ -349,13 +349,15 @@ Optional:
                            Note: Omitting this value defaults to the first
                              available datacenter
   -n MBPS, --network=MBPS  Network port speed in Mbps
-  --private                Allocate a private CCI
+  --dedicated              Allocate a dedicated CCI (non-shared host)
   --dry-run, --test        Do not create CCI, just get a quote
 
   -u --userdata=DATA       User defined metadata string
   -F --userfile=FILE       Read userdata from file
   -i --postinstall=URI     Post-install script to download
                              (Only HTTPS executes, HTTP leaves file in /root)
+  --private                Forces the CCI to only have access the private
+                             network.
   --wait=SECONDS           Block until CCI is finished provisioning for up to X
                              seconds before returning.
 """
@@ -380,8 +382,9 @@ Optional:
             "cpus": args['--cpu'],
             "domain": args['--domain'],
             "hostname": args['--hostname'],
-            "private": args['--private'],
+            "dedicated": args['--dedicated'],
             "local_disk": True,
+            "private": args['--private']
         }
 
         try:

--- a/SoftLayer/managers/cci.py
+++ b/SoftLayer/managers/cci.py
@@ -218,8 +218,9 @@ class CCIManager(IdentifierMixin, object):
             self, cpus=None, memory=None, hourly=True,
             hostname=None, domain=None, local_disk=True,
             datacenter=None, os_code=None, image_id=None,
-            private=False, public_vlan=None, private_vlan=None,
-            userdata=None, nic_speed=None, disks=None, post_uri=None):
+            dedicated=False, public_vlan=None, private_vlan=None,
+            userdata=None, nic_speed=None, disks=None, post_uri=None,
+            private=False):
         """
         Translates a list of arguments into a dictionary necessary for creating
         a CCI.
@@ -238,9 +239,9 @@ class CCIManager(IdentifierMixin, object):
                                if image_id is specified.
         :param int image_id: The ID of the image to load onto the server.
                              Cannot be specified if os_code is specified.
-        :param bool private: Flag to indicate if this should be housed on a
-                             private or shared host (default). This will incur
-                             a fee on your account.
+        :param bool dedicated: Flag to indicate if this should be housed on a
+                               dedicated or shared host (default). This will
+                               incur a fee on your account.
         :param int public_vlan: The ID of the public VLAN on which you want
                                 this CCI placed.
         :param int private_vlan: The ID of the public VLAN on which you want
@@ -250,6 +251,8 @@ class CCIManager(IdentifierMixin, object):
         :param list disks: A list of disk capacities for this server.
         :param string post_url: The URI of the post-install script to run
                                 after reload
+        :param bool private: If true, the CCI will be provisioned only with
+                             access to the private network. Defaults to false
         """
 
         required = [cpus, memory, hostname, domain]
@@ -276,8 +279,11 @@ class CCIManager(IdentifierMixin, object):
 
         data["hourlyBillingFlag"] = hourly
 
+        if dedicated:
+            data["dedicatedAccountHostOnlyFlag"] = dedicated
+
         if private:
-            data["dedicatedAccountHostOnlyFlag"] = private
+            data['privateNetworkOnlyFlag'] = private
 
         if image_id:
             data["blockDeviceTemplateGroup"] = {"globalIdentifier": image_id}

--- a/SoftLayer/tests/managers/cci_tests.py
+++ b/SoftLayer/tests/managers/cci_tests.py
@@ -212,14 +212,14 @@ class CCITests(unittest.TestCase):
 
         self.assertEqual(data, assert_data)
 
-    def test_generate_private(self):
+    def test_generate_dedicated(self):
         data = self.cci._generate_create_dict(
             cpus=1,
             memory=1,
             hostname='test',
             domain='example.com',
             os_code="STRING",
-            private=True,
+            dedicated=True,
         )
 
         assert_data = {
@@ -344,6 +344,31 @@ class CCITests(unittest.TestCase):
             'domain': 'example.com',
             'localDiskFlag': True,
             'operatingSystemReferenceCode': "STRING",
+            'hourlyBillingFlag': True,
+            'networkComponents': [{'maxSpeed': 9001}],
+        }
+
+        self.assertEqual(data, assert_data)
+
+    def test_generate_private_network_only(self):
+        data = self.cci._generate_create_dict(
+            cpus=1,
+            memory=1,
+            hostname='test',
+            domain='example.com',
+            os_code="STRING",
+            nic_speed=9001,
+            private=True
+        )
+
+        assert_data = {
+            'startCpus': 1,
+            'maxMemory': 1,
+            'hostname': 'test',
+            'domain': 'example.com',
+            'localDiskFlag': True,
+            'operatingSystemReferenceCode': "STRING",
+            'privateNetworkOnlyFlag': True,
             'hourlyBillingFlag': True,
             'networkComponents': [{'maxSpeed': 9001}],
         }


### PR DESCRIPTION
 Also renamed previous 'private' option to 'dedicated' for a more accurate description
