### PR TITLE
Add argument timezone to set MAINTENANCE_WINDOW in SoftLayer/manager/vs....

### DIFF
--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -9,6 +9,7 @@ import datetime
 import itertools
 import socket
 import time
+import pytz
 
 from SoftLayer.managers import ordering
 from SoftLayer import utils
@@ -636,7 +637,7 @@ class VSManager(utils.IdentifierMixin, object):
                            'Upgrade',
             'prices': prices,
             'properties': [{'name': 'MAINTENANCE_WINDOW',
-                            'value': str(datetime.datetime.now())}],
+                            'value': str(datetime.datetime.now(tz=pytz.timezone("posixrules")))}],
             'virtualGuests': [{'id': int(instance_id)}],
         }
         if prices:

--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -637,7 +637,7 @@ class VSManager(utils.IdentifierMixin, object):
                            'Upgrade',
             'prices': prices,
             'properties': [{'name': 'MAINTENANCE_WINDOW',
-                            'value': str(datetime.datetime.now(tz=pytz.timezone("posixrules")))}],
+                            'value': str(datetime.datetime.utcnow().replace(tzinfo=pytz.utc))}],
             'virtualGuests': [{'id': int(instance_id)}],
         }
         if prices:

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ REQUIRES = [
     'prettytable >= 0.7.0',
     'click',
     'requests',
+    'pytz',
 ]
 
 if sys.version_info < (2, 7):

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -2,3 +2,4 @@ requests
 click
 prettytable >= 0.7.0
 six >= 1.7.0
+pytz


### PR DESCRIPTION
...py.

I want upgrade vs's memory from 1024MB to 2048MB, type "sl vs upgrade ID --memory 2048".
Then maintenance time is not immediate. Because not set timezone to datetime.now() in vs.py.
Add import pytz package for use timezone object.