### PR TITLE
Removes travis-ci irc notifications from the config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,3 @@ env:
   - TOX_ENV=pep8
 install: pip install tox --use-mirrors
 script: tox -e $TOX_ENV
-notifications:
-  irc:
-    - "chat.freenode.net#softlayer"


### PR DESCRIPTION
This will stay this way until travis-ci can be configured to not notify on forked repos
