### PR TITLE
Messaging Module Fixup

### DIFF
--- a/SoftLayer/CLI/modules/messaging.py
+++ b/SoftLayer/CLI/modules/messaging.py
@@ -340,7 +340,7 @@ Options:
         manager = MessagingManager(self.client)
         mq_client = manager.get_connection(args['<account_id>'])
 
-        messages = mq_client.pop_message(
+        messages = mq_client.pop_messages(
             args['<queue_name>'],
             args.get('--count') or 1)
         formatted_messages = []

--- a/SoftLayer/managers/messaging.py
+++ b/SoftLayer/managers/messaging.py
@@ -256,8 +256,8 @@ class MessagingConnection(object):
                                   data=json.dumps(message))
         return json.loads(resp.content)
 
-    def pop_message(self, queue_name, count=1):
-        """ Pop message from a queue
+    def pop_messages(self, queue_name, count=1):
+        """ Pop messages from a queue
 
         :param queue_name: Queue Name
         :param count: (optional) number of messages to retrieve
@@ -265,6 +265,18 @@ class MessagingConnection(object):
         resp = self._make_request('get', 'queues/%s/messages' % queue_name,
                                   params={'batch': count})
         return json.loads(resp.content)
+
+    def pop_message(self, queue_name):
+        """ Pop a single message from a queue. If no messages are returned
+            this returns None
+
+        :param queue_name: Queue Name
+        """
+        messages = self.pop_messages(queue_name, count=1)
+        if messages['item_count'] > 0:
+            return messages['items'][0]
+        else:
+            return None
 
     def delete_message(self, queue_name, message_id):
         """ Delete a message

--- a/SoftLayer/tests/managers/queue_tests.py
+++ b/SoftLayer/tests/managers/queue_tests.py
@@ -28,6 +28,14 @@ MESSAGE_1 = {
     'message': 'Object created',
     'visibility_delay': 0,
     'visibility_interval': 30000}
+MESSAGE_POP = {
+    'item_count': 1,
+    'items': [MESSAGE_1],
+}
+MESSAGE_POP_EMPTY = {
+    'item_count': 0,
+    'items': []
+}
 
 TOPIC_1 = {'name': 'example_topic', 'tags': ['tag1', 'tag2', 'tag3']}
 TOPIC_LIST = {'item_count': 1, 'items': [TOPIC_1]}
@@ -304,13 +312,31 @@ class MessagingConnectionTests(unittest.TestCase):
         self.assertEqual(MESSAGE_1, result)
 
     @patch('SoftLayer.managers.messaging.MessagingConnection._make_request')
+    def test_pop_messages(self, make_request):
+        make_request().content = json.dumps(MESSAGE_POP)
+        result = self.conn.pop_messages('example_queue')
+
+        make_request.assert_called_with(
+            'get', 'queues/example_queue/messages', params={'batch': 1})
+        self.assertEqual(MESSAGE_POP, result)
+
+    @patch('SoftLayer.managers.messaging.MessagingConnection._make_request')
     def test_pop_message(self, make_request):
-        make_request().content = json.dumps(MESSAGE_1)
+        make_request().content = json.dumps(MESSAGE_POP)
         result = self.conn.pop_message('example_queue')
 
         make_request.assert_called_with(
             'get', 'queues/example_queue/messages', params={'batch': 1})
         self.assertEqual(MESSAGE_1, result)
+
+    @patch('SoftLayer.managers.messaging.MessagingConnection._make_request')
+    def test_pop_message_empty(self, make_request):
+        make_request().content = json.dumps(MESSAGE_POP_EMPTY)
+        result = self.conn.pop_message('example_queue')
+
+        make_request.assert_called_with(
+            'get', 'queues/example_queue/messages', params={'batch': 1})
+        self.assertEqual(None, result)
 
     @patch('SoftLayer.managers.messaging.MessagingConnection._make_request')
     def test_delete_message(self, make_request):


### PR DESCRIPTION
Renames pop_message() to pop_messages(). Makes pop_message() a convenience method that returns only one message instead of a list.

This probably breaks existing external code!
