### PR TITLE
CLI: Bug Fix for CCIs/Hardware detail with no public interface

### DIFF
--- a/SoftLayer/CLI/modules/cci.py
+++ b/SoftLayer/CLI/modules/cci.py
@@ -195,12 +195,13 @@ Options:
         if tag_row:
             t.add_row(['tags', listing(tag_row, separator=',')])
 
-        ptr_domains = client['Virtual_Guest'].\
-            getReverseDomainRecords(id=cci_id)
+        if not result['privateNetworkOnlyFlag']:
+            ptr_domains = client['Virtual_Guest'].\
+                getReverseDomainRecords(id=cci_id)
 
-        for ptr_domain in ptr_domains:
-            for ptr in ptr_domain['resourceRecords']:
-                t.add_row(['ptr', ptr['data']])
+            for ptr_domain in ptr_domains:
+                for ptr in ptr_domain['resourceRecords']:
+                    t.add_row(['ptr', ptr['data']])
 
         return t
 

--- a/SoftLayer/CLI/modules/server.py
+++ b/SoftLayer/CLI/modules/server.py
@@ -174,12 +174,13 @@ Options:
         if tag_row:
             t.add_row(['tags', listing(tag_row, separator=',')])
 
-        ptr_domains = client['Hardware_Server'].getReverseDomainRecords(
-            id=hardware_id)
+        if not result['privateNetworkOnlyFlag']:
+            ptr_domains = client['Hardware_Server'].getReverseDomainRecords(
+                id=hardware_id)
 
-        for ptr_domain in ptr_domains:
-            for ptr in ptr_domain['resourceRecords']:
-                t.add_row(['ptr', ptr['data']])
+            for ptr_domain in ptr_domains:
+                for ptr in ptr_domain['resourceRecords']:
+                    t.add_row(['ptr', ptr['data']])
 
         return t
 

--- a/SoftLayer/managers/hardware.py
+++ b/SoftLayer/managers/hardware.py
@@ -245,6 +245,7 @@ class HardwareManager(IdentifierMixin, object):
                 'processorPhysicalCoreAmount',
                 'memoryCapacity',
                 'notes',
+                'privateNetworkOnlyFlag',
                 'primaryBackendIpAddress',
                 'primaryIpAddress',
                 'userData',


### PR DESCRIPTION
`sl cci detail` and `sl server detail` was trying to get PTR records for devices without a public interface, which doesn't make sense. This change set fixes that issue.
