### PR TITLE
Changes to dns cli module

### DIFF
--- a/SoftLayer/CLI/modules/dns.py
+++ b/SoftLayer/CLI/modules/dns.py
@@ -102,7 +102,7 @@ Filters:
     def list_zone(self, args):
         manager = DNSManager(self.client)
         t = Table([
-			"id",
+            "id",
             "record",
             "type",
             "ttl",
@@ -128,7 +128,7 @@ Filters:
 
         for rr in records:
             t.add_row([
-				rr['id'],
+                rr['id'],
                 rr['host'],
                 rr['type'].upper(),
                 rr['ttl'],


### PR DESCRIPTION
This adds an 'id' column to the 'sl dns list <zone>' output, as well as fixing the use of 'id' for editing dns records with 'sl dns edit <zone> <record> --id=<id>'
