### PR TITLE
Changed default version of endpoints from 3 to 3.1

### DIFF
--- a/SoftLayer/consts.py
+++ b/SoftLayer/consts.py
@@ -6,8 +6,8 @@
     :license: MIT, see LICENSE for more details.
 """
 VERSION = 'v3.0.2'
-API_PUBLIC_ENDPOINT = 'https://api.softlayer.com/xmlrpc/v3/'
-API_PRIVATE_ENDPOINT = 'https://api.service.softlayer.com/xmlrpc/v3/'
-API_PUBLIC_ENDPOINT_REST = 'https://api.softlayer.com/rest/v3/'
-API_PRIVATE_ENDPOINT_REST = 'https://api.service.softlayer.com/rest/v3/'
+API_PUBLIC_ENDPOINT = 'https://api.softlayer.com/xmlrpc/v3.1/'
+API_PRIVATE_ENDPOINT = 'https://api.service.softlayer.com/xmlrpc/v3.1/'
+API_PUBLIC_ENDPOINT_REST = 'https://api.softlayer.com/rest/v3.1/'
+API_PRIVATE_ENDPOINT_REST = 'https://api.service.softlayer.com/rest/v3.1/'
 USER_AGENT = "SoftLayer Python %s" % VERSION


### PR DESCRIPTION
This is just to change the default configured endpoint from API version 3 to version 3.1. Version 3.1 allows some new methods and services to be used due to SLAPI improvements.
