### PR TITLE
Issues238 - added rpm spec file

### DIFF
--- a/pkg/softlayer-python.spec
+++ b/pkg/softlayer-python.spec
@@ -15,7 +15,7 @@ Source:         https://github.com/softlayer/softlayer-python/archive/%{commit}/
 
 #BuildArch:      
 BuildRequires:  python-devel, python-setuptools
-Requires:       python-requests, python-docopt = 0.6.1, python-prettytable >= 0.7.0
+Requires:       python-requests, python-click, python-prettytable >= 0.7.0
 Requires:       python-importlib, python-six >= 1.6.1
 
 %description


### PR DESCRIPTION
A pretty basic spec file, builds on CENTOS_LATEST x86 and x86_64, once you install the required packages, which was a bit of a pain since they are not in the softlayer repos :(

```
git clone https://github.com/softlayer/softlayer-python.git
cd softlayer-python
spectool -g -C /root/rpmbuild/SOURCES/  softlayer-python.spec
rpmbuild -ba softlayer-python.spec
rpm -ivh /root/rpmbuild/RPMS/i386/softlayer-python-master-2.el6.i386.rpm
```
