### PR TITLE
Cleans up multi-line masks. Removes un-needed sets

### DIFF
--- a/SoftLayer/managers/hardware.py
+++ b/SoftLayer/managers/hardware.py
@@ -100,7 +100,7 @@ class HardwareManager(IdentifierMixin, object):
 
         """
         if 'mask' not in kwargs:
-            hw_items = set([
+            hw_items = [
                 'id',
                 'hostname',
                 'domain',
@@ -112,10 +112,10 @@ class HardwareManager(IdentifierMixin, object):
                 'primaryBackendIpAddress',
                 'primaryIpAddress',
                 'datacenter',
-            ])
-            server_items = set([
+            ]
+            server_items = [
                 'activeTransaction[id, transactionStatus[friendlyName,name]]',
-            ])
+            ]
 
             kwargs['mask'] = '[mask[%s],' \
                              ' mask(SoftLayer_Hardware_Server)[%s]]' % \
@@ -263,7 +263,7 @@ class HardwareManager(IdentifierMixin, object):
         """
 
         if 'mask' not in kwargs:
-            items = set([
+            items = [
                 'id',
                 'globalIdentifier',
                 'fullyQualifiedDomainName',
@@ -280,21 +280,20 @@ class HardwareManager(IdentifierMixin, object):
                 'networkManagementIpAddress',
                 'userData',
                 'datacenter',
-                'networkComponents[id, status, speed, maxSpeed, name,'
-                'ipmiMacAddress, ipmiIpAddress, macAddress, primaryIpAddress,'
-                'port, primarySubnet]',
-                'networkComponents.primarySubnet[id, netmask,'
-                'broadcastAddress, networkIdentifier, gateway]',
+                '''networkComponents[id, status, speed, maxSpeed, name,
+                   ipmiMacAddress, ipmiIpAddress, macAddress, primaryIpAddress,
+                   port, primarySubnet[id, netmask, broadcastAddress,
+                                       networkIdentifier, gateway]]''',
                 'hardwareChassis[id,name]',
                 'activeTransaction[id, transactionStatus[friendlyName,name]]',
-                'operatingSystem.softwareLicense.'
                 'softwareDescription[manufacturer,name,version,referenceCode]',
-                'operatingSystem.passwords[username,password]',
+                '''operatingSystem[softwareLicense,
+                                   passwords[username,password]]''',
                 'billingItem.recurringFee',
                 'hourlyBillingFlag',
                 'tagReferences[id,tag[name,id]]',
                 'networkVlans[id,vlanNumber,networkSpace]',
-            ])
+            ]
             kwargs['mask'] = "mask[%s]" % ','.join(items)
 
         return self.hardware.getObject(id=hardware_id, **kwargs)

--- a/SoftLayer/managers/iscsi.py
+++ b/SoftLayer/managers/iscsi.py
@@ -79,7 +79,7 @@ class ISCSIManager(IdentifierMixin, object):
         """
 
         if 'mask' not in kwargs:
-            items = set([
+            items = [
                 'id',
                 'serviceResourceName',
                 'createDate',
@@ -92,7 +92,7 @@ class ISCSIManager(IdentifierMixin, object):
                 'notes',
                 'username',
                 'password'
-            ])
+            ]
             kwargs['mask'] = "mask[%s]" % ','.join(items)
         return self.iscsi_svc.getObject(id=volume_id, **kwargs)
 

--- a/SoftLayer/managers/messaging.py
+++ b/SoftLayer/managers/messaging.py
@@ -78,12 +78,12 @@ class MessagingManager(object):
         :param dict \\*\\*kwargs: response-level options (mask, limit, etc.)
         """
         if 'mask' not in kwargs:
-            items = set([
+            items = [
                 'id',
                 'name',
                 'status',
                 'nodes',
-            ])
+            ]
             kwargs['mask'] = "mask[%s]" % ','.join(items)
 
         return self.client['Account'].getMessageQueueAccounts(**kwargs)

--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -58,7 +58,7 @@ class VSManager(IdentifierMixin, object):
 
         """
         if 'mask' not in kwargs:
-            items = set([
+            items = [
                 'id',
                 'globalIdentifier',
                 'hostname',
@@ -73,7 +73,7 @@ class VSManager(IdentifierMixin, object):
                 'datacenter',
                 'activeTransaction.transactionStatus[friendlyName,name]',
                 'status',
-            ])
+            ]
             kwargs['mask'] = "mask[%s]" % ','.join(items)
 
         call = 'getVirtualGuests'
@@ -149,7 +149,7 @@ class VSManager(IdentifierMixin, object):
         """
 
         if 'mask' not in kwargs:
-            items = set([
+            items = [
                 'id',
                 'globalIdentifier',
                 'fullyQualifiedDomainName',
@@ -163,8 +163,9 @@ class VSManager(IdentifierMixin, object):
                 'privateNetworkOnlyFlag',
                 'primaryBackendIpAddress',
                 'primaryIpAddress',
-                'networkComponents[id, status, speed, maxSpeed, name,'
-                'macAddress, primaryIpAddress, port, primarySubnet]',
+                '''networkComponents[id, status, speed, maxSpeed, name,'
+                                     macAddress, primaryIpAddress, port,
+                                     primarySubnet]'''
                 'lastKnownPowerState.name',
                 'powerState',
                 'status',
@@ -177,14 +178,15 @@ class VSManager(IdentifierMixin, object):
                 'blockDeviceTemplateGroup[id, name, globalIdentifier]',
                 'postInstallScriptUri',
                 'userData',
-                'operatingSystem.softwareLicense.'
-                'softwareDescription[manufacturer,name,version,referenceCode]',
-                'operatingSystem.passwords[username,password]',
+                '''operatingSystem[passwords[username,password],
+                                   softwareLicense.softwareDescription[
+                                       manufacturer,name,version,
+                                       referenceCode]]''',
                 'hourlyBillingFlag',
                 'billingItem.recurringFee',
                 'tagReferences[id,tag[name,id]]',
                 'networkVlans[id,vlanNumber,networkSpace]',
-            ])
+            ]
             kwargs['mask'] = "mask[%s]" % ','.join(items)
 
         return self.guest.getObject(id=instance_id, **kwargs)


### PR DESCRIPTION
The string continuation was fairly confusing even when you're aware it was there. Instead, this change makes long and/or deeply nested masks use multi-line strings.

Also, I removed the creation of sets. It's not really needed.
