### PR TITLE
Adds `sl setup` command

### DIFF
--- a/SoftLayer/CLI/core.py
+++ b/SoftLayer/CLI/core.py
@@ -69,7 +69,7 @@ class CommandLoader(click.MultiCommand):
 @click.group(help="SoftLayer Command-line Client",
              epilog="""To use most commands your SoftLayer
 username and api_key need to be configured. The easiest way to do that is to
-use: 'sl config setup'""",
+use: 'sl setup'""",
              cls=CommandLoader,
              context_settings={'help_option_names': ['-h', '--help']})
 @click.pass_context

--- a/SoftLayer/CLI/routes.py
+++ b/SoftLayer/CLI/routes.py
@@ -47,6 +47,7 @@ ALL_ROUTES = [
     ('config', 'SoftLayer.CLI.config'),
     ('config:setup', 'SoftLayer.CLI.config.setup:cli'),
     ('config:show', 'SoftLayer.CLI.config.show:cli'),
+    ('setup', 'SoftLayer.CLI.config.setup:cli'),
 
     ('dns', 'SoftLayer.CLI.dns'),
     ('dns:import', 'SoftLayer.CLI.dns.zone_import:cli'),

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -19,10 +19,10 @@ functionality not fully documented here.
 
 Configuration Setup
 -------------------
-To update the configuration, you can use `sl config setup`.
+To update the configuration, you can use `sl setup`.
 ::
 
-	$ sl config setup
+	$ sl setup
 	Username []: username
 	API Key or Password []:
 	Endpoint (public|private|custom): public
@@ -99,7 +99,7 @@ To discover the available commands, simply type `sl`.
 	  vs         Virtual Servers.
 
 	  To use most commands your SoftLayer username and api_key need to be
-	  configured. The easiest way to do that is to use: 'sl config setup'
+	  configured. The easiest way to do that is to use: 'sl setup'
 
 As you can see, there are a number of commands/sections. To look at the list of
 subcommands for virtual servers type `sl vs`. For example:

--- a/docs/config_file.rst
+++ b/docs/config_file.rst
@@ -14,7 +14,7 @@ locations.
 The configuration file is INI-based and requires the `softlayer` section to be
 present. The only required fields are `username` and `api_key`. You can
 optionally supply the `endpoint_url` as well. This file is created
-automatically by the `sl config setup` command detailed here:
+automatically by the `sl setup` command detailed here:
 :ref:`config_setup`.
 
 *Config Example*


### PR DESCRIPTION
Now you just have to remember `sl setup` to set up the command line client. Resolve #459.