### PR TITLE
Adds virtual/hardware server rescue to command list

### DIFF
--- a/SoftLayer/CLI/modules/server.py
+++ b/SoftLayer/CLI/modules/server.py
@@ -18,6 +18,7 @@ The available commands are:
   power-on        Boots up a server
   reboot          Reboots a running server
   reload          Perform an OS reload
+  rescue          Reboot server into a rescue image
 
 For several commands, <identifier> will be asked for. This can be the id,
 hostname or the ip address for a piece of hardware.

--- a/SoftLayer/CLI/modules/vs.py
+++ b/SoftLayer/CLI/modules/vs.py
@@ -20,6 +20,7 @@ The available commands are:
   ready           Check if a virtual server has finished provisioning
   reboot          Reboots a running virtual server
   reload          Reload the OS on a VS based on its current configuration
+  rescue          Reboot server into a rescue image
   resume          Resumes a paused virtual server
   upgrade         Upgrades parameters of a virtual server
 


### PR DESCRIPTION
Adding it to the doc block to be shown when listing commands for `sl vs` and `sl server` was overlooked.

Note that this is going to the v3 branch, not master. A minor release (3.3.1) will happen with this after a week (to give time for things like this to arise).
