### PR TITLE
Fixes issue with skipping confirmations

### DIFF
--- a/SoftLayer/CLI/dns/record_remove.py
+++ b/SoftLayer/CLI/dns/record_remove.py
@@ -17,7 +17,7 @@ def cli(env, record_id):
 
     manager = SoftLayer.DNSManager(env.client)
 
-    if env.skip_confirmations or formatting.no_going_back('yes'):
-        manager.delete_record(record_id)
-    else:
+    if not (env.skip_confirmations or formatting.no_going_back('yes')):
         raise exceptions.CLIAbort("Aborted.")
+
+    manager.delete_record(record_id)

--- a/SoftLayer/CLI/dns/zone_delete.py
+++ b/SoftLayer/CLI/dns/zone_delete.py
@@ -19,7 +19,7 @@ def cli(env, zone):
     manager = SoftLayer.DNSManager(env.client)
     zone_id = helpers.resolve_id(manager.resolve_ids, zone, name='zone')
 
-    if env.skip_confirmations or formatting.no_going_back(zone):
-        manager.delete_zone(zone_id)
-    else:
+    if not (env.skip_confirmations or formatting.no_going_back(zone)):
         raise exceptions.CLIAbort("Aborted.")
+
+    manager.delete_zone(zone_id)

--- a/SoftLayer/CLI/firewall/cancel.py
+++ b/SoftLayer/CLI/firewall/cancel.py
@@ -20,7 +20,7 @@ def cli(env, identifier):
     firewall_type, firewall_id = firewall.parse_id(identifier)
 
     if not (env.skip_confirmations or
-            formatting.confirm("This action will cancel a firewall from your"
+            formatting.confirm("This action will cancel a firewall from your "
                                "account. Continue?")):
         raise exceptions.CLIAbort('Aborted.')
 
@@ -28,5 +28,7 @@ def cli(env, identifier):
         mgr.cancel_firewall(firewall_id, dedicated=False)
     elif firewall_type == 'vlan':
         mgr.cancel_firewall(firewall_id, dedicated=True)
+    else:
+        raise exceptions.CLIAbort('Unknown firewall type: %s' % firewall_type)
 
     return 'Firewall with id %s is being cancelled!' % identifier

--- a/SoftLayer/CLI/firewall/cancel.py
+++ b/SoftLayer/CLI/firewall/cancel.py
@@ -19,13 +19,14 @@ def cli(env, identifier):
     mgr = SoftLayer.FirewallManager(env.client)
     firewall_type, firewall_id = firewall.parse_id(identifier)
 
-    if any([env.skip_confirmations,
+    if not (env.skip_confirmations or
             formatting.confirm("This action will cancel a firewall from your"
-                               "account. Continue?")]):
-        if firewall_type in ['vs', 'server']:
-            mgr.cancel_firewall(firewall_id, dedicated=False)
-        elif firewall_type == 'vlan':
-            mgr.cancel_firewall(firewall_id, dedicated=True)
-        return 'Firewall with id %s is being cancelled!' % identifier
-    else:
+                               "account. Continue?")):
         raise exceptions.CLIAbort('Aborted.')
+
+    if firewall_type in ['vs', 'server']:
+        mgr.cancel_firewall(firewall_id, dedicated=False)
+    elif firewall_type == 'vlan':
+        mgr.cancel_firewall(firewall_id, dedicated=True)
+
+    return 'Firewall with id %s is being cancelled!' % identifier

--- a/SoftLayer/CLI/formatting.py
+++ b/SoftLayer/CLI/formatting.py
@@ -188,9 +188,9 @@ def confirm(prompt_str, default=False):
     :param bool default: Default value to True or False
     """
     if default:
-        prompt = '%s [Y/n]: ' % prompt_str
+        prompt = '%s [Y/n]' % prompt_str
     else:
-        prompt = '%s [y/N]: ' % prompt_str
+        prompt = '%s [y/N]' % prompt_str
 
     response = valid_response(prompt, 'y', 'yes', 'yeah', 'yup', 'yolo')
 
@@ -211,7 +211,7 @@ def no_going_back(confirmation):
 
     return valid_response(
         'This action cannot be undone! '
-        'Type "%s" or press Enter to abort: ' % confirmation,
+        'Type "%s" or press Enter to abort' % confirmation,
         str(confirmation))
 
 

--- a/SoftLayer/CLI/globalip/cancel.py
+++ b/SoftLayer/CLI/globalip/cancel.py
@@ -20,7 +20,7 @@ def cli(env, identifier):
     global_ip_id = helpers.resolve_id(mgr.resolve_global_ip_ids, identifier,
                                       name='global ip')
 
-    if env.skip_confirmations or formatting.no_going_back(global_ip_id):
-        mgr.cancel_global_ip(global_ip_id)
-    else:
+    if not (env.skip_confirmations or formatting.no_going_back(global_ip_id)):
         raise exceptions.CLIAbort('Aborted')
+
+    mgr.cancel_global_ip(global_ip_id)

--- a/SoftLayer/CLI/globalip/create.py
+++ b/SoftLayer/CLI/globalip/create.py
@@ -21,10 +21,12 @@ def cli(env, ipv6, test):
     version = 4
     if ipv6:
         version = 6
-    if not test and not env.skip_confirmations:
+
+    if not (test or env.skip_confirmations):
         if not formatting.confirm("This action will incur charges on your "
                                   "account. Continue?"):
             raise exceptions.CLIAbort('Cancelling order.')
+
     result = mgr.add_global_ip(version=version, test_order=test)
 
     table = formatting.Table(['item', 'cost'])

--- a/SoftLayer/CLI/iscsi/cancel.py
+++ b/SoftLayer/CLI/iscsi/cancel.py
@@ -24,7 +24,7 @@ def cli(env, identifier, reason, immediate):
     iscsi_mgr = SoftLayer.ISCSIManager(env.client)
     iscsi_id = helpers.resolve_id(iscsi_mgr.resolve_ids, identifier, 'iSCSI')
 
-    if env.skip_confirmations or formatting.no_going_back(iscsi_id):
-        iscsi_mgr.cancel_iscsi(iscsi_id, reason, immediate)
-    else:
+    if not (env.skip_confirmations or formatting.no_going_back(iscsi_id)):
         raise exceptions.CLIAbort('Aborted')
+
+    iscsi_mgr.cancel_iscsi(iscsi_id, reason, immediate)

--- a/SoftLayer/CLI/loadbal/cancel.py
+++ b/SoftLayer/CLI/loadbal/cancel.py
@@ -20,10 +20,10 @@ def cli(env, identifier):
 
     _, loadbal_id = loadbal.parse_id(identifier)
 
-    if any([env.skip_confirmations,
+    if not (env.skip_confirmations or
             formatting.confirm("This action will cancel a load balancer. "
-                               "Continue?")]):
-        mgr.cancel_lb(loadbal_id)
-        return 'Load Balancer with id %s is being cancelled!' % identifier
-    else:
+                               "Continue?")):
         raise exceptions.CLIAbort('Aborted.')
+
+    mgr.cancel_lb(loadbal_id)
+    return 'Load Balancer with id %s is being cancelled!' % identifier

--- a/SoftLayer/CLI/loadbal/group_delete.py
+++ b/SoftLayer/CLI/loadbal/group_delete.py
@@ -19,10 +19,10 @@ def cli(env, identifier):
 
     _, group_id = loadbal.parse_id(identifier)
 
-    if env.skip_confirmations or formatting.confirm("This action will cancel "
-                                                    "a service group. "
-                                                    "Continue?"):
-        mgr.delete_service_group(group_id)
-        return 'Service group %s is being deleted!' % identifier
-    else:
+    if not (env.skip_confirmations or
+            formatting.confirm("This action will cancel a service group. "
+                               "Continue?")):
         raise exceptions.CLIAbort('Aborted.')
+
+    mgr.delete_service_group(group_id)
+    return 'Service group %s is being deleted!' % identifier

--- a/SoftLayer/CLI/loadbal/service_delete.py
+++ b/SoftLayer/CLI/loadbal/service_delete.py
@@ -19,10 +19,10 @@ def cli(env, identifier):
     mgr = SoftLayer.LoadBalancerManager(env.client)
     _, service_id = loadbal.parse_id(identifier)
 
-    if env.skip_confirmations or formatting.confirm("This action will cancel "
-                                                    "a service from your load "
-                                                    "balancer. Continue?"):
-        mgr.delete_service(service_id)
-        return 'Load balancer service %s is being cancelled!' % service_id
-    else:
+    if not (env.skip_confirmations or
+            formatting.confirm("This action will cancel a service from your "
+                               "load balancer. Continue?")):
         raise exceptions.CLIAbort('Aborted.')
+
+    mgr.delete_service(service_id)
+    return 'Load balancer service %s is being cancelled!' % service_id

--- a/SoftLayer/CLI/loadbal/service_toggle.py
+++ b/SoftLayer/CLI/loadbal/service_toggle.py
@@ -19,10 +19,10 @@ def cli(env, identifier):
     mgr = SoftLayer.LoadBalancerManager(env.client)
     _, service_id = loadbal.parse_id(identifier)
 
-    if env.skip_confirmations or formatting.confirm("This action will toggle "
-                                                    "the status on the "
-                                                    "service. Continue?"):
-        mgr.toggle_service_status(service_id)
-        return 'Load balancer service %s status updated!' % identifier
-    else:
+    if not (env.skip_confirmations or
+            formatting.confirm("This action will toggle the status on the "
+                               "service. Continue?")):
         raise exceptions.CLIAbort('Aborted.')
+
+    mgr.toggle_service_status(service_id)
+    return 'Load balancer service %s status updated!' % identifier

--- a/SoftLayer/CLI/server/cancel.py
+++ b/SoftLayer/CLI/server/cancel.py
@@ -29,9 +29,6 @@ def cli(env, identifier, immediate, comment, reason):
     mgr = SoftLayer.HardwareManager(env.client)
     hw_id = helpers.resolve_id(mgr.resolve_ids, identifier, 'hardware')
 
-    if not (comment or env.skip_confirmations):
-        comment = env.input("(Optional) Add a cancellation comment:")
-
     if not (env.skip_confirmations or formatting.no_going_back(hw_id)):
         raise exceptions.CLIAbort('Aborted')
 

--- a/SoftLayer/CLI/server/cancel.py
+++ b/SoftLayer/CLI/server/cancel.py
@@ -29,10 +29,10 @@ def cli(env, identifier, immediate, comment, reason):
     mgr = SoftLayer.HardwareManager(env.client)
     hw_id = helpers.resolve_id(mgr.resolve_ids, identifier, 'hardware')
 
-    if not comment and not env.skip_confirmations:
+    if not (comment or env.skip_confirmations):
         comment = env.input("(Optional) Add a cancellation comment:")
 
-    if env.skip_confirmations or formatting.no_going_back(hw_id):
-        mgr.cancel_hardware(hw_id, reason, comment, immediate)
-    else:
+    if not (env.skip_confirmations or formatting.no_going_back(hw_id)):
         raise exceptions.CLIAbort('Aborted')
+
+    mgr.cancel_hardware(hw_id, reason, comment, immediate)

--- a/SoftLayer/CLI/server/create.py
+++ b/SoftLayer/CLI/server/create.py
@@ -119,19 +119,19 @@ def cli(env, **args):
         return 'Successfully exported options to a template file.'
 
     if do_create:
-        if env.skip_confirmations or formatting.confirm(
+        if not (env.skip_confirmations or formatting.confirm(
                 "This action will incur charges on your account. "
-                "Continue?"):
-            result = mgr.place_order(**order)
-
-            table = formatting.KeyValueTable(['name', 'value'])
-            table.align['name'] = 'r'
-            table.align['value'] = 'l'
-            table.add_row(['id', result['orderId']])
-            table.add_row(['created', result['orderDate']])
-            output = table
-        else:
+                "Continue?")):
             raise exceptions.CLIAbort('Aborting dedicated server order.')
+
+        result = mgr.place_order(**order)
+
+        table = formatting.KeyValueTable(['name', 'value'])
+        table.align['name'] = 'r'
+        table.align['value'] = 'l'
+        table.add_row(['id', result['orderId']])
+        table.add_row(['created', result['orderDate']])
+        output = table
 
     return output
 

--- a/SoftLayer/CLI/server/power.py
+++ b/SoftLayer/CLI/server/power.py
@@ -18,12 +18,12 @@ def power_off(env, identifier):
 
     mgr = SoftLayer.HardwareManager(env.client)
     hw_id = helpers.resolve_id(mgr.resolve_ids, identifier, 'hardware')
-    if env.skip_confirmations or formatting.confirm('This will power off the '
-                                                    'server with id %s '
-                                                    'Continue?' % hw_id):
-        env.client['Hardware_Server'].powerOff(id=hw_id)
-    else:
+    if not (env.skip_confirmations or
+            formatting.confirm('This will power off the server with id %s '
+                               'Continue?' % hw_id)):
         raise exceptions.CLIAbort('Aborted.')
+
+    env.client['Hardware_Server'].powerOff(id=hw_id)
 
 
 @click.command()
@@ -38,17 +38,17 @@ def reboot(env, identifier, hard):
     hardware_server = env.client['Hardware_Server']
     mgr = SoftLayer.HardwareManager(env.client)
     hw_id = helpers.resolve_id(mgr.resolve_ids, identifier, 'hardware')
-    if env.skip_confirmations or formatting.confirm('This will power off the '
-                                                    'server with id %s. '
-                                                    'Continue?' % hw_id):
-        if hard is True:
-            hardware_server.rebootHard(id=hw_id)
-        elif hard is False:
-            hardware_server.rebootSoft(id=hw_id)
-        else:
-            hardware_server.rebootDefault(id=hw_id)
-    else:
+    if not (env.skip_confirmations or
+            formatting.confirm('This will power off the server with id %s. '
+                               'Continue?' % hw_id)):
         raise exceptions.CLIAbort('Aborted.')
+
+    if hard is True:
+        hardware_server.rebootHard(id=hw_id)
+    elif hard is False:
+        hardware_server.rebootSoft(id=hw_id)
+    else:
+        hardware_server.rebootDefault(id=hw_id)
 
 
 @click.command()
@@ -71,9 +71,9 @@ def power_cycle(env, identifier):
     mgr = SoftLayer.HardwareManager(env.client)
     hw_id = helpers.resolve_id(mgr.resolve_ids, identifier, 'hardware')
 
-    if env.skip_confirmations or formatting.confirm('This will power off the '
-                                                    'server with id %s. '
-                                                    'Continue?' % hw_id):
-        env.client['Hardware_Server'].powerCycle(id=hw_id)
-    else:
+    if not (env.skip_confirmations or
+            formatting.confirm('This will power off the server with id %s. '
+                               'Continue?' % hw_id)):
         raise exceptions.CLIAbort('Aborted.')
+
+    env.client['Hardware_Server'].powerCycle(id=hw_id)

--- a/SoftLayer/CLI/server/reload.py
+++ b/SoftLayer/CLI/server/reload.py
@@ -30,7 +30,7 @@ def cli(env, identifier, postinstall, key):
             resolver = SoftLayer.SshKeyManager(env.client).resolve_ids
             key_id = helpers.resolve_id(resolver, single_key, 'SshKey')
             key_list.append(key_id)
-    if env.skip_confirmations or formatting.no_going_back(hardware_id):
-        hardware.reload(hardware_id, postinstall, key_list)
-    else:
+    if not (env.skip_confirmations or formatting.no_going_back(hardware_id)):
         raise exceptions.CLIAbort('Aborted')
+
+    hardware.reload(hardware_id, postinstall, key_list)

--- a/SoftLayer/CLI/server/rescue.py
+++ b/SoftLayer/CLI/server/rescue.py
@@ -19,10 +19,10 @@ def cli(env, identifier):
     server = SoftLayer.HardwareManager(env.client)
     server_id = helpers.resolve_id(server.resolve_ids, identifier, 'hardware')
 
-    if env.skip_confirmations or formatting.confirm(
-            "This action will reboot this server. "
-            "Continue?"):
+    if not (env.skip_confirmations or
+            formatting.confirm("This action will reboot this server. "
+                               "Continue?")):
 
-        server.rescue(server_id)
-    else:
         raise exceptions.CLIAbort('Aborted')
+
+    server.rescue(server_id)

--- a/SoftLayer/CLI/server/update_firmware.py
+++ b/SoftLayer/CLI/server/update_firmware.py
@@ -23,4 +23,4 @@ def cli(env, identifier):
                                'update device firmware. Continue?' % hw_id)):
         raise exceptions.CLIAbort('Aborted.')
 
-    mgr.update_firmware()
+    mgr.update_firmware(hw_id)

--- a/SoftLayer/CLI/server/update_firmware.py
+++ b/SoftLayer/CLI/server/update_firmware.py
@@ -18,10 +18,9 @@ def cli(env, identifier):
 
     mgr = SoftLayer.HardwareManager(env.client)
     hw_id = helpers.resolve_id(mgr.resolve_ids, identifier, 'hardware')
-    if env.skip_confirmations or formatting.confirm('This will power off the '
-                                                    'server with id %s and '
-                                                    'update device firmware. '
-                                                    'Continue?' % hw_id):
-        mgr.update_firmware(hw_id)
-    else:
+    if not (env.skip_confirmations or
+            formatting.confirm('This will power off the server with id %s and '
+                               'update device firmware. Continue?' % hw_id)):
         raise exceptions.CLIAbort('Aborted.')
+
+    mgr.update_firmware()

--- a/SoftLayer/CLI/sshkey/remove.py
+++ b/SoftLayer/CLI/sshkey/remove.py
@@ -18,7 +18,7 @@ def cli(env, identifier):
     mgr = SoftLayer.SshKeyManager(env.client)
 
     key_id = helpers.resolve_id(mgr.resolve_ids, identifier, 'SshKey')
-    if env.skip_confirmations or formatting.no_going_back(key_id):
-        mgr.delete_key(key_id)
-    else:
+    if not (env.skip_confirmations or formatting.no_going_back(key_id)):
         raise exceptions.CLIAbort('Aborted')
+
+    mgr.delete_key(key_id)

--- a/SoftLayer/CLI/ssl/remove.py
+++ b/SoftLayer/CLI/ssl/remove.py
@@ -16,6 +16,7 @@ def cli(env, identifier):
     """Remove SSL certificate."""
 
     manager = SoftLayer.SSLManager(env.client)
-    if env.skip_confirmations or formatting.no_going_back('yes'):
-        manager.remove_certificate(identifier)
-    raise exceptions.CLIAbort("Aborted.")
+    if not (env.skip_confirmations or formatting.no_going_back('yes')):
+        raise exceptions.CLIAbort("Aborted.")
+
+    manager.remove_certificate(identifier)

--- a/SoftLayer/CLI/subnet/cancel.py
+++ b/SoftLayer/CLI/subnet/cancel.py
@@ -20,7 +20,7 @@ def cli(env, identifier):
     subnet_id = helpers.resolve_id(mgr.resolve_subnet_ids, identifier,
                                    name='subnet')
 
-    if env.skip_confirmations or formatting.no_going_back(subnet_id):
-        mgr.cancel_subnet(subnet_id)
-    else:
+    if not (env.skip_confirmations or formatting.no_going_back(subnet_id)):
         raise exceptions.CLIAbort('Aborted')
+
+    mgr.cancel_subnet(subnet_id)

--- a/SoftLayer/CLI/subnet/create.py
+++ b/SoftLayer/CLI/subnet/create.py
@@ -34,13 +34,15 @@ def cli(env, network, quantity, vlan_id, ipv6, test):
 
     mgr = SoftLayer.NetworkManager(env.client)
 
-    version = 4
-    if ipv6:
-        version = 6
-    if not test and not env.skip_confirmations:
+    if not (test or env.skip_confirmations):
         if not formatting.confirm("This action will incur charges on your "
                                   "account. Continue?"):
             raise exceptions.CLIAbort('Cancelling order.')
+
+    version = 4
+    if ipv6:
+        version = 6
+
     result = mgr.add_subnet(network,
                             quantity=quantity,
                             vlan_id=vlan_id,

--- a/SoftLayer/CLI/virt/cancel.py
+++ b/SoftLayer/CLI/virt/cancel.py
@@ -19,7 +19,7 @@ def cli(env, identifier):
 
     vsi = SoftLayer.VSManager(env.client)
     vs_id = helpers.resolve_id(vsi.resolve_ids, identifier, 'VS')
-    if env.skip_confirmations or formatting.no_going_back(vs_id):
-        vsi.cancel_instance(vs_id)
-    else:
+    if not (env.skip_confirmations or formatting.no_going_back(vs_id)):
         raise exceptions.CLIAbort('Aborted')
+
+    vsi.cancel_instance(vs_id)

--- a/SoftLayer/CLI/virt/create.py
+++ b/SoftLayer/CLI/virt/create.py
@@ -130,24 +130,24 @@ def cli(env, **args):
         return 'Successfully exported options to a template file.'
 
     if do_create:
-        if env.skip_confirmations or formatting.confirm(
-                "This action will incur charges on your account. Continue?"):
-            result = vsi.create_instance(**data)
-
-            table = formatting.KeyValueTable(['name', 'value'])
-            table.align['name'] = 'r'
-            table.align['value'] = 'l'
-            table.add_row(['id', result['id']])
-            table.add_row(['created', result['createDate']])
-            table.add_row(['guid', result['globalIdentifier']])
-            output.append(table)
-
-            if args.get('wait'):
-                ready = vsi.wait_for_ready(
-                    result['id'], int(args.get('wait') or 1))
-                table.add_row(['ready', ready])
-        else:
+        if not (env.skip_confirmations or formatting.confirm(
+                "This action will incur charges on your account. Continue?")):
             raise exceptions.CLIAbort('Aborting virtual server order.')
+
+        result = vsi.create_instance(**data)
+
+        table = formatting.KeyValueTable(['name', 'value'])
+        table.align['name'] = 'r'
+        table.align['value'] = 'l'
+        table.add_row(['id', result['id']])
+        table.add_row(['created', result['createDate']])
+        table.add_row(['guid', result['globalIdentifier']])
+        output.append(table)
+
+        if args.get('wait'):
+            ready = vsi.wait_for_ready(
+                result['id'], int(args.get('wait') or 1))
+            table.add_row(['ready', ready])
 
     return output
 

--- a/SoftLayer/CLI/virt/power.py
+++ b/SoftLayer/CLI/virt/power.py
@@ -18,12 +18,11 @@ def rescue(env, identifier):
 
     vsi = SoftLayer.VSManager(env.client)
     vs_id = helpers.resolve_id(vsi.resolve_ids, identifier, 'VS')
-    if env.skip_confirmations or formatting.confirm(
-            "This action will reboot this VSI. Continue?"):
-
-        vsi.rescue(vs_id)
-    else:
+    if not (env.skip_confirmations or
+            formatting.confirm("This action will reboot this VSI. Continue?")):
         raise exceptions.CLIAbort('Aborted')
+
+    vsi.rescue(vs_id)
 
 
 @click.command()
@@ -38,17 +37,17 @@ def reboot(env, identifier, hard):
     virtual_guest = env.client['Virtual_Guest']
     mgr = SoftLayer.HardwareManager(env.client)
     vs_id = helpers.resolve_id(mgr.resolve_ids, identifier, 'VS')
-    if any([env.skip_confirmations,
+    if not (env.skip_confirmations or
             formatting.confirm('This will reboot the VS with id %s. '
-                               'Continue?' % vs_id)]):
-        if hard is True:
-            virtual_guest.rebootHard(id=vs_id)
-        elif hard is False:
-            virtual_guest.rebootSoft(id=vs_id)
-        else:
-            virtual_guest.rebootDefault(id=vs_id)
-    else:
+                               'Continue?' % vs_id)):
         raise exceptions.CLIAbort('Aborted.')
+
+    if hard is True:
+        virtual_guest.rebootHard(id=vs_id)
+    elif hard is False:
+        virtual_guest.rebootSoft(id=vs_id)
+    else:
+        virtual_guest.rebootDefault(id=vs_id)
 
 
 @click.command()
@@ -61,15 +60,15 @@ def power_off(env, identifier, hard):
     virtual_guest = env.client['Virtual_Guest']
     vsi = SoftLayer.VSManager(env.client)
     vs_id = helpers.resolve_id(vsi.resolve_ids, identifier, 'VS')
-    if any([env.skip_confirmations,
+    if not (env.skip_confirmations or
             formatting.confirm('This will power off the VS with id %s. '
-                               'Continue?' % vs_id)]):
-        if hard:
-            virtual_guest.powerOff(id=vs_id)
-        else:
-            virtual_guest.powerOffSoft(id=vs_id)
-    else:
+                               'Continue?' % vs_id)):
         raise exceptions.CLIAbort('Aborted.')
+
+    if hard:
+        virtual_guest.powerOff(id=vs_id)
+    else:
+        virtual_guest.powerOffSoft(id=vs_id)
 
 
 @click.command()
@@ -92,12 +91,12 @@ def pause(env, identifier):
     vsi = SoftLayer.VSManager(env.client)
     vs_id = helpers.resolve_id(vsi.resolve_ids, identifier, 'VS')
 
-    if any([env.skip_confirmations,
+    if not (env.skip_confirmations or
             formatting.confirm('This will pause the VS with id %s. Continue?'
-                               % vs_id)]):
-        env.client['Virtual_Guest'].pause(id=vs_id)
-    else:
+                               % vs_id)):
         raise exceptions.CLIAbort('Aborted.')
+
+    env.client['Virtual_Guest'].pause(id=vs_id)
 
 
 @click.command()

--- a/SoftLayer/CLI/virt/reload.py
+++ b/SoftLayer/CLI/virt/reload.py
@@ -27,7 +27,7 @@ def cli(env, identifier, postinstall, key):
             resolver = SoftLayer.SshKeyManager(env.client).resolve_ids
             key_id = helpers.resolve_id(resolver, single_key, 'SshKey')
             keys.append(key_id)
-    if env.skip_confirmations or formatting.no_going_back(vs_id):
-        vsi.reload_instance(vs_id, postinstall, keys)
-    else:
+    if not (env.skip_confirmations or formatting.no_going_back(vs_id)):
         raise exceptions.CLIAbort('Aborted')
+
+    vsi.reload_instance(vs_id, postinstall, keys)

--- a/SoftLayer/CLI/virt/upgrade.py
+++ b/SoftLayer/CLI/virt/upgrade.py
@@ -28,12 +28,14 @@ def cli(env, identifier, cpu, private, memory, network):
     vsi = SoftLayer.VSManager(env.client)
 
     vs_id = helpers.resolve_id(vsi.resolve_ids, identifier, 'VS')
-    if env.skip_confirmations or formatting.confirm(
+    if not (env.skip_confirmations or formatting.confirm(
             "This action will incur charges on your account. "
-            "Continue?"):
-        if not vsi.upgrade(vs_id,
-                           cpus=cpu,
-                           memory=memory,
-                           nic_speed=network,
-                           public=not private):
-            raise exceptions.CLIAbort('VS Upgrade Failed')
+            "Continue?")):
+        raise exceptions.CLIAbort('Aborted')
+
+    if not vsi.upgrade(vs_id,
+                       cpus=cpu,
+                       memory=memory,
+                       nic_speed=network,
+                       public=not private):
+        raise exceptions.CLIAbort('VS Upgrade Failed')

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands = nosetests
 basepython = python2.7
 commands = nosetests \
                      --with-coverage \
-                     --cover-min-percentage=79 \
+                     --cover-min-percentage=78 \
                      --cover-erase \
                      --cover-package=SoftLayer \
                      --cover-html


### PR DESCRIPTION
I also took the liberty of inverting the logic in to to short-circuit aborting of commands so that the happy path is no longer un-essentially nested an additional level.

Test Cases:
```
sl --fixtures dns record-remove 1234
sl --fixtures dns zone-delete 12345
sl --fixtures firewall cancel type:12345
sl --fixtures globalip cancel 12345
sl --fixtures globalip create
sl --fixtures iscsi cancel 12345
sl --fixtures loadbal cancel type:12345
sl --fixtures loadbal group-delete type:12345
sl --fixtures loadbal service-delete type:12345
sl --fixtures loadbal service-toggle type:12345
sl --fixtures server cancel 12345
sl --fixtures server power-off 12345
sl --fixtures server reboot 12345
sl --fixtures server power-cycle 12345
sl --fixtures server reload 12345
sl --fixtures server rescue 12345
sl --fixtures server update-firmware 12345
sl --fixtures sshkey remove 12345
sl --fixtures subnet cancel 12345
sl --fixtures subnet create public 1 234
sl --fixtures vs cancel 12345
sl --fixtures vs rescue 12345
sl --fixtures vs reboot 12345
sl --fixtures vs power-off 12345
sl --fixtures vs pause 12345
sl --fixtures vs reload 12345
sl --fixtures vs upgrade 12345 12345 --cpu=8
```

I left out `sl vs create` and `sl server create` from the list since those commands are pretty involved. They need to be tested too.