### PR TITLE
Fixes ordering with multiple disks

### DIFF
--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -332,7 +332,7 @@ class VSManager(utils.IdentifierMixin, object):
         if nic_speed:
             data['networkComponents'] = [{'maxSpeed': nic_speed}]
 
-        if disks and isinstance(disks, list):
+        if disks:
             data['blockDevices'] = [
                 {"device": "0", "diskImage": {"capacity": disks[0]}}
             ]


### PR DESCRIPTION
There was a type check for lists... With click, multiple items are represented with tuples.
