### PR TITLE
Consistency Changes for #144

### DIFF
--- a/SoftLayer/CLI/core.py
+++ b/SoftLayer/CLI/core.py
@@ -7,18 +7,18 @@ usage: sl <module> [<args>...]
 SoftLayer Command-line Client
 
 The available modules are:
-  cci       Manage, delete, order compute instances
+  bmc       Interact with bare metal instances
+  cci       Manage, delete, order compute instances. Also available with 'vm'
   config    View and edit configuration for this tool
   dns       Manage DNS
   firewall  Firewall rule and security management
-  hardware  View hardware details
-  bmetal    Interact with bare metal instances
-  network   Perform various network operations
   help      Show help
-  iscsi     View iSCSI details
   image     Manages compute and flex images
+  iscsi     View iSCSI details
   metadata  Get details about this machine. Also available with 'my' and 'meta'
   nas       View NAS details
+  network   Perform various network operations
+  server    Manage hardware servers
   sshkey    Manage SSH keys on your account
   ssl       Manages SSL
 

--- a/SoftLayer/CLI/environment.py
+++ b/SoftLayer/CLI/environment.py
@@ -40,6 +40,9 @@ class Environment(object):
     aliases = {
         'meta': 'metadata',
         'my': 'metadata',
+        'vm': 'cci',
+        'hardware': 'server',
+        'bmetal': 'bmc',
     }
     config = {}
     stdout = sys.stdout

--- a/SoftLayer/CLI/modules/bmc.py
+++ b/SoftLayer/CLI/modules/bmc.py
@@ -1,13 +1,13 @@
 """
-usage: sl bmetal [<command>] [<args>...] [options]
-       sl bmetal [-h | --help]
+usage: sl bmc [<command>] [<args>...] [options]
+       sl bmc [-h | --help]
 
 Manage bare metal instances
 
 The available commands are:
-  create-options  Output available available options when creating a server
-  create    Create a new bare metal instance
   cancel    Cancels a bare metal instance
+  create    Create a new bare metal instance
+  create-options  Output available available options when creating a server
 
 For several commands, <identifier> will be asked for. This can be the id,
 hostname or the ip address for a piece of hardware.
@@ -23,20 +23,20 @@ from SoftLayer.CLI.helpers import (
 from SoftLayer import HardwareManager
 
 
-class BMetalCreateOptions(CLIRunnable):
+class BMCCreateOptions(CLIRunnable):
     """
-usage: sl bmetal create-options [options]
+usage: sl bmc create-options [options]
 
 Output available available options when creating a bare metal instance.
 
 Options:
   --all         Show all options. default if no other option provided
-  --datacenter  Show datacenter options
   --cpu         Show CPU options
-  --nic         Show NIC speed options
+  --datacenter  Show datacenter options
   --disk        Show disk options
-  --os          Show operating system options
   --memory      Show memory size options
+  --nic         Show NIC speed options
+  --os          Show operating system options
 """
     action = 'create-options'
     options = ['datacenter', 'cpu', 'memory', 'os', 'disk', 'nic']
@@ -262,38 +262,35 @@ Options:
         return []
 
 
-class CreateBMetalInstance(CLIRunnable):
+class CreateBMCInstance(CLIRunnable):
     """
-usage: sl bmetal create [--disk=DISK...] [options]
+usage: sl bmc create [--disk=DISK...] [options]
 
-Order/create a bare metal instance. See 'sl bmetal create-options' for valid
+Order/create a bare metal instance. See 'sl bmc create-options' for valid
 options
 
+NOTE: Due to hardware configurations, the CPU and memory must match
+      appropriately. See create-options for options
+
 Required:
-  -H --hostname=HOST  Host portion of the FQDN. example: server
-  -D --domain=DOMAIN  Domain portion of the FQDN example: example.com
   -c --cpu=CPU        Number of CPU cores
-  -m --memory=MEMORY  Memory in mebibytes (n * 1024)
-
-                      NOTE: Due to hardware configurations, the CPU and memory
-                            must match appropriately. See create-options for
-                            options.
-
-  -o OS, --os=OS      OS install code.
-
+  -D --domain=DOMAIN  Domain portion of the FQDN example: example.com
+  -H --hostname=HOST  Host portion of the FQDN. example: server
+  -m --memory=MEMORY  Memory in mebibytes. Example: 2048
+  -o OS, --os=OS      OS install code
   --hourly            Hourly rate instance type
   --monthly           Monthly rate instance type
 
 
 Optional:
-  -d DC, --datacenter=DC   datacenter name
-                           Note: Omitting this value defaults to the first
-                             available datacenter
-  -n MBPS, --network=MBPS  Network port speed in Mbps
+  -d DC, --datacenter=DC   datacenter name Note: Omitting this value defaults
+                             to the first available datacenter
   --dry-run, --test        Do not create the instance, just get a quote
+  --export=FILE            Exports options to a template file
+  -n MBPS, --network=MBPS  Network port speed in Mbps
   -t, --template=FILE      A template file that defaults the command-line
                             options using the long name in INI format
-  --export=FILE            Exports options to a template file
+
 """
     action = 'create'
     options = ['confirm']
@@ -400,7 +397,7 @@ Optional:
             output.append(FormattedItem(
                 '',
                 ' -- ! Prices reflected here are retail and do not '
-                'take account level discounts and are not guarenteed.')
+                'take account level discounts and are not guaranteed.')
             )
         elif args['--really'] or confirm(
                 "This action will incur charges on your account. Continue?"):
@@ -439,7 +436,7 @@ Optional:
     @classmethod
     def _get_cpu_and_memory_price_ids(cls, bmi_options, cpu_value,
                                       memory_value):
-        bmi_obj = BMetalCreateOptions()
+        bmi_obj = BMCCreateOptions()
         price_id = None
 
         cpu_regex = re.compile('(\d+)')
@@ -470,7 +467,7 @@ Optional:
 
     @classmethod
     def _get_price_id_from_options(cls, bmi_options, option, value):
-        bmi_obj = BMetalCreateOptions()
+        bmi_obj = BMCCreateOptions()
         price_id = None
 
         for k, v in bmi_obj.get_create_options(bmi_options, option, False):
@@ -483,13 +480,13 @@ Optional:
 
 class CancelInstance(CLIRunnable):
     """
-usage: sl bmetal cancel <identifier> [options]
+usage: sl bmc cancel <identifier> [options]
 
 Cancel a bare metal instance
 
 Options:
   --immediate  Cancels the instance immediately (instead of on the billing
-                 anniversary).
+                 anniversary)
 """
 
     action = 'cancel'

--- a/SoftLayer/CLI/modules/cci.py
+++ b/SoftLayer/CLI/modules/cci.py
@@ -4,18 +4,18 @@ usage: sl cci [<command>] [<args>...] [options]
 Manage, delete, order compute instances
 
 The available commands are:
-  network         Manage network settings
-  edit            Edit details of a CCI
+  cancel          Cancel a running CCI
   create          Order and create a CCI
                     (see `sl cci create-options` for choices)
-  manage          Manage active CCI
-  list            List CCI's on the account
+  create-options  Output available available options when creating a CCI
   detail          Output details about a CCI
   dns             DNS related actions to a CCI
-  cancel          Cancel a running CCI
-  create-options  Output available available options when creating a CCI
-  reload          Reload the OS on a CCI based on its current configuration
+  edit            Edit details of a CCI
+  list            List CCI's on the account
+  manage          Manage active CCI
+  network         Manage network settings
   ready           Check if a CCI has finished provisioning
+  reload          Reload the OS on a CCI based on its current configuration
 
 For several commands, <identifier> will be asked for. This can be the id,
 hostname or the ip address for a CCI.
@@ -54,16 +54,16 @@ Options:
                 Cores, memory, primary_ip, backend_ip
 
 Filters:
+  -c --cpu=CPU             Number of CPU cores
+  -D --domain=DOMAIN       Domain portion of the FQDN. example: example.com
+  -d DC, --datacenter=DC   datacenter shortname (sng01, dal05, ...)
+  -H --hostname=HOST       Host portion of the FQDN. example: server
+  -m --memory=MEMORY       Memory in mebibytes
+  -n MBPS, --network=MBPS  Network port speed in Mbps
   --hourly                 Show hourly instances
   --monthly                Show monthly instances
-  -H --hostname=HOST       Host portion of the FQDN. example: server
-  -D --domain=DOMAIN       Domain portion of the FQDN. example: example.com
-  -c --cpu=CPU             Number of CPU cores
-  -m --memory=MEMORY       Memory in mebibytes (n * 1024)
-  -d DC, --datacenter=DC   datacenter shortname (sng01, dal05, ...)
-  -n MBPS, --network=MBPS  Network port speed in Mbps
   --tags=ARG               Only show instances that have one of these tags.
-                           Comma-separated. (production,db)
+                             Comma-separated. (production,db)
 
 For more on filters see 'sl help filters'
 """
@@ -209,12 +209,12 @@ Output available available options when creating a CCI
 
 Options:
   --all         Show all options. default if no other option provided
-  --datacenter  Show datacenter options
   --cpu         Show CPU options
-  --nic         Show NIC speed options
+  --datacenter  Show datacenter options
   --disk        Show disk options
-  --os          Show operating system options
   --memory      Show memory size options
+  --nic         Show NIC speed options
+  --os          Show operating system options
 """
     action = 'create-options'
     options = ['datacenter', 'cpu', 'nic', 'disk', 'os', 'memory']
@@ -337,39 +337,37 @@ usage: sl cci create [options]
 Order/create a CCI. See 'sl cci create-options' for valid options
 
 Required:
-  -H --hostname=HOST  Host portion of the FQDN. example: server
-  -D --domain=DOMAIN  Domain portion of the FQDN example: example.com
-  -c --cpu=CPU        Number of CPU cores
-  -m --memory=MEMORY  Memory in mebibytes (n * 1024)
-
-  -o OS, --os=OS      OS install code. Tip: you can specify <OS>_LATEST
-  --image=GUID        Image GUID. See: 'sl image list' for reference
+  -c, --cpu=CPU        Number of CPU cores
+  -D, --domain=DOMAIN  Domain portion of the FQDN. example: example.com
+  -H, --hostname=HOST  Host portion of the FQDN. example: server
+  --image=GUID         Image GUID. See: 'sl image list' for reference
+  -m, --memory=MEMORY  Memory in mebibytes. example: 2048
+  -o, --os=OS          OS install code. Tip: you can specify <OS>_LATEST
 
   --hourly            Hourly rate instance type
   --monthly           Monthly rate instance type
 
 
 Optional:
-  -d DC, --datacenter=DC   Datacenter shortname (sng01, dal05, ...)
-                           Note: Omitting this value defaults to the first
-                             available datacenter
-  -n MBPS, --network=MBPS  Network port speed in Mbps
-  --dedicated              Allocate a dedicated CCI (non-shared host)
-  --dry-run, --test        Do not create CCI, just get a quote
-
-  -u --userdata=DATA       User defined metadata string
-  -F --userfile=FILE       Read userdata from file
-  -i --postinstall=URI     Post-install script to download
-                             (Only HTTPS executes, HTTP leaves file in /root)
-  -k KEY, --key=KEY        The SSH key to add to the root user
-  --private                Forces the CCI to only have access the private
-                             network.
-  -t, --template=FILE      A template file that defaults the command-line
-                            options using the long name in INI format
-  --like=IDENTIFIER        Use the configuration from an existing CCI
-  --export=FILE            Exports options to a template file
-  --wait=SECONDS           Block until CCI is finished provisioning for up to X
-                             seconds before returning
+  -d, --datacenter=DC    Datacenter shortname (sng01, dal05, ...)
+                         Note: Omitting this value defaults to the first
+                           available datacenter
+  --dedicated            Allocate a dedicated CCI (non-shared host)
+  --dry-run, --test      Do not create CCI, just get a quote
+  --export=FILE          Exports options to a template file
+  -F, --userfile=FILE       Read userdata from file
+                            (Only HTTPS executes, HTTP leaves file in /root)
+  -i, --postinstall=URI  Post-install script to download
+  -k, --key=KEY          The SSH key to add to the root user
+  --like=IDENTIFIER      Use the configuration from an existing CCI
+  -n, --network=MBPS     Network port speed in Mbps
+  --private              Forces the CCI to only have access the private
+                           network
+  -t, --template=FILE    A template file that defaults the command-line
+                           options using the long name in INI format
+  -u, --userdata=DATA    User defined metadata string
+  --wait=SECONDS         Block until CCI is finished provisioning for up to X
+                           seconds before returning
 """
     action = 'create'
     options = ['confirm']
@@ -423,7 +421,7 @@ Optional:
             output.append(FormattedItem(
                 None,
                 ' -- ! Prices reflected here are retail and do not '
-                'take account level discounts and are not guarenteed.')
+                'take account level discounts and are not guaranteed.')
             )
 
         if args['--export']:
@@ -765,10 +763,10 @@ usage: sl cci network port <identifier> --speed=SPEED (--public | --private)
 Manage network settings
 
 Options:
-    --speed=SPEED  Port speed. 0 disables the port.
-                   [Options: 0, 10, 100, 1000, 10000]
     --public       Public network
     --private      Private network
+    --speed=SPEED  Port speed. 0 disables the port.
+                     [Options: 0, 10, 100, 1000, 10000]
 """
     action = 'network'
 
@@ -907,10 +905,10 @@ usage: sl cci edit <identifier> [options]
 Edit CCI details
 
 Options:
-  -H --hostname=HOST  Host portion of the FQDN. example: server
   -D --domain=DOMAIN  Domain portion of the FQDN example: example.com
-  -u --userdata=DATA  User defined metadata string
   -F --userfile=FILE  Read userdata from file
+  -H --hostname=HOST  Host portion of the FQDN. example: server
+  -u --userdata=DATA  User defined metadata string
 """
     action = 'edit'
 

--- a/SoftLayer/CLI/modules/dns.py
+++ b/SoftLayer/CLI/modules/dns.py
@@ -89,10 +89,10 @@ usage: sl dns list [<zone>] [options]
 List zones and optionally, records
 
 Filters:
-  --type=TYPE    Record type, such as A or CNAME
   --data=DATA    Record data, such as an IP address
   --record=HOST  Host record, such as www
   --ttl=TTL      TTL value in seconds, such as 86400
+  --type=TYPE    Record type, such as A or CNAME
 """
     action = 'list'
 
@@ -209,8 +209,8 @@ Arguments:
 
 Options:
   --data=DATA
-  --ttl=TTL    Time to live [default: 7200]
   --id=ID      Modify only the given ID
+  --ttl=TTL    Time to live [default: 7200]
 """
     action = 'edit'
 

--- a/SoftLayer/CLI/modules/filters.py
+++ b/SoftLayer/CLI/modules/filters.py
@@ -20,8 +20,8 @@ Available Operations:
     '<= value'  Less than or equal to value
 
 Examples:
-    sl hardware list --datacenter=dal05
-    sl hardware list --hostname='prod*'
+    sl server list --datacenter=dal05
+    sl server list --hostname='prod*'
     sl cci list --network=100 --cpu=2
     sl cci list --network='< 100' --cpu=2
     sl cci list --memory='>= 2048'

--- a/SoftLayer/CLI/modules/image.py
+++ b/SoftLayer/CLI/modules/image.py
@@ -20,8 +20,8 @@ usage: sl image list [--public | --private] [options]
 List images
 
 Options:
-  --public   Display only public images
   --private  Display only private images
+  --public   Display only public images
 """
     action = 'list'
 

--- a/SoftLayer/CLI/modules/network.py
+++ b/SoftLayer/CLI/modules/network.py
@@ -5,9 +5,9 @@ Perform various network operations
 
 The available commands are:
   ip-lookup       Find information about a specific IP
-  summary         Provide a summary view of the network
   subnet-detail   Display detailed information about a subnet
   subnet-list     Show a list of all subnets on the network
+  summary         Provide a summary view of the network
   vlan-detail     Display detailed information about a VLAN
   vlan-list       Show a list of all VLANs on the network
 """
@@ -17,9 +17,7 @@ The available commands are:
 # :license: BSD, see LICENSE for more details.
 
 from SoftLayer import NetworkManager
-from SoftLayer.CLI import (CLIRunnable, Table, KeyValueTable, FormattedItem,
-                           confirm)
-from SoftLayer.CLI.helpers import (CLIAbort, SequentialOutput)
+from SoftLayer.CLI import CLIRunnable, Table, KeyValueTable
 
 
 class NetworkLookupIp(CLIRunnable):
@@ -185,9 +183,9 @@ Options:
 
 Filters:
   -d DC, --datacenter=DC   datacenter shortname (sng01, dal05, ...)
+  --identifier=ID          Filter by identifier
   --v4                     Display only IPV4 subnets
   --v6                     Display only IPV6 subnets
-  --identifier=ID          Filter by identifier
 """
     action = 'subnet-list'
 

--- a/SoftLayer/CLI/modules/server.py
+++ b/SoftLayer/CLI/modules/server.py
@@ -1,19 +1,19 @@
 """
-usage: sl hardware [<command>] [<args>...] [options]
-       sl hardware [-h | --help]
+usage: sl server [<command>] [<args>...] [options]
+       sl server [-h | --help]
 
 Manage hardware
 
 The available commands are:
-  list            List hardware devices
-  detail          Retrieve hardware details
-  reload          Perform an OS reload
   cancel          Cancel a dedicated server.
   cancel-reasons  Provides the list of possible cancellation reasons
-  network         Manage network settings
-  list-chassis    Provide a list of all chassis available for ordering
-  create-options  Display a list of creation options for a specific chassis
   create          Create a new dedicated server
+  create-options  Display a list of creation options for a specific chassis
+  detail          Retrieve hardware details
+  list            List hardware devices
+  list-chassis    Provide a list of all chassis available for ordering
+  network         Manage network settings
+  reload          Perform an OS reload
 
 For several commands, <identifier> will be asked for. This can be the id,
 hostname or the ip address for a piece of hardware.
@@ -28,30 +28,30 @@ from SoftLayer.CLI.helpers import (
 from SoftLayer import HardwareManager, SshKeyManager
 
 
-class ListHardware(CLIRunnable):
+class ListServers(CLIRunnable):
     """
-usage: sl hardware list [options]
+usage: sl server list [options]
 
 List hardware servers on the acount
 
 Examples:
-  sl hardware list --datacenter=dal05
-  sl hardware list --network=100 --domain=example.com
-  sl hardware list --tags=production,db
+  sl server list --datacenter=dal05
+  sl server list --network=100 --domain=example.com
+  sl server list --tags=production,db
 
 Options:
   --sortby=ARG  Column to sort by. options: id, datacenter, host, cores,
                   memory, primary_ip, backend_ip
 
 Filters:
-  -H --hostname=HOST       Host portion of the FQDN. example: server
-  -D --domain=DOMAIN       Domain portion of the FQDN. example: example.com
-  -c --cpu=CPU             Number of CPU cores
-  -m --memory=MEMORY       Memory in gigabytes
-  -d DC, --datacenter=DC   datacenter shortname (sng01, dal05, ...)
-  -n MBPS, --network=MBPS  Network port speed in Mbps
-  --tags=ARG               Only show instances that have one of these tags.
-                           Comma-separated. (production,db)
+  -c, --cpu=CPU        Number of CPU cores
+  -D, --domain=DOMAIN  Domain portion of the FQDN. example: example.com
+  -d, --datacenter=DC  Datacenter shortname (sng01, dal05, ...)
+  -H, --hostname=HOST  Host portion of the FQDN. example: server
+  -m, --memory=MEMORY  Memory in gigabytes
+  -n, --network=MBPS   Network port speed in Mbps
+  --tags=ARG           Only show instances that have one of these tags.
+                         Comma-separated. (production,db)
 
 For more on filters see 'sl help filters'
 """
@@ -100,9 +100,9 @@ For more on filters see 'sl help filters'
         return t
 
 
-class HardwareDetails(CLIRunnable):
+class ServerDetails(CLIRunnable):
     """
-usage: sl hardware detail [--passwords] [--price] <identifier> [options]
+usage: sl server detail [--passwords] [--price] <identifier> [options]
 
 Get details for a hardware device
 
@@ -170,7 +170,7 @@ Options:
         if tag_row:
             t.add_row(['tags', listing(tag_row, separator=',')])
 
-        ptr_domains = client['Hardware_Server'].getReverseDomainRecords(
+        ptr_domains = client['Server_Server'].getReverseDomainRecords(
             id=hardware_id)
 
         for ptr_domain in ptr_domains:
@@ -180,9 +180,9 @@ Options:
         return t
 
 
-class HardwareReload(CLIRunnable):
+class ServerReload(CLIRunnable):
     """
-usage: sl hardware reload <identifier> [options]
+usage: sl server reload <identifier> [options]
 
 Reload the OS on a hardware server based on its current configuration
 
@@ -205,15 +205,15 @@ Optional:
             CLIAbort('Aborted')
 
 
-class CancelHardware(CLIRunnable):
+class CancelServer(CLIRunnable):
     """
-usage: sl hardware cancel <identifier> [options]
+usage: sl server cancel <identifier> [options]
 
 Cancel a dedicated server
 
 Options:
-  --reason   An optional cancellation reason. See cancel-reasons for a list of
-             available options.
+  --reason  An optional cancellation reason. See cancel-reasons for a list of
+              available options
 """
 
     action = 'cancel'
@@ -235,9 +235,9 @@ Options:
             CLIAbort('Aborted')
 
 
-class HardwareCancelReasons(CLIRunnable):
+class ServerCancelReasons(CLIRunnable):
     """
-usage: sl hardware cancel-reasons
+usage: sl server cancel-reasons
 
 Display a list of cancellation reasons
 """
@@ -259,18 +259,18 @@ Display a list of cancellation reasons
         return t
 
 
-class NetworkHardware(CLIRunnable):
+class NetworkServer(CLIRunnable):
     """
-usage: sl hardware network port <identifier> --speed=SPEED
+usage: sl server network port <identifier> --speed=SPEED
                                 (--public | --private) [options]
 
 Manage network settings
 
 Options:
+    --private      Private network
+    --public       Public network
     --speed=SPEED  Port speed. 0 disables the port.
                      [Options: 0, 10, 100, 1000, 10000]
-    --public       Public network
-    --private      Private network
 """
     action = 'network'
 
@@ -296,9 +296,9 @@ Options:
             return result
 
 
-class ListChassisHardware(CLIRunnable):
+class ListChassisServer(CLIRunnable):
     """
-usage: sl hardware list-chassis [options]
+usage: sl server list-chassis [options]
 
 Display a list of chassis available for ordering dedicated servers.
 """
@@ -319,22 +319,22 @@ Display a list of chassis available for ordering dedicated servers.
         return t
 
 
-class HardwareCreateOptions(CLIRunnable):
+class ServerCreateOptions(CLIRunnable):
     """
-usage: sl hardware create-options <chassis_id> [options]
+usage: sl server create-options <chassis_id> [options]
 
 Output available available options when creating a dedicated server with the
 specified chassis.
 
 Options:
   --all         Show all options. default if no other option provided
-  --datacenter  Show datacenter options
-  --cpu         Show CPU options
-  --nic         Show NIC speed options
-  --disk        Show disk options
-  --os          Show operating system options
-  --memory      Show memory size options
   --controller  Show disk controller options
+  --cpu         Show CPU options
+  --datacenter  Show datacenter options
+  --disk        Show disk options
+  --memory      Show memory size options
+  --nic         Show NIC speed options
+  --os          Show operating system options
 """
 
     action = 'create-options'
@@ -589,36 +589,36 @@ Options:
             return [('disk_controllers', options)]
 
 
-class CreateHardware(CLIRunnable):
+class CreateServer(CLIRunnable):
     """
-usage: sl hardware create [--disk=SIZE...] [options]
+usage: sl server create [--disk=SIZE...] [options]
 
-Order/create a dedicated server. See 'sl hardware list-chassis' and
-'sl hardware create-options' for valid options. --disk can be repeated to
+Order/create a dedicated server. See 'sl server list-chassis' and
+'sl server create-options' for valid options. --disk can be repeated to
 order multiple disks.
 
 Required:
   -H --hostname=HOST  Host portion of the FQDN. example: server
-  -D --domain=DOMAIN  Domain portion of the FQDN example: example.com
+  -D --domain=DOMAIN  Domain portion of the FQDN. example: example.com
   --chassis=CHASSIS   The chassis to use for the new server
   -c --cpu=CPU        CPU model
   -o OS, --os=OS      OS install code.
-  -m --memory=MEMORY  Memory in gigabytes
+  -m --memory=MEMORY  Memory in gigabytes. example: 4
 
 
 Optional:
-  -d DC, --datacenter=DC   datacenter name
-                           Note: Omitting this value defaults to the first
-                             available datacenter
-  -n MBPS, --network=MBPS  Network port speed in Mbps
-  -d, --disk=SIZE...       Disks. Can be specified multiple times.
-  --controller=RAID        The RAID configuration for the server.
-                             Defaults to None.
-  -k KEY, --key=KEY        The SSH key to assign to the root user
-  --dry-run, --test        Do not create the server, just get a quote
-  -t, --template=FILE      A template file that defaults the command-line
-                            options using the long name in INI format
-  --export=FILE            Exports options to a template file
+  -d, --datacenter=DC  datacenter name
+                         Note: Omitting this value defaults to the first
+                         available datacenter
+  -n, --network=MBPS   Network port speed in Mbps
+  -d, --disk=SIZE...   Disks. Can be specified multiple times
+  --controller=RAID    The RAID configuration for the server.
+                         Defaults to None.
+  -k KEY, --key=KEY    The SSH key to assign to the root user
+  --dry-run, --test    Do not create the server, just get a quote
+  -t, --template=FILE  A template file that defaults the command-line
+                         options using the long name in INI format
+  --export=FILE        Exports options to a template file
 """
     action = 'create'
     options = ['confirm']
@@ -725,7 +725,7 @@ Optional:
             output.append(FormattedItem(
                 '',
                 ' -- ! Prices reflected here are retail and do not '
-                'take account level discounts and are not guarenteed.')
+                'take account level discounts and are not guaranteed.')
             )
 
         if args['--export']:
@@ -789,7 +789,7 @@ Optional:
     @classmethod
     def _get_price_id_from_options(cls, ds_options, option, value,
                                    item_id=False):
-        ds_obj = HardwareCreateOptions()
+        ds_obj = ServerCreateOptions()
 
         for k, v in ds_obj.get_create_options(ds_options, option, False):
             for item_options in v:
@@ -799,17 +799,17 @@ Optional:
                     return item_options[2]
 
 
-class EditHardware(CLIRunnable):
+class EditServer(CLIRunnable):
     """
-usage: sl hardware edit <identifier> [options]
+usage: sl server edit <identifier> [options]
 
 Edit hardware details
 
 Options:
-  -H --hostname=HOST  Host portion of the FQDN. example: server
   -D --domain=DOMAIN  Domain portion of the FQDN example: example.com
-  -u --userdata=DATA  User defined metadata string
   -F --userfile=FILE  Read userdata from file
+  -H --hostname=HOST  Host portion of the FQDN. example: server
+  -u --userdata=DATA  User defined metadata string
 """
     action = 'edit'
 

--- a/SoftLayer/CLI/modules/sshkey.py
+++ b/SoftLayer/CLI/modules/sshkey.py
@@ -30,14 +30,14 @@ Required:
   <label>                  The label for your SSH key. will appear in various
                              interfaces to help you easily identify this key.
                              You can enclose multiple words in quotation marks
-                             "like this" if desired.
+                             "like this" if desired
   -f FILE, --file=FILE     The id_rsa.pub file to import for this key. Mutually
                              exclusive with --key
   -k KEY, --key=KEY        The actual SSH key. Mutually exclusive with --file.
-                             Should be enclosed within quotation marks.
+                             Should be enclosed within quotation marks
 
 Optional:
-  -n NOTES, --notes=NOTES  Any notes you want to add to the SSH key.
+  -n NOTES, --notes=NOTES  Any notes you want to add to the SSH key
 """
     action = 'add'
 
@@ -61,10 +61,10 @@ class DeleteSshKey(CLIRunnable):
     """
 usage: sl sshkey delete <identifier> [options]
 
-Permanently deletes an SSH key from your account.
+Permanently deletes an SSH key from your account
 
 Required:
-  <identifier>   The ID or label for the SSH key to be deleted.
+  <identifier>   The ID or label for the SSH key to be deleted
 
 """
 
@@ -118,8 +118,8 @@ usage: sl sshkey list [options]
 Display a list of SSH keys on your account
 
 Options:
-  --sortby=ARG  Column to sort by. options: datacenter, vlans,
-                subnets, IPs, networking, hardware, ccis, firewall
+  --sortby=ARG  Column to sort by. options: datacenter, vlans, subnets, IPs,
+                  networking, hardware, ccis, firewall
 """
     action = 'list'
 
@@ -145,7 +145,7 @@ Prints out an SSH key to the screen
 
 Options:
   -f FILE, --file=FILE  If specified, the public SSH key will be written to
-                          this file.
+                          this file
 """
     action = 'print'
 

--- a/SoftLayer/CLI/modules/ssl.py
+++ b/SoftLayer/CLI/modules/ssl.py
@@ -5,9 +5,9 @@ usage: sl ssl [<command>] [<args>...] [options]
 Manage SSL
 
 The available commands are:
-  edit      Edit ssl certificate
-  download  Download certificate & key file
   add       Add ssl certificate
+  download  Download certificate & key file
+  edit      Edit ssl certificate
   list      List ssl certificates
   remove    Remove ssl certificate
 """
@@ -59,9 +59,9 @@ Add and upload SSL certificate details
 
 Options:
   --crt=FILE     Certificate file
-  --key=FILE     Private Key file
-  --icc=FILE     Intermediate Certificate file
   --csr=FILE     Certificate Signing Request file
+  --icc=FILE     Intermediate Certificate file
+  --key=FILE     Private Key file
   --notes=NOTES  Additional notes
 """
     action = 'add'
@@ -99,9 +99,9 @@ Edit SSL certificate
 
 Options:
   --crt=FILE     Certificate file
-  --key=FILE     Private Key file
-  --icc=FILE     Intermediate Certificate file
   --csr=FILE     Certificate Signing Request file
+  --icc=FILE     Intermediate Certificate file
+  --key=FILE     Private Key file
   --notes=NOTES  Additional notes
 """
     action = 'edit'

--- a/SoftLayer/tests/CLI/helper_tests.py
+++ b/SoftLayer/tests/CLI/helper_tests.py
@@ -372,4 +372,4 @@ class TestExportToTemplate(unittest.TestCase):
             open_().write.assert_has_calls([
                 call('datacenter=ams01\n'),
                 call('disk=disk1,disk2\n'),
-            ], any_order=False)  # Order isn't really guarenteed
+            ], any_order=False)  # Order isn't really guaranteed

--- a/docs/api/client.rst
+++ b/docs/api/client.rst
@@ -5,10 +5,9 @@ API Documentation
 =================
 This is the primary API client to make API calls. It deals with constructing and executing XML-RPC calls against the SoftLayer API. Below are some links that will help to use the SoftLayer API.
 
-.. toctree::
 
-   SoftLayer API Documentation <http://sldn.softlayer.com/reference/softlayerapi>
-   Source on Github <https://github.com/softlayer/softlayer-api-python-client>
+* `SoftLayer API Documentation <http://sldn.softlayer.com/reference/softlayerapi>`_
+* `Source on Github <https://github.com/softlayer/softlayer-api-python-client>`_
 
 ::
 
@@ -38,7 +37,7 @@ Creating a client instance with environmental variables set:
     import SoftLayer
     client = SoftLayer.Client()
 
-Below is an example of creating a client instance with more options. This will create a client with the private API endpoint (only accessable from the SoftLayer network), a timeout of 2 minutes, and with verbose mode on (prints out more than you ever wanted to know about the HTTP requests to stdout).
+Below is an example of creating a client instance with more options. This will create a client with the private API endpoint (only accessable from the SoftLayer network) and a timeout of 2 minutes.
 ::
 
     client = SoftLayer.Client(
@@ -46,7 +45,6 @@ Below is an example of creating a client instance with more options. This will c
             api_key='YOUR_API_KEY'
             endpoint_url=SoftLayer.API_PRIVATE_ENDPOINT,
             timeout=240,
-            verbose=True,
         )
 
 Managers

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -9,7 +9,6 @@ The SoftLayer command line interface is available via the `sl` command available
    :maxdepth: 2
 
    cli/cci
-   cli/dev
 
 
 .. _config_setup:

--- a/docs/cli/config_file.rst
+++ b/docs/cli/config_file.rst
@@ -1,5 +1,6 @@
 .. _config_file:
 
+
 CLI Configuration File
 ======================
 The CLI loads your settings from a number of different locations.

--- a/docs/dev/cli.rst
+++ b/docs/dev/cli.rst
@@ -1,4 +1,4 @@
-.. _dev:
+.. _cli_dev:
 
 .. note::
   
@@ -28,33 +28,22 @@ A module is a python module residing in `SoftLayer/CLI/modules/<module>.py`.  Th
   Example implementation of a CLI module
 
   Available commands are:
-    print    print example
-    pretty   formatted print example
-    parse  parsing args example
+    parse   Parsing args example
+    pretty  Formatted print example
+    print   Print example
   """
 
-  from SoftLayer.CLI import (
-      CLIRunnable, Table, no_going_back, confirm)
+There are some tenants for styling the doc blocks
+ * These are parsed with `docopt <http://docopt.org/>`_ so conform to the spec.
+ * Two spaces before commands in a command list and options in an option list. 
+ * Align the descriptions two spaces after the loggest command/option
+ * If a description has to take up more than one line, indent two spaces past the current indention for all additional lines.
+ * Alphabetize all commands/option listings. For options, use the long name to judge ordering.
 
-
-::
-
-  $ sl example
-  usage: sl example [<command>] [<args>...] [options]
-
-  Example implementation of a CLI module
-
-  Available commands are:
-    print    print example
-    pretty   formatted print example
-    parse  parsing args example
-
-  Standard Options:
-    -h --help  Show this screen
 
 Action
 ------
-Actions are implemented using classes in the module that subclass `CLIRunnable`.  The actual class name is irrelevant for the implementation details as it isn't used anywhere.  The docblock is used as the arguement parser as well.  Unlike the modules docblock, additional, common, arguments are added to the end as well; i.e. `--config` and `--format`.
+Actions are implemented using classes in the module that subclass `SoftLayer.CLI.CLIRunnable`.  The actual class name is irrelevant for the implementation details as it isn't used anywhere.  The docblock is used as the arguement parser as well.  Unlike the modules docblock, additional, common, arguments are added to the end as well; i.e. `--config` and `--format`.
 
 ::
 
@@ -72,7 +61,7 @@ Actions are implemented using classes in the module that subclass `CLIRunnable`.
 The required interfaces are:
 
 * The docblock (__doc__) for docopt
-* action
+* action class attribute
 * def execute(client, args)
 
   - Don't forget the @staticmethod annotation!

--- a/docs/dev/example_module.rst
+++ b/docs/dev/example_module.rst
@@ -2,6 +2,9 @@
 
 :orphan:
 
+Example CLI Module
+==================
+
 ::
 
     """
@@ -10,9 +13,9 @@
     Example implementation of a CLI module
 
     Available commands are:
-      print    print example
-      pretty   formatted print example
-      parse  parsing args example
+      parse   parsing args example
+      pretty  formatted print example
+      print   print example
     """
 
     from SoftLayer.CLI import (
@@ -91,3 +94,4 @@
 
             if args.get('--that'):
                 print "you dont have", args['--that']
+    

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -1,0 +1,81 @@
+.. _api_dev:
+
+Contribution Guide
+==================
+This page explains how to get started contributing code to the SoftLayer API Python Bindings project.
+
+
+Code Organization
+-----------------
+
+* **docs** - Where The source to this documentation lives.
+* **SoftLayer** - All the source lives under here.
+
+  * **API** - Primary API client.
+  * **CLI** - Code for the command-line interface.
+
+    * **modules** - CLI Modules.
+  * **managers** - API Managers. Abstractions to help use the API.
+
+
+Setting Up A Dev Environment
+----------------------------
+Before installing/downloading anything I highly recommend learning how to use Python's `virtualenv <https://pypi.python.org/pypi/virtualenv>`_. Virtualenv allows you to have isolated python environments, which is extremely useful for development. After you have a virtualenv, download the SoftLayer API Python Bindings source code. That's explained here: :ref:`install`. After you have the source, change into the base directory and run the following to install the pre-requisites for testing the project. Make sure you've activated your virtualenv before you do this.
+
+::
+
+  pip install -r requirements
+
+
+Testing
+-------
+The project have a mix of functional and unit tests. All the tests run using `nose <https://nose.readthedocs.org>`_. To run the test suite, change into the base directory and run:
+
+::
+
+  python setup.py nosetests
+
+
+To test with all supported versions of Python, this project utilizes `tox <https://pypi.python.org/pypi/tox>`_.
+
+To avoid having to install those versions of Python locally, you can also set up `Travis <https://travis-ci.org>`_ on your fork. This can run all the required tests on every code push to github. This is highly recommended.
+
+
+Documentation
+-------------
+The project is documented in `reStructuredText <http://sphinx-doc.org/rest.html>`_ and built using `Sphinx <http://sphinx-doc.org/>`_. If you have `fabric <http://fabfile.org>`_ installed, you simply need to run the following to build the docs:
+
+::
+
+  fab make_html
+
+The documentation will be built in `docs/_build/html`. If you don't have fabric, use the following commands.
+
+::
+
+  cd docs
+  make html
+
+The primary docs are built at `Read the Docs <https://readthedocs.org/projects/softlayer-api-python-client/>`_.
+
+
+Style
+-----
+This project follows :pep:`8` and most of the style suggestions that pyflakes recommends. `Flake8 <https://pypi.python.org/pypi/flake8/2.0>`_ should be ran regularly.
+
+
+Contributing
+------------
+Contributing to the Python API bindings follows the fork-pull-request model on `github <http://github.com>`_. The project uses Github's `issues <https://github.com/softlayer/softlayer-api-python-client/issues>`_ and `pull requests <https://github.com/softlayer/softlayer-api-python-client/pulls>`_ to manage source control, bug fixes and new feature development regarding the API bindings and the CLI.
+
+
+Developer Resources
+-------------------
+.. toctree::
+
+   SoftLayer API Documentation <http://sldn.softlayer.com/reference/softlayerapi>
+   Source on Github <https://github.com/softlayer/softlayer-api-python-client>
+   Issues <https://github.com/softlayer/softlayer-api-python-client/issues>
+   PyPI <https://pypi.python.org/pypi/softlayer/>
+   Twitter <https://twitter.com/SoftLayerDevs>
+   #softlayer on freenode <irc://irc.freenode.net/#softlayer>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,8 +17,18 @@ This is the documentation to SoftLayer's Python API Bindings. These bindings use
    :glob:
 
    install
-   api/client
+   api/*
    cli
+
+
+Contributing
+------------
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   dev/index
+   dev/cli
 
 
 External Links
@@ -30,3 +40,4 @@ External Links
    Issues <https://github.com/softlayer/softlayer-api-python-client/issues>
    PyPI <https://pypi.python.org/pypi/softlayer/>
    Twitter <https://twitter.com/SoftLayerDevs>
+   #softlayer on freenode <irc://irc.freenode.net/#softlayer>

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,6 +16,7 @@ Install from source gia pip (requires git): ::
 
 The most up to date version of this library can be found on the SoftLayer GitHub public repositories: https://github.com/softlayer. Please post to the SoftLayer forums https://forums.softlayer.com/ or open a support ticket in the SoftLayer customer portal if you have any questions regarding use of this library.
 
+.. _install_from_source:
 
 From Source
 -----------

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,22 +1,4 @@
-from fabric.api import local, lcd, settings
-
-
-def publish_docs():
-    " Publishes docs to github via github pages. "
-    with lcd('docs'):
-        with settings(warn_only=True):
-            local('rm -rf _build/html')
-            local('mkdir -p _build/html')
-        local('git clone -b gh-pages '
-              'git@github.com:softlayer/softlayer-api-python-client.git '
-              '_build/html')
-        local('make html')
-        with lcd('_build/html'):
-            local('touch .nojekyll')
-            local('git add .nojekyll')
-            local('git add -A')
-            local('git commit -m "Documentation Build"')
-            local('git push origin gh-pages')
+from fabric.api import local, lcd
 
 
 def make_html():

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,6 @@ setup(
         'SoftLayer.CLI',
         'SoftLayer.CLI.modules',
         'SoftLayer.managers',
-        'SoftLayer.tests',
-        'SoftLayer.tests.CLI',
-        'SoftLayer.tests.managers',
     ],
     license='The BSD License',
     zip_safe=False,
@@ -65,7 +62,7 @@ setup(
     package_data={
         'SoftLayer': ['tests/fixtures/*'],
     },
-    test_suite = 'nose.collector',
+    test_suite='nose.collector',
     install_requires=requires,
     classifiers=[
         'Environment :: Console',


### PR DESCRIPTION
- CLI: Renames bmetal to bmc (and creates an alias for bmc).
- CLI: Renames hardware to server (and creates an alias for hardware).
- CLI: Orders command list and options.
- CLI: Removes periods at the end of option descriptions.
- General: Adds contribution docs to bootstrap devs.

This does most if not all of the work for issue #144
