### PR TITLE
Removes last_calls from SoftLayer.Client

### DIFF
--- a/SoftLayer/API.py
+++ b/SoftLayer/API.py
@@ -67,7 +67,6 @@ class Client(object):
         self.endpoint_url = (
             settings.get('endpoint_url') or API_PUBLIC_ENDPOINT).rstrip('/')
         self.timeout = None
-        self.last_calls = []
         if settings.get('timeout'):
             self.timeout = float(settings.get('timeout'))
 
@@ -270,7 +269,10 @@ class TimedClient(Client):
     internal list. This will have a slight impact on your client's memory
     usage and performance. You should only use this for debugging.
     """
-    last_calls = []
+
+    def __init__(self, *args, **kwargs):
+        self.last_calls = []
+        super(TimedClient, self).__init__(*args, **kwargs)
 
     def call(self, service, method, *args, **kwargs):
         """ See Client.call for documentation. """


### PR DESCRIPTION
I brought this issue up as a comment to the original pull request:

https://github.com/softlayer/softlayer-python/commit/2724219b6bd0d5826a24682d834f534b2834585d#diff-42ad73fc99a4612e5eafda98f81a1ebaR266

Basically, last_calls is an array that's currently being created on each initialization. It being in the Client class was leaking an implementation of the subclass (TimedClient).
