### PR TITLE
Improves logging of the assert_called_with method

### DIFF
--- a/SoftLayer/testing/__init__.py
+++ b/SoftLayer/testing/__init__.py
@@ -148,15 +148,16 @@ class TestCase(unittest.TestCase):
 def call_has_props(call, props):
     """Check if a call has matching properties of a given props dictionary."""
 
-    for prop, value in props.items():
-        call_value = getattr(call, prop)
-        if call_value != value:
-            logging.info('%s::%s property mismatch(%s): %r != %r',
-                         call.service,
-                         call.method,
-                         prop,
-                         value,
-                         call_value)
+    for prop, expected_value in props.items():
+        actual_value = getattr(call, prop)
+        if actual_value != expected_value:
+            logging.info(
+                '%s::%s property mismatch, %s: expected=%r; actual=%r',
+                call.service,
+                call.method,
+                prop,
+                expected_value,
+                actual_value)
             return False
 
     return True


### PR DESCRIPTION
This will now add a log for whenever a condition does not match when calling `self.assert_called_with()` in a test. This should make it easier to find why assertions are incorrect during test failures.
