### PR TITLE
Use slcli command over sl

### DIFF
--- a/SoftLayer/CLI/call_api.py
+++ b/SoftLayer/CLI/call_api.py
@@ -19,9 +19,9 @@ def cli(env, service, method, _id, mask, limit, offset):
 
     \b
     Examples:
-    sl call-api Account getObject
-    sl call-api Account getVirtualGuests --limit=10 --mask=id,hostname
-    sl call-api Virtual_Guest getObject --id=2710344
+    slcli call-api Account getObject
+    slcli call-api Account getVirtualGuests --limit=10 --mask=id,hostname
+    slcli call-api Virtual_Guest getObject --id=2710344
     """
     result = env.client.call(service, method,
                              id=_id,

--- a/SoftLayer/CLI/core.py
+++ b/SoftLayer/CLI/core.py
@@ -69,7 +69,7 @@ class CommandLoader(click.MultiCommand):
 @click.group(help="SoftLayer Command-line Client",
              epilog="""To use most commands your SoftLayer
 username and api_key need to be configured. The easiest way to do that is to
-use: 'sl setup'""",
+use: 'slcli setup'""",
              cls=CommandLoader,
              context_settings={'help_option_names': ['-h', '--help']})
 @click.pass_context
@@ -178,7 +178,7 @@ def main():
     except SoftLayer.SoftLayerAPIError as ex:
         if 'invalid api token' in ex.faultString.lower():
             print("Authentication Failed: To update your credentials,"
-                  " use 'sl config setup'")
+                  " use 'slcli config setup'")
             exit_status = 1
         else:
             print(str(ex))

--- a/SoftLayer/CLI/deprecated.py
+++ b/SoftLayer/CLI/deprecated.py
@@ -1,0 +1,16 @@
+"""
+    SoftLayer.CLI.deprecated
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+    Handles usage of the deprecated command name, 'sl'.
+    :license: MIT, see LICENSE for more details.
+"""
+import sys
+
+import click
+
+
+def main():
+    """Main function for the deprecated 'sl' command."""
+    click.echo("ERROR: Use the 'slcli' command instead.", err=True)
+    click.echo("> slcli %s" % ' '.join(sys.argv[1:]), err=True)
+    exit(-1)

--- a/SoftLayer/CLI/deprecated.py
+++ b/SoftLayer/CLI/deprecated.py
@@ -4,14 +4,12 @@
     Handles usage of the deprecated command name, 'sl'.
     :license: MIT, see LICENSE for more details.
 """
+from __future__ import print_function
 import sys
 
-import click
 
-
-@click.command()
 def main():
     """Main function for the deprecated 'sl' command."""
-    click.echo("ERROR: Use the 'slcli' command instead.", err=True)
-    click.echo("> slcli %s" % ' '.join(sys.argv[1:]), err=True)
+    print("ERROR: Use the 'slcli' command instead.", file=sys.stderr)
+    print("> slcli %s" % ' '.join(sys.argv[1:]), file=sys.stderr)
     exit(-1)

--- a/SoftLayer/CLI/deprecated.py
+++ b/SoftLayer/CLI/deprecated.py
@@ -9,6 +9,7 @@ import sys
 import click
 
 
+@click.command()
 def main():
     """Main function for the deprecated 'sl' command."""
     click.echo("ERROR: Use the 'slcli' command instead.", err=True)

--- a/SoftLayer/CLI/metadata.py
+++ b/SoftLayer/CLI/metadata.py
@@ -36,7 +36,7 @@ PROP Choices
 Examples :
 %s
 """ % ('*'+'\n*'.join(META_CHOICES),
-       'sl metadata '+'\nsl metadata '.join(META_CHOICES))
+       'slcli metadata '+'\nslcli metadata '.join(META_CHOICES))
 
 
 @click.command(help=HELP,

--- a/SoftLayer/CLI/server/create.py
+++ b/SoftLayer/CLI/server/create.py
@@ -12,8 +12,8 @@ import click
 
 
 @click.command(epilog="""See 'sl server create-options' for valid options.""")
-@click.option('--domain', '-D', help="Domain portion of the FQDN")
 @click.option('--hostname', '-H', help="Host portion of the FQDN")
+@click.option('--domain', '-D', help="Domain portion of the FQDN")
 @click.option('--size', '-s', help="Hardware size")
 @click.option('--os', '-o', help="OS install code")
 @click.option('--datacenter', '-d', help="Datacenter shortname")

--- a/SoftLayer/CLI/ticket/create.py
+++ b/SoftLayer/CLI/ticket/create.py
@@ -13,7 +13,7 @@ import click
 @click.option('--subject-id',
               required=True,
               help="""The subject id to use for the ticket,
- issue 'sl ticket subjects' to get the list""")
+ issue 'slcli ticket subjects' to get the list""")
 @click.option('--body', help="The ticket body")
 @environment.pass_env
 def cli(env, title, subject_id, body):

--- a/SoftLayer/CLI/virt/create.py
+++ b/SoftLayer/CLI/virt/create.py
@@ -13,11 +13,11 @@ from SoftLayer import utils
 import click
 
 
-@click.command(epilog="See 'sl vs create-options' for valid options")
+@click.command(epilog="See 'slcli vs create-options' for valid options")
 @click.option('--domain', '-D', help="Domain portion of the FQDN")
 @click.option('--hostname', '-H', help="Host portion of the FQDN")
 @click.option('--image',
-              help="Image GUID. See: 'sl image list' for reference")
+              help="Image GUID. See: 'slcli image list' for reference")
 @click.option('--cpu', '-c', help="Number of CPU cores", type=click.INT)
 @click.option('--memory', '-m', help="Memory in mebibytes", type=virt.MEM_TYPE)
 @click.option('--os', '-o',

--- a/SoftLayer/tests/CLI/core_tests.py
+++ b/SoftLayer/tests/CLI/core_tests.py
@@ -90,7 +90,7 @@ class CoreMainTests(testing.TestCase):
         self.assertRaises(SystemExit, core.main)
 
         self.assertIn("Authentication Failed:", stdoutmock.getvalue())
-        self.assertIn("use 'sl config setup'", stdoutmock.getvalue())
+        self.assertIn("use 'slcli config setup'", stdoutmock.getvalue())
 
 
 def recursive_subcommand_loader(root, path=''):

--- a/SoftLayer/tests/CLI/deprecated_tests.py
+++ b/SoftLayer/tests/CLI/deprecated_tests.py
@@ -4,6 +4,7 @@
 
     :license: MIT, see LICENSE for more details.
 """
+import click
 
 from SoftLayer.CLI import deprecated
 from SoftLayer import testing
@@ -12,7 +13,8 @@ from SoftLayer import testing
 class EnvironmentTests(testing.TestCase):
 
     def test_main(self):
-        try:
-            deprecated.main()
-        except SystemExit as ex:
-            self.assertEquals(ex.code, -1)
+        runner = click.testing.CliRunner()
+        result = runner.invoke(deprecated.main)
+
+        self.assertEquals(result.exit_code, -1)
+        self.assertIn("ERROR: Use the 'slcli' command instead.", result.output)

--- a/SoftLayer/tests/CLI/deprecated_tests.py
+++ b/SoftLayer/tests/CLI/deprecated_tests.py
@@ -16,5 +16,5 @@ class EnvironmentTests(testing.TestCase):
         runner = click.testing.CliRunner()
         result = runner.invoke(deprecated.main)
 
-        self.assertEquals(result.exit_code, -1)
+        self.assertEqual(result.exit_code, -1)
         self.assertIn("ERROR: Use the 'slcli' command instead.", result.output)

--- a/SoftLayer/tests/CLI/deprecated_tests.py
+++ b/SoftLayer/tests/CLI/deprecated_tests.py
@@ -1,0 +1,18 @@
+"""
+    SoftLayer.tests.CLI.deprecated_tests
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :license: MIT, see LICENSE for more details.
+"""
+
+from SoftLayer.CLI import deprecated
+from SoftLayer import testing
+
+
+class EnvironmentTests(testing.TestCase):
+
+    def test_main(self):
+        try:
+            deprecated.main()
+        except SystemExit as ex:
+            self.assertEquals(ex.code, -1)

--- a/SoftLayer/tests/CLI/deprecated_tests.py
+++ b/SoftLayer/tests/CLI/deprecated_tests.py
@@ -14,6 +14,7 @@ from SoftLayer import utils
 class EnvironmentTests(testing.TestCase):
 
     def test_main(self):
+
         with mock.patch('sys.stderr', new=utils.StringIO()) as fake_out:
             ex = self.assertRaises(SystemExit, deprecated.main)
             self.assertEqual(ex.code, -1)
@@ -22,7 +23,6 @@ class EnvironmentTests(testing.TestCase):
                           fake_out.getvalue())
 
     def test_with_args(self):
-
         with mock.patch('sys.stderr', new=utils.StringIO()) as fake_out:
             with mock.patch('sys.argv', new=['sl', 'module', 'subcommand']):
                 ex = self.assertRaises(SystemExit, deprecated.main)

--- a/SoftLayer/tests/CLI/deprecated_tests.py
+++ b/SoftLayer/tests/CLI/deprecated_tests.py
@@ -4,17 +4,29 @@
 
     :license: MIT, see LICENSE for more details.
 """
-import click
+import mock
 
 from SoftLayer.CLI import deprecated
 from SoftLayer import testing
+from SoftLayer import utils
 
 
 class EnvironmentTests(testing.TestCase):
 
     def test_main(self):
-        runner = click.testing.CliRunner()
-        result = runner.invoke(deprecated.main)
+        with mock.patch('sys.stderr', new=utils.StringIO()) as fake_out:
+            ex = self.assertRaises(SystemExit, deprecated.main)
+            self.assertEqual(ex.code, -1)
 
-        self.assertEqual(result.exit_code, -1)
-        self.assertIn("ERROR: Use the 'slcli' command instead.", result.output)
+            self.assertIn("ERROR: Use the 'slcli' command instead.",
+                          fake_out.getvalue())
+
+    def test_with_args(self):
+
+        with mock.patch('sys.stderr', new=utils.StringIO()) as fake_out:
+            with mock.patch('sys.argv', new=['sl', 'module', 'subcommand']):
+                ex = self.assertRaises(SystemExit, deprecated.main)
+                self.assertEqual(ex.code, -1)
+
+                self.assertIn("ERROR: Use the 'slcli' command instead.",
+                              fake_out.getvalue())

--- a/SoftLayer/tests/api_tests.py
+++ b/SoftLayer/tests/api_tests.py
@@ -43,15 +43,6 @@ class Inititialization(testing.TestCase):
 
 
 class ClientMethods(testing.TestCase):
-    def test_help(self):
-        help(SoftLayer)
-        help(SoftLayer.Client)
-        client = SoftLayer.Client(
-            username='doesnotexist',
-            api_key='issurelywrong'
-        )
-        help(client)
-        help(client['SERVICE'])
 
     def test_repr(self):
         client = SoftLayer.Client(

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -19,10 +19,10 @@ functionality not fully documented here.
 
 Configuration Setup
 -------------------
-To update the configuration, you can use `sl setup`.
+To update the configuration, you can use `slcli setup`.
 ::
 
-	$ sl setup
+	$ slcli setup
 	Username []: username
 	API Key or Password []:
 	Endpoint (public|private|custom): public
@@ -35,10 +35,10 @@ To update the configuration, you can use `sl setup`.
 	:..............:..................................................................:
 	Are you sure you want to write settings to "/home/me/.softlayer"? [y/N]: y
 
-To check the configuration, you can use `sl config show`.
+To check the configuration, you can use `slcli config show`.
 ::
 
-	$ sl config show
+	$ slcli config show
 	:..............:..................................................................:
 	:         Name : Value                                                            :
 	:..............:..................................................................:
@@ -58,7 +58,7 @@ To discover the available commands, simply type `sl`.
 ::
 
 	$ sl
-	Usage: sl [OPTIONS] COMMAND [ARGS]...
+	Usage: slcli [OPTIONS] COMMAND [ARGS]...
 
 	  SoftLayer Command-line Client
 
@@ -99,14 +99,14 @@ To discover the available commands, simply type `sl`.
 	  vs         Virtual Servers.
 
 	  To use most commands your SoftLayer username and api_key need to be
-	  configured. The easiest way to do that is to use: 'sl setup'
+	  configured. The easiest way to do that is to use: 'slcli setup'
 
 As you can see, there are a number of commands/sections. To look at the list of
-subcommands for virtual servers type `sl vs`. For example:
+subcommands for virtual servers type `slcli vs`. For example:
 ::
 
-	$ sl vs
-	Usage: sl vs [OPTIONS] COMMAND [ARGS]...
+	$ slcli vs
+	Usage: slcli vs [OPTIONS] COMMAND [ARGS]...
 
 	  Virtual Servers.
 
@@ -135,11 +135,11 @@ subcommands for virtual servers type `sl vs`. For example:
 	  upgrade         Upgrade a virtual server.
 
 Finally, we can make an actual call. Let's list out the virtual servers on our
-account by using `sl vs list`.
+account by using `slcli vs list`.
 
 ::
 
-	$ sl vs list
+	$ slcli vs list
 	:.........:............:....................:.......:........:................:..............:....................:
 	:    id   : datacenter :       host         : cores : memory :   primary_ip   :  backend_ip  : active_transaction :
 	:.........:............:....................:.......:........:................:..............:....................:
@@ -149,8 +149,8 @@ account by using `sl vs list`.
 Most commands will take in additional options/arguments. To see all available actions, use `--help`.
 ::
 
-	$ sl vs list --help
-	Usage: sl vs list [OPTIONS]
+	$ slcli vs list --help
+	Usage: slcli vs list [OPTIONS]
 
 	  List virtual servers.
 

--- a/docs/cli/vs.rst
+++ b/docs/cli/vs.rst
@@ -14,10 +14,10 @@ using SoftLayer's command-line client.
 	:ref:`configured with valid SoftLayer credentials<cli>`.
 
 
-First, let's list the current virtual servers with `sl vs list`.
+First, let's list the current virtual servers with `slcli vs list`.
 ::
 
-	$ sl vs list
+	$ slcli vs list
 	:.....:............:.........................:.......:........:..............:.............:....................:........:
 	:  id : datacenter :           host          : cores : memory :  primary_ip  :  backend_ip : active_transaction : owner  :
 	:.....:............:.........................:.......:........:..............:.............:....................:........:
@@ -26,11 +26,11 @@ First, let's list the current virtual servers with `sl vs list`.
 We don't have any virtual servers yet! Let's fix that. Before we can create a
 virtual server (VS), we need to know what options are available to us: RAM,
 CPU, operating systems, disk sizes, disk types, datacenters, and so on.
-Luckily, there's a simple command to show all options: `sl vs create-options`.
+Luckily, there's a simple command to show all options: `slcli vs create-options`.
 
 ::
 
-	$ sl vs create-options
+	$ slcli vs create-options
 	:.................:...........................................................................................:
 	:            Name : Value                                                                                     :
 	:.................:...........................................................................................:
@@ -112,11 +112,11 @@ Luckily, there's a simple command to show all options: `sl vs create-options`.
 
 Here's the command to create a 2-core virtual server with 1GiB memory, running
 Ubuntu 14.04 LTS, and that is billed on an hourly basis in the San Jose 1
-datacenter using the command `sl vs create`.
+datacenter using the command `slcli vs create`.
 
 ::
 
-	$ sl vs create --hostname=example --domain=softlayer.com --cpu 2 --memory 1024 -o UBUNTU_14_64 --datacenter=sjc01 --billing=hourly
+	$ slcli vs create --hostname=example --domain=softlayer.com --cpu 2 --memory 1024 -o UBUNTU_14_64 --datacenter=sjc01 --billing=hourly
 	This action will incur charges on your account. Continue? [y/N]: y
 	:.........:......................................:
 	:    name : value                                :
@@ -132,7 +132,7 @@ instantly appear in your virtual server list now.
 
 ::
 
-	$ sl vs list
+	$ slcli vs list
 	:.........:............:.......................:.......:........:................:..............:....................:
 	:    id   : datacenter :          host         : cores : memory :   primary_ip   :  backend_ip  : active_transaction :
 	:.........:............:.......................:.......:........:................:..............:....................:
@@ -144,7 +144,7 @@ here's how:
 
 ::
 
-	$ sl vs ready 'example' --wait=600
+	$ slcli vs ready 'example' --wait=600
 	READY
 
 When the previous command returns, you'll know that the virtual server has
@@ -152,7 +152,7 @@ finished the provisioning process and is ready to use. This is *very* useful
 for chaining commands together.
 
 Now that you have your virtual server, let's get access to it. To do that, use
-the `sl vs detail` command. From the example below, you can see that the
+the `slcli vs detail` command. From the example below, you can see that the
 username is 'root' and password is 'ABCDEFGH'.
 
 .. warning::
@@ -165,7 +165,7 @@ username is 'root' and password is 'ABCDEFGH'.
 
 ::
 
-	$ sl vs detail example --passwords
+	$ slcli vs detail example --passwords
 	:..............:...........................:
 	:         Name : Value                     :
 	:..............:...........................:
@@ -188,12 +188,12 @@ username is 'root' and password is 'ABCDEFGH'.
 
 
 There are many other commands to help manage virtual servers. To see them all,
-use `sl help vs`.
+use `slcli help vs`.
 
 ::
 
-	$ sl vs
-	Usage: sl vs [OPTIONS] COMMAND [ARGS]...
+	$ slcli vs
+	Usage: slcli vs [OPTIONS] COMMAND [ARGS]...
 
 	  Virtual Servers.
 

--- a/docs/config_file.rst
+++ b/docs/config_file.rst
@@ -14,7 +14,7 @@ locations.
 The configuration file is INI-based and requires the `softlayer` section to be
 present. The only required fields are `username` and `api_key`. You can
 optionally supply the `endpoint_url` as well. This file is created
-automatically by the `sl setup` command detailed here:
+automatically by the `slcli setup` command detailed here:
 :ref:`config_setup`.
 
 *Config Example*

--- a/docs/dev/cli.rst
+++ b/docs/dev/cli.rst
@@ -9,7 +9,7 @@ The command line parsing is currently based on `click <http://click.pocoo.org/>`
 
 First Example
 -------------
-For the first example, we can create `sl table-example` by creating the following file at SoftLayer/CLI/table_example.py:
+For the first example, we can create `slcli table-example` by creating the following file at SoftLayer/CLI/table_example.py:
 
 ::
 
@@ -36,7 +36,7 @@ For the first example, we can create `sl table-example` by creating the followin
 
         return t
 
-Then we need to register it so that `sl table-example` will know to route to this new module. We do that by adding ALL_ROUTES in SoftLayer/CLI/routes.py to include the following:
+Then we need to register it so that `slcli table-example` will know to route to this new module. We do that by adding ALL_ROUTES in SoftLayer/CLI/routes.py to include the following:
 
 ::
 
@@ -47,7 +47,7 @@ Then we need to register it so that `sl table-example` will know to route to thi
 Which gives us
 ::
 
-  $ sl table-example
+  $ slcli table-example
   :.......:.......:
   :  col1 : col2  :
   :.......:.......:
@@ -55,9 +55,9 @@ Which gives us
   : test2 : test2 :
   :.......:.......:
 
-  $ sl --format=raw table-example
-   test   test  
-   test2  test2 
+  $ slcli --format=raw table-example
+   test   test
+   test2  test2
 
 Formatting of the data represented in the table is actually controlled upstream from the CLIRunnable's making supporting more data formats in the future easier.
 

--- a/docs/dev/example_module.rst
+++ b/docs/dev/example_module.rst
@@ -8,7 +8,7 @@ Example CLI Module
 ::
 
     """
-    usage: sl example [<command>] [<args>...] [options]
+    usage: slcli example [<command>] [<args>...] [options]
 
     Example implementation of a CLI module
 
@@ -24,7 +24,7 @@ Example CLI Module
 
     class ExampleAction(CLIRunnable):
         """
-    usage: sl example print [options]
+    usage: slcli example print [options]
 
     Print example
     """
@@ -37,7 +37,7 @@ Example CLI Module
 
     class ExamplePretty(CLIRunnable):
         """
-    usage: sl example pretty [options]
+    usage: slcli example pretty [options]
 
     Pretty output example
     """
@@ -63,7 +63,7 @@ Example CLI Module
 
     class ExampleArgs(CLIRunnable):
         """
-    usage: sl example parse [--test] [--this=THIS|--that=THAT]
+    usage: slcli example parse [--test] [--this=THIS|--that=THAT]
                             (--one|--two) [options]
 
     Argument parsing example
@@ -91,4 +91,3 @@ Example CLI Module
 
             if args.get('--that'):
                 print "you dont have", args['--that']
-    

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,10 @@ setup(
     zip_safe=False,
     url='http://github.com/softlayer/softlayer-python',
     entry_points={
-        'console_scripts': ['sl = SoftLayer.CLI.core:main'],
+        'console_scripts': [
+            'slcli = SoftLayer.CLI.core:main',
+            'sl = SoftLayer.CLI.deprecated:main',
+        ],
     },
     test_suite='nose.collector',
     install_requires=REQUIRES,


### PR DESCRIPTION
#452 is a big change and it has been some time and several other large changes have been merged in since the great refactor. Since the PR stalled for so long, the merging effort is about equal to simply re-doing the changes. Therefore, this PR just implements the renaming of the CLI from `sl` to `slcli`.

I'll close #452 and re-implement it, but it might not be in time for the v4 release.