### PR TITLE
API: Ensures return values of lists when limit=1 is specified in a method call

### DIFF
--- a/SoftLayer/API.py
+++ b/SoftLayer/API.py
@@ -171,10 +171,18 @@ class Client(object):
             http_headers.update(raw_headers)
 
         uri = '/'.join([self.endpoint_url, service])
-        return make_xml_rpc_api_call(uri, method, args,
-                                     headers=headers,
-                                     http_headers=http_headers,
-                                     timeout=self.timeout)
+        results = make_xml_rpc_api_call(uri, method, args,
+                                        headers=headers,
+                                        http_headers=http_headers,
+                                        timeout=self.timeout)
+
+        # For some calls, the SL-API returns listings as an object instead of
+        # a list when the limit is set to 1.
+        if limit and int(limit) == 1:
+            if not isinstance(results, list):
+                results = [results]
+
+        return results
 
     __call__ = call
 

--- a/SoftLayer/tests/api_tests.py
+++ b/SoftLayer/tests/api_tests.py
@@ -6,7 +6,6 @@
     :license: MIT, see LICENSE for more details.
 """
 from mock import patch, call, Mock, MagicMock
-import datetime
 
 import SoftLayer
 import SoftLayer.API
@@ -230,6 +229,18 @@ class APIClient(unittest.TestCase):
         self.assertRaises(
             TypeError,
             self.client.call, 'SERVICE', 'METHOD', invalid_kwarg='invalid')
+
+    @patch('SoftLayer.API.make_xml_rpc_api_call')
+    def test_limit_1_call(self, make_xml_rpc_api_call):
+        # The SL API returns objects instead of a list of objects for listing
+        # calls with limit = 1
+        make_xml_rpc_api_call.return_value = {'id': 1234}
+        results = self.client['SERVICE'].METHOD(limit=1)
+        self.assertEquals([{'id': 1234}], results)
+
+        make_xml_rpc_api_call.return_value = [{'id': 1234}]
+        results = self.client['SERVICE'].METHOD(limit=1)
+        self.assertEquals([{'id': 1234}], results)
 
 
 class APITimedClient(unittest.TestCase):


### PR DESCRIPTION
Calling a method with limit=1 will always return a list from the API client. This change intends to standardize on returning a list for listing calls regardless of limit.

This change could be rejected due to the possibility of breaking existing code. 
