### PR TITLE
Image detail call modified 

### DIFF
--- a/SoftLayer/CLI/modules/image.py
+++ b/SoftLayer/CLI/modules/image.py
@@ -11,7 +11,7 @@ The available commands are:
 # :license: MIT, see LICENSE for more details.
 
 from SoftLayer import ImageManager
-
+from SoftLayer.utils import converter
 from SoftLayer.CLI import CLIRunnable, Table, KeyValueTable, blank, resolve_id
 
 
@@ -78,6 +78,7 @@ Get details for an image
                               'image')
 
         image = image_mgr.get_image(image_id)
+        data = self._parmateter_parsing(image)
 
         table = KeyValueTable(['Name', 'Value'])
         table.align['Name'] = 'r'
@@ -88,8 +89,58 @@ Get details for an image
         table.add_row(['name', image['name'].strip()])
         table.add_row(['global_identifier',
                        image.get('globalIdentifier', blank())])
+        table.add_row(['note', data.get('note', blank())])
+        table.add_row(['tag', data.get('tag', blank())])
+        table.add_row(['datacenter', data.get('location', blank())])
+        table.add_row(['status', data.get('status', blank())])
+        table.add_row(['disk_utilized', data.get('size_value', blank())])
+        table.add_row(['disk_capacity', data.get('capacity_value', blank())])
 
         return table
+
+    def _parmateter_parsing(self, image):
+        """
+        Parsing the data to get the required information
+        param image: contains image related data
+        """
+        data = {}
+        data['note'] = image.get('note')
+        data['tag'] = []
+        for i in range(len(image['tagReferences'])):
+            data['tag'].append(image['tagReferences'][i]['tag']['name'])
+        data['status'] = image['status']['name']
+        data['location'] = ""
+        for i in range(len(image['children'])):
+            data['location'] = data['location'] + "" + \
+                str((image['children'][i]['datacenter']['longName'])) + ", "
+        data['location'] = data['location'][0:-2]
+        totalblockdevices = image['children'][0]['blockDevices']
+        blockdevices_length = len(totalblockdevices)
+        capacity = [[] for i in range(blockdevices_length)]
+        capacity_unit = list(capacity)
+        size_on_disk = list(capacity)
+        size_on_disk_unit = list(capacity)
+        for i in range(blockdevices_length):
+            if totalblockdevices[i]['diskImage']['type']['name'] == 'Swap':
+                continue
+            capacity[i] = totalblockdevices[i]['diskImage']['capacity']
+            capacity_unit[i] = totalblockdevices[i]['diskImage']['units']
+            size_on_disk[i] = float(totalblockdevices[i]['diskSpace'])
+            size_on_disk_unit[i] = totalblockdevices[i]['units']
+            size_on_disk[i] = converter(size_on_disk[i])
+        if [] in capacity:
+            capacity.remove([])
+            capacity_unit.remove([])
+            size_on_disk.remove([])
+            size_on_disk_unit.remove([])
+        data['size_value'] = ""
+        data['capacity_value'] = ""
+        for i in range(len(capacity)):
+            data['size_value'] = data['size_value'] + str(size_on_disk[i]) + \
+                "    "
+            data['capacity_value'] = data['capacity_value'] + \
+                str(capacity[i]) + str(capacity_unit[i]) + "      "
+        return data
 
 
 class DeleteImage(CLIRunnable):

--- a/SoftLayer/managers/image.py
+++ b/SoftLayer/managers/image.py
@@ -31,9 +31,11 @@ class ImageManager(IdentifierMixin, object):
         :param int image: The ID of the image.
         :param dict \\*\\*kwargs: response-level options (mask, limit, etc.)
         """
+        image_mask = ('id,accountId,name,globalIdentifier,blockDevices,'
+                      'parentId,createDate,note,status,tagReferences[tag],'
+                      'children[blockDevices[diskImage[type]],datacenter]')
         if 'mask' not in kwargs:
-            kwargs['mask'] = IMAGE_MASK
-
+            kwargs['mask'] = image_mask
         return self.vgbdtg.getObject(id=image_id, **kwargs)
 
     def delete_image(self, image_id):

--- a/SoftLayer/tests/fixtures/Virtual_Guest_Block_Device_Template_Group.py
+++ b/SoftLayer/tests/fixtures/Virtual_Guest_Block_Device_Template_Group.py
@@ -5,7 +5,15 @@ IMAGES = [{
     'globalIdentifier': '0B5DEAF4-643D-46CA-A695-CECBE8832C9D',
     'id': 100,
     'name': 'test_image',
-    'parentId': ''
+    'parentId': '',
+    'note': 'image_note',
+    'tagReferences': [{'tag': {'name': 'Image_Tags'}}],
+    'status': {'name': 'Active'},
+    'children': [{'blockDevices': [{'diskImage': {'capacity': 25,
+                                    'units': 'GB', 'type': {'name': 'System'}},
+                                    'diskSpace': 1232423421234, 'units': 'B'},
+                                   {'diskImage': {'type': {'name': 'Swap'}}}],
+                 'datacenter': {'id': 138124, 'longName': 'Dallas 5'}}]
 }, {
     'accountId': 1234,
     'blockDevices': [],

--- a/SoftLayer/tests/managers/image_tests.py
+++ b/SoftLayer/tests/managers/image_tests.py
@@ -22,7 +22,6 @@ class ImageTests(unittest.TestCase):
 
     def test_get_image(self):
         result = self.image.get_image(100)
-
         self.vgbdtg.getObject.assert_called_once_with(id=100, mask=ANY)
         self.assertEqual(result,
                          Virtual_Guest_Block_Device_Template_Group.getObject)

--- a/SoftLayer/utils.py
+++ b/SoftLayer/utils.py
@@ -146,3 +146,17 @@ def resolve_ids(identifier, resolvers):
             return ids
 
     return []
+
+
+def converter(value):
+    """converts value and unit into human readable form
+
+    :param value: Value to be cionverted
+    :param unit: Unit to be converted
+    : return list
+    """
+    for unit in ['bytes', 'KB', 'MB', 'GB']:
+        if value < 1024.0:
+            return "%3.1f%s" % (value, unit)
+        value = value/1024.0
+    return "%3.1f%s" % (value, 'TB')


### PR DESCRIPTION
Currently only four fields are listed in image detail command namely id, account id, name and global_identifier which are already listed in sl image list call.So this might make the sl image detail call redundant.
Added additional fields Notes, Tags, Status, capacity and size on disk which will give us more details regarding an image. https://github.com/softlayer/softlayer-python/issues/295
Also,this will help to confirm the sl image edit call. https://github.com/softlayer/softlayer-python/pull/306
