### PR TITLE
Fixes --dry-run returning "Unknown arguments"

### DIFF
--- a/SoftLayer/CLI/modules/globalip.py
+++ b/SoftLayer/CLI/modules/globalip.py
@@ -72,7 +72,7 @@ Add a new global IP address to your account.
 
 Options:
   --v6                 Orders IPv6
-  --dry-run, --test    Do not order the IP; just get a quote
+  --test               Do not order the IP; just get a quote
 """
     action = 'create'
     options = ['confirm']

--- a/SoftLayer/CLI/modules/server.py
+++ b/SoftLayer/CLI/modules/server.py
@@ -763,7 +763,7 @@ Optional:
   -i, --postinstall=URI  Post-install script to download
   -k KEY, --key=KEY      SSH keys to assign to the root user. Can be specified
                            multiple times.
-  --dry-run, --test      Do not create the server, just get a quote
+  --test                 Do not create the server, just get a quote
   --vlan_public=VLAN     The ID of the public VLAN on which you want the
                            hardware placed
   --vlan_private=VLAN    The ID of the private VLAN on which you want the

--- a/SoftLayer/CLI/modules/subnet.py
+++ b/SoftLayer/CLI/modules/subnet.py
@@ -62,7 +62,7 @@ Required:
 
 Options:
   --v6                 Orders IPv6
-  --dry-run, --test    Do not order the subnet; just get a quote
+  --test               Do not order the subnet; just get a quote
 """
     action = 'create'
     options = ['confirm']

--- a/SoftLayer/CLI/modules/vs.py
+++ b/SoftLayer/CLI/modules/vs.py
@@ -356,7 +356,7 @@ Optional:
   --dedicated            Create a dedicated VS (Virtual Server (Private Node))
   --san                  Use SAN storage instead of local disk. Applies to
                            all disks specified with --disk.
-  --dry-run, --test      Do not create VS, just get a quote
+  --test                 Do not create VS, just get a quote
   --export=FILE          Exports options to a template file
   -F, --userfile=FILE    Read userdata from file
   -i, --postinstall=URI  Post-install script to download


### PR DESCRIPTION
It appears --dry-run didn't work at all, but its equivalent argument, --test, does work. This (possibly) seems to be a limitation of docopt. Removing --dry-run should be backwards compatible since it didn't work previously.
