### PR TITLE
display prop choices in help with examples

### DIFF
--- a/SoftLayer/CLI/metadata.py
+++ b/SoftLayer/CLI/metadata.py
@@ -44,18 +44,7 @@ Examples :
                epilog="These commands only work on devices on the backend "
                       "SoftLayer network. This allows for self-discovery for "
                       "newly provisioned resources.")
-@click.argument('prop', type=click.Choice(['backend_ip',
-                                           'backend_mac',
-                                           'datacenter',
-                                           'datacenter_id',
-                                           'fqdn',
-                                           'frontend_mac',
-                                           'id',
-                                           'ip',
-                                           'network',
-                                           'provision_state',
-                                           'tags',
-                                           'user_data']))
+@click.argument('prop', type=click.Choice(META_CHOICES))
 def cli(prop):
     """Find details about this machine."""
 


### PR DESCRIPTION
~/office/softlayer-python (issue437again) > sl metadata --help
Usage: sl metadata [OPTIONS] PROP

  Find details about this machine

  PROP Choices
  *backend_ip
  *backend_mac
  *datacenter
  *datacenter_id
  *fqdn
  *frontend_mac
  *id
  *ip
  *network
  *provision_state
  *tags
  *user_data

  Examples :
  sl metadata backend_ip
  sl metadata backend_mac
  sl metadata datacenter
  sl metadata datacenter_id
  sl metadata fqdn
  sl metadata frontend_mac
  sl metadata id
  sl metadata ip
  sl metadata network
  sl metadata provision_state
  sl metadata tags
  sl metadata user_data

Options:
  --help  Show this message and exit.

  These commands only work on devices on the backend SoftLayer network. This
  allows for self-discovery for newly provisioned resources.
