### PR TITLE
Fix bug with vs edit and tags

### DIFF
--- a/SoftLayer/CLI/server/create.py
+++ b/SoftLayer/CLI/server/create.py
@@ -46,9 +46,6 @@ The hourly rate is only available on bare metal instances""")
 @click.option('--export',
               type=click.Path(writable=True, resolve_path=True),
               help="Exports options to a template file")
-@click.option('--userfile', '-F',
-              help="Read userdata from file",
-              type=click.Path(exists=True, readable=True, resolve_path=True))
 @click.option('--postinstall', '-i', help="Post-install script to download")
 @click.option('--key', '-k',
               multiple=True,
@@ -63,6 +60,9 @@ The hourly rate is only available on bare metal instances""")
               help="A template file that defaults the command-line options",
               type=click.Path(exists=True, readable=True, resolve_path=True))
 @click.option('--userdata', '-u', help="User defined metadata string")
+@click.option('--userfile', '-F',
+              help="Read userdata from file",
+              type=click.Path(exists=True, readable=True, resolve_path=True))
 @click.option('--vlan-public',
               help="The ID of the public VLAN on which you want the virtual "
               "server placed",

--- a/SoftLayer/CLI/virt/create.py
+++ b/SoftLayer/CLI/virt/create.py
@@ -39,9 +39,6 @@ import click
 @click.option('--export',
               type=click.Path(writable=True, resolve_path=True),
               help="Exports options to a template file")
-@click.option('--userfile', '-F',
-              help="Read userdata from file",
-              type=click.Path(exists=True, readable=True, resolve_path=True))
 @click.option('--postinstall', '-i', help="Post-install script to download")
 @click.option('--key', '-k',
               multiple=True,
@@ -59,6 +56,9 @@ import click
               help="A template file that defaults the command-line options",
               type=click.Path(exists=True, readable=True, resolve_path=True))
 @click.option('--userdata', '-u', help="User defined metadata string")
+@click.option('--userfile', '-F',
+              help="Read userdata from file",
+              type=click.Path(exists=True, readable=True, resolve_path=True))
 @click.option('--vlan-public',
               help="The ID of the public VLAN on which you want the virtual "
               "server placed",

--- a/SoftLayer/CLI/virt/detail.py
+++ b/SoftLayer/CLI/virt/detail.py
@@ -95,7 +95,7 @@ def cli(self, identifier, passwords=False, price=False):
         tag_row.append(tag['tag']['name'])
 
     if tag_row:
-        table.add_row(['tags', formatting.listing(tag_row, separator=',')])
+        table.add_row(['tags', formatting.listing(tag_row, separator=', ')])
 
     # Test to see if this actually has a primary (public) ip address
     try:

--- a/SoftLayer/CLI/virt/edit.py
+++ b/SoftLayer/CLI/virt/edit.py
@@ -1,9 +1,6 @@
 """Edit a virtual server's details."""
 # :license: MIT, see LICENSE for more details.
 
-import os
-import os.path
-
 import SoftLayer
 from SoftLayer.CLI import environment
 from SoftLayer.CLI import exceptions
@@ -15,12 +12,15 @@ import click
 @click.command()
 @click.argument('identifier')
 @click.option('--domain', '-D', help="Domain portion of the FQDN")
-@click.option('--userfile', '-F', help="Read userdata from file")
-@click.option('--tag', '-g',
-              help="Comma list of tags to set or empty string to remove all")
 @click.option('--hostname', '-H',
               help="Host portion of the FQDN. example: server")
+@click.option('--tag', '-g',
+              multiple=True,
+              help="Tags to set or empty string to remove all")
 @click.option('--userdata', '-u', help="User defined metadata string")
+@click.option('--userfile', '-F',
+              help="Read userdata from file",
+              type=click.Path(exists=True, readable=True, resolve_path=True))
 @environment.pass_env
 def cli(env, identifier, domain, userfile, tag, hostname, userdata):
     """Edit a virtual server's details."""
@@ -30,10 +30,6 @@ def cli(env, identifier, domain, userfile, tag, hostname, userdata):
     if userdata and userfile:
         raise exceptions.ArgumentError(
             '[-u | --userdata] not allowed with [-F | --userfile]')
-    if userfile:
-        if not os.path.exists(userfile):
-            raise exceptions.ArgumentError(
-                'File does not exist [-u | --userfile] = %s' % userfile)
 
     if userdata:
         data['userdata'] = userdata
@@ -43,7 +39,7 @@ def cli(env, identifier, domain, userfile, tag, hostname, userdata):
 
     data['hostname'] = hostname
     data['domain'] = domain
-    data['tag'] = tag
+    data['tags'] = ','.join(tag)
 
     vsi = SoftLayer.VSManager(env.client)
     vs_id = helpers.resolve_id(vsi.resolve_ids, identifier, 'VS')


### PR DESCRIPTION
The initial bug was that 'tag' was being used instead of 'tags' for VSManager.edit. I ended up making a couple changes which improve consistency of userdata/userfile and tags in the CLI.
