### PR TITLE
Fixes two misc CCI-related bugs

### DIFF
--- a/SoftLayer/CLI/modules/cci.py
+++ b/SoftLayer/CLI/modules/cci.py
@@ -152,12 +152,12 @@ Options:
         operating_system = lookup(result,
                                   'operatingSystem',
                                   'softwareLicense',
-                                  'softwareDescription')
+                                  'softwareDescription') or {}
         t.add_row([
             'os',
             FormattedItem(
-                operating_system['version'] or blank(),
-                operating_system['name'] or blank()
+                operating_system.get('version') or blank(),
+                operating_system.get('name') or blank()
             )])
         t.add_row(['os_version', operating_system['version'] or blank()])
         t.add_row(['cores', result['maxCpu']])

--- a/SoftLayer/managers/cci.py
+++ b/SoftLayer/managers/cci.py
@@ -314,7 +314,7 @@ class CCIManager(IdentifierMixin, object):
         if nic_speed:
             data['networkComponents'] = [{'maxSpeed': nic_speed}]
 
-        if isinstance(disks, list):
+        if disks and isinstance(disks, list):
             data['blockDevices'] = [
                 {"device": "0", "diskImage": {"capacity": disks[0]}}
             ]


### PR DESCRIPTION
CLI: Fixes an issue with `sl cci detail` where a CCI might not have an operating system.
API: When creating a CCI with the manager, if you send in disks as an empty list, [], an IndexError occurs. This fix makes that work better.
