### PR TITLE
Fix sl bmc create --network 1000

### DIFF
--- a/SoftLayer/CLI/modules/bmc.py
+++ b/SoftLayer/CLI/modules/bmc.py
@@ -257,7 +257,7 @@ Options:
                     dual.append((str(int(item['capacity'])) + '_DUAL',
                                  item['price_id']))
                 else:
-                    single.append((int(item['capacity']), item['price_id']))
+                    single.append((str(int(item['capacity'])), item['price_id']))
 
             return [('single nic', single), ('dual nic', dual)]
 

--- a/SoftLayer/tests/CLI/modules/bmc_tests.py
+++ b/SoftLayer/tests/CLI/modules/bmc_tests.py
@@ -33,7 +33,6 @@ class BMCCLITests(unittest.TestCase):
         }
 
         client = self._setup_package_mocks(self.client)
-
         output = bmc.BMCCreateOptions.execute(client, args)
 
         expected = {
@@ -46,7 +45,7 @@ class BMCCLITests(unittest.TestCase):
                          'WIN_2008-STD-R2_64', 'WIN_2008-STD_64',
                          'WIN_2012-DC-HYPERV_64'],
             'disks': [250, 500],
-            'single nic': [100, 1000],
+            'single nic': ['100', '1000'],
             'memory/cpu': [
                 {'cpu': ['2'], 'memory': '2'},
                 {'cpu': ['4'], 'memory': '4'}
@@ -90,7 +89,7 @@ class BMCCLITests(unittest.TestCase):
             '--domain': 'example.com',
             '--datacenter': 'TEST00',
             '--cpu': '2',
-            '--network': 100,
+            '--network': '100',
             '--disk': [250, 250],
             '--os': 'UBUNTU_12_64_MINIMAL',
             '--memory': '2',


### PR DESCRIPTION
It is possible to pass --network 1000 or --network 1000_DUAL. If 1000 is treated as int it will return error 'Invalid NIC speed specified'
