### PR TITLE
Bumps required six version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if sys.version_info <= (2, 6):
 extra = {}
 
 requires = [
-    'six >= 1.1.0',
+    'six >= 1.7.0',
     'prettytable >= 0.7.0',
     'docopt == 0.6.1',
     'requests',

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,4 @@
 requests
 prettytable >= 0.7.0
 docopt == 0.6.1
-six >= 1.1.0
+six >= 1.7.0


### PR DESCRIPTION
Older versions of six do not have the xmlrpc client alias. This change bumps the version in setup.py and requirements.txt.

``` python
    xmlrpc_client = six.moves.xmlrpc_client  # pylint: disable=E1101,C0103
AttributeError: '_MovedItems' object has no attribute 'xmlrpc_client'
```
