### PR TITLE
Fixes SoftLayer.TimedClient for Python 2.6

### DIFF
--- a/SoftLayer/API.py
+++ b/SoftLayer/API.py
@@ -6,7 +6,7 @@
     :copyright: (c) 2013, SoftLayer Technologies, Inc. All rights reserved.
     :license: MIT, see LICENSE for more details.
 """
-import datetime
+import time
 
 from consts import API_PUBLIC_ENDPOINT, API_PRIVATE_ENDPOINT, USER_AGENT
 from transports import make_xml_rpc_api_call
@@ -265,14 +265,12 @@ class TimedClient(Client):
 
     def call(self, service, method, *args, **kwargs):
         """ See Client.call for documentation. """
-        start_time = datetime.datetime.utcnow()
+        start_time = time.time()
         result = super(TimedClient, self).call(service, method, *args,
                                                **kwargs)
-        end_time = datetime.datetime.utcnow()
+        end_time = time.time()
         diff = end_time - start_time
-        self.last_calls.append((service + '.' + method,
-                                start_time.strftime('%s'),
-                                diff.total_seconds()))
+        self.last_calls.append((service + '.' + method, start_time, diff))
         return result
 
     def get_last_calls(self):

--- a/SoftLayer/tests/api_tests.py
+++ b/SoftLayer/tests/api_tests.py
@@ -5,7 +5,7 @@
     :copyright: (c) 2013, SoftLayer Technologies, Inc. All rights reserved.
     :license: MIT, see LICENSE for more details.
 """
-from mock import patch, call, Mock, MagicMock
+from mock import patch, call, Mock
 
 import SoftLayer
 import SoftLayer.API
@@ -239,32 +239,23 @@ class APIClient(unittest.TestCase):
 
 
 class APITimedClient(unittest.TestCase):
+
     def setUp(self):
         self.client = SoftLayer.TimedClient(
             username='doesnotexist', api_key='issurelywrong',
             endpoint_url="ENDPOINT")
 
-    @patch('datetime.datetime')
+    @patch('SoftLayer.API.time.time')
     @patch('SoftLayer.API.Client.call')
-    def test_overriden_call_times_methods(self, _call, datetime_mock):
+    def test_overriden_call_times_methods(self, _call, _time):
         _call.side_effect = [range(10)]
-        total_seconds_mock = Mock()
-        total_seconds_mock.total_seconds = Mock()
-        total_seconds_mock.total_seconds.return_value = 1
-        delta_mock = MagicMock()
-        delta_mock.__sub__ = Mock()
-        delta_mock.__sub__.return_value = total_seconds_mock
-        delta_mock.strftime = Mock()
-        delta_mock.strftime.return_value = 1000
-        now_mock = MagicMock()
-        now_mock.return_value = delta_mock
-        datetime_mock.utcnow = now_mock
+        _time.side_effect = [1121362200, 1121762200]
 
         result = list(self.client.call('SERVICE', 'METHOD'))
 
         self.assertEqual(range(10), result)
 
-        expected_calls = [('SERVICE.METHOD', 1000, 1)]
+        expected_calls = [('SERVICE.METHOD', 1121362200, 400000)]
         self.assertEqual(expected_calls, self.client.get_last_calls())
 
 


### PR DESCRIPTION
Also cleans up the test a bit.
