### PR TITLE
Adds release and upload task to the fabfile

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -9,7 +9,6 @@ def make_html():
 
 def upload():
     "Upload distribution to PyPi"
-    puts("Uploading to PyPI")
     local('python setup.py sdist register upload')
 
 


### PR DESCRIPTION
Now to do a release it should look like `fab release:3.0.0`. This will tag the release in git, build/upload the release to pypi and push the tag to upstream.
