### PR TITLE
Adds fast cpu provision as a package type for the HW manager

### DIFF
--- a/SoftLayer/managers/hardware.py
+++ b/SoftLayer/managers/hardware.py
@@ -212,7 +212,9 @@ class HardwareManager(utils.IdentifierMixin, object):
         ordering_manager = self.ordering_manager
 
         mask = 'id,name,description,type,isActive'
-        package_types = ['BARE_METAL_CPU', 'BARE_METAL_CORE']
+        package_types = ['BARE_METAL_CPU',
+                         'BARE_METAL_CORE',
+                         'BARE_METAL_CPU_FAST_PROVISION']
 
         packages = ordering_manager.get_packages_of_type(package_types,
                                                          mask)

--- a/SoftLayer/tests/managers/hardware_tests.py
+++ b/SoftLayer/tests/managers/hardware_tests.py
@@ -305,7 +305,9 @@ class HardwareTests(testing.TestCase):
                     'operation': 'in',
                     'options': [{
                         'name': 'data',
-                        'value': ['BARE_METAL_CPU', 'BARE_METAL_CORE']
+                        'value': ['BARE_METAL_CPU',
+                                  'BARE_METAL_CORE',
+                                  'BARE_METAL_CPU_FAST_PROVISION']
                     }]
                 }
             }


### PR DESCRIPTION
This will cause fast hardware provisioning to appear with `sl hardware list-chassis` and HardwareManager.get_available_dedicated_server_packages().

The BARE_METAL_CPU_FAST_PROVISION package that exists now doesn't appear to have a very detailed description as it just says "Bare Metal Server", but that's probably a server-side issue.
