### PR TITLE
Fixes Bugs with the CLI Messaging module

### DIFF
--- a/SoftLayer/CLI/core.py
+++ b/SoftLayer/CLI/core.py
@@ -17,13 +17,14 @@ Compute:
   sshkey    Manage SSH keys on your account
 
 Networking:
-  dns       Domain Name System
-  firewall  Firewall rule and security management
-  globalip  Global IP address management
-  rwhois    RWhoIs operations
-  ssl       Manages SSL
-  subnet    Subnet ordering and management
-  vlan      Manage VLANs on your account
+  dns        Domain Name System
+  firewall   Firewall rule and security management
+  globalip   Global IP address management
+  messaging  Message Queue Service
+  rwhois     RWhoIs operations
+  ssl        Manages SSL
+  subnet     Subnet ordering and management
+  vlan       Manage VLANs on your account
 
 Storage:
   iscsi     View iSCSI details

--- a/SoftLayer/CLI/modules/messaging.py
+++ b/SoftLayer/CLI/modules/messaging.py
@@ -59,6 +59,9 @@ List SoftLayer Message Queue Accounts
             'id', 'name', 'status'
         ])
         for account in accounts:
+            if not account['nodes']:
+                continue
+
             t.add_row([
                 account['nodes'][0]['accountName'],
                 account['name'],

--- a/SoftLayer/exceptions.py
+++ b/SoftLayer/exceptions.py
@@ -12,7 +12,7 @@ class SoftLayerError(StandardError):
     " The base SoftLayer error. "
 
 
-class Unauthenticated(StandardError):
+class Unauthenticated(SoftLayerError):
     " Unauthenticated "
 
 

--- a/SoftLayer/managers/messaging.py
+++ b/SoftLayer/managers/messaging.py
@@ -44,7 +44,8 @@ class QueueAuth(requests.auth.AuthBase):
         if resp.ok:
             self.auth_token = resp.headers['X-Auth-Token']
         else:
-            raise Unauthenticated("Error while authenticating", resp)
+            raise Unauthenticated("Error while authenticating: %s"
+                                  % resp.status_code)
 
     def handle_error(self, r, **kwargs):
         """ Handle errors """


### PR DESCRIPTION
- Adds messaging service to the main help so it can be discovered
- Prevents an ugly exception that occurrs if the user didn't have permission to manage message queue accounts and used `sl messaging accounts-list`
- Changes SoftLayer.exceptions.Unauthenticated to be a SoftLayerError instead of StandardError
