### PR TITLE
Adding return value to create_iscsi function

### DIFF
--- a/SoftLayer/managers/iscsi.py
+++ b/SoftLayer/managers/iscsi.py
@@ -64,7 +64,7 @@ class ISCSIManager(utils.IdentifierMixin, object):
         item_price = self._find_item_prices(int(size),
                                             categorycode='iscsi')
         iscsi_order = self._build_order(item_price, location)
-        self.product_order.placeOrder(iscsi_order)
+        return self.product_order.placeOrder(iscsi_order)
 
     def list_iscsi(self):
         """List iSCSI volume."""


### PR DESCRIPTION
The function 'create_iscsi()' does not return the SoftLayer_Container_Product_Order_Receipt object, this information is needed for applications that need to know the exact volume that was just provisioned in the same scope as the provisioning call. The resourceId of the iscsi volume can then be found by looking up the billing item by the SoftLayer_Billing_Order_Item id in the 'SoftLayer_Billing_Order_Item' service.