### PR TITLE
Improves REST transport + client fixup

### DIFF
--- a/SoftLayer/API.py
+++ b/SoftLayer/API.py
@@ -67,15 +67,27 @@ class Client(object):
                                               api_key=api_key,
                                               endpoint_url=endpoint_url,
                                               timeout=timeout,
-                                              auth=auth,
-                                              transport=transport,
                                               proxy=proxy,
                                               config_file=config_file)
-        self.auth = settings.get('auth')
-        self.version = settings.get('version')
 
-        self.endpoint_url = (settings.get('endpoint_url') or '').rstrip('/')
-        self.transport = settings.get('transport')
+        # Default the transport to use XMLRPC
+        if transport is None:
+            transport = transports.XmlRpcTransport()
+        self.transport = transport
+
+        self.endpoint_url = (settings.get('endpoint_url') or
+                             consts.API_PUBLIC_ENDPOINT).rstrip('/')
+
+        # If we have enough information to make an auth driver, let's do it
+        if(auth is None and
+           settings.get('username') and
+           settings.get('api_key')):
+
+            auth = slauth.BasicAuthentication(
+                settings.get('username'),
+                settings.get('api_key'),
+            )
+        self.auth = auth
 
         self.timeout = None
         if settings.get('timeout'):

--- a/SoftLayer/API.py
+++ b/SoftLayer/API.py
@@ -89,7 +89,7 @@ def create_client_from_env(username=None,
         transport = transports.XmlRpcTransport(
             endpoint_url=settings.get('endpoint_url'),
             proxy=settings.get('proxy'),
-            timeout=settings.get('timeout')
+            timeout=settings.get('timeout'),
             user_agent=user_agent,
         )
 

--- a/SoftLayer/API.py
+++ b/SoftLayer/API.py
@@ -89,11 +89,9 @@ def create_client_from_env(username=None,
         transport = transports.XmlRpcTransport(
             endpoint_url=settings.get('endpoint_url'),
             proxy=settings.get('proxy'),
-            user_agent=user_agent,
             timeout=settings.get('timeout')
+            user_agent=user_agent,
         )
-
-    transport = transport
 
     # If we have enough information to make an auth driver, let's do it
     if auth is None and settings.get('username') and settings.get('api_key'):
@@ -111,7 +109,8 @@ def Client(**kwargs):
 
     Deprecated in favor of create_client_from_env()
     """
-    warnings.warn("use create_client_from_env() instead", DeprecationWarning)
+    warnings.warn("use SoftLayer.create_client_from_env() instead",
+                  DeprecationWarning)
     return create_client_from_env(**kwargs)
 
 

--- a/SoftLayer/API.py
+++ b/SoftLayer/API.py
@@ -12,11 +12,20 @@ from SoftLayer import config
 from SoftLayer import consts
 from SoftLayer import transports
 
+# pylint: disable=invalid-name
+
+
 API_PUBLIC_ENDPOINT = consts.API_PUBLIC_ENDPOINT
 API_PRIVATE_ENDPOINT = consts.API_PRIVATE_ENDPOINT
-__all__ = ['Client', 'API_PUBLIC_ENDPOINT', 'API_PRIVATE_ENDPOINT']
+__all__ = [
+    'create_client_from_env',
+    'Client',
+    'BaseClient',
+    'API_PUBLIC_ENDPOINT',
+    'API_PRIVATE_ENDPOINT',
+]
 
-VALID_CALL_ARGS = set([
+VALID_CALL_ARGS = set((
     'id',
     'mask',
     'filter',
@@ -25,11 +34,22 @@ VALID_CALL_ARGS = set([
     'raw_headers',
     'limit',
     'offset',
-])
+))
 
 
-class Client(object):
-    """A SoftLayer API client.
+def create_client_from_env(username=None,
+                           api_key=None,
+                           endpoint_url=None,
+                           timeout=None,
+                           auth=None,
+                           config_file=None,
+                           proxy=None,
+                           user_agent=None,
+                           transport=None):
+    """Creates a SoftLayer API client using your environment.
+
+    Settings are loaded via keyword arguments, environemtal variables and
+    config file.
 
     :param username: an optional API username if you wish to bypass the
         package's built-in username
@@ -51,52 +71,63 @@ class Client(object):
     Usage:
 
         >>> import SoftLayer
-        >>> client = SoftLayer.Client(username="username", api_key="api_key")
+        >>> client = SoftLayer.create_client_from_env()
         >>> resp = client['Account'].getObject()
         >>> resp['companyName']
         'Your Company'
 
     """
+    settings = config.get_client_settings(username=username,
+                                          api_key=api_key,
+                                          endpoint_url=endpoint_url,
+                                          timeout=timeout,
+                                          proxy=proxy,
+                                          config_file=config_file)
+
+    # Default the transport to use XMLRPC
+    if transport is None:
+        transport = transports.XmlRpcTransport(
+            endpoint_url=settings.get('endpoint_url'),
+            proxy=settings.get('proxy'),
+            user_agent=user_agent,
+            timeout=settings.get('timeout')
+        )
+
+    transport = transport
+
+    # If we have enough information to make an auth driver, let's do it
+    if auth is None and settings.get('username') and settings.get('api_key'):
+
+        auth = slauth.BasicAuthentication(
+            settings.get('username'),
+            settings.get('api_key'),
+        )
+
+    return BaseClient(auth=auth, transport=transport)
+
+
+def Client(**kwargs):
+    """Get a SoftLayer API Client using environmental settings.
+
+    Deprecated in favor of create_client_from_env()
+    """
+    warnings.warn("use create_client_from_env() instead", DeprecationWarning)
+    return create_client_from_env(**kwargs)
+
+
+class BaseClient(object):
+    """Base SoftLayer API client.
+
+    :param auth: auth driver that looks like SoftLayer.auth.AuthenticationBase
+    :param transport: An object that's callable with this signature:
+                      transport(SoftLayer.transports.Request)
+    """
+
     _prefix = "SoftLayer_"
 
-    def __init__(self, username=None, api_key=None, endpoint_url=None,
-                 timeout=None, auth=None, config_file=None, proxy=None,
-                 user_agent=None, transport=None):
-
-        settings = config.get_client_settings(username=username,
-                                              api_key=api_key,
-                                              endpoint_url=endpoint_url,
-                                              timeout=timeout,
-                                              proxy=proxy,
-                                              config_file=config_file)
-
-        # Default the transport to use XMLRPC
-        if transport is None:
-            transport = transports.XmlRpcTransport()
-        self.transport = transport
-
-        self.endpoint_url = (settings.get('endpoint_url') or
-                             consts.API_PUBLIC_ENDPOINT).rstrip('/')
-
-        # If we have enough information to make an auth driver, let's do it
-        if(auth is None and
-           settings.get('username') and
-           settings.get('api_key')):
-
-            auth = slauth.BasicAuthentication(
-                settings.get('username'),
-                settings.get('api_key'),
-            )
+    def __init__(self, auth=None, transport=None):
         self.auth = auth
-
-        self.timeout = None
-        if settings.get('timeout'):
-            self.timeout = float(settings.get('timeout'))
-
-        self.proxy = None
-        if settings.get('proxy'):
-            self.proxy = settings.get('proxy')
-        self.user_agent = user_agent
+        self.transport = transport
 
     def authenticate_with_password(self, username, password,
                                    security_question_id=None,
@@ -159,13 +190,10 @@ class Client(object):
             raise TypeError(
                 'Invalid keyword arguments: %s' % ','.join(invalid_kwargs))
 
-        if not service.startswith(self._prefix):
+        if self._prefix and not service.startswith(self._prefix):
             service = self._prefix + service
 
-        http_headers = {
-            'User-Agent': self.user_agent or consts.USER_AGENT,
-            'Content-Type': 'application/xml',
-        }
+        http_headers = {}
 
         if kwargs.get('compress', True):
             http_headers['Accept'] = '*/*'
@@ -175,13 +203,10 @@ class Client(object):
             http_headers.update(kwargs.get('raw_headers'))
 
         request = transports.Request()
-        request.endpoint = self.endpoint_url
         request.service = service
         request.method = method
         request.args = args
         request.transport_headers = http_headers
-        request.timeout = self.timeout
-        request.proxy = self.proxy
         request.identifier = kwargs.get('id')
         request.mask = kwargs.get('mask')
         request.filter = kwargs.get('filter')
@@ -258,8 +283,7 @@ class Client(object):
                 break
 
     def __repr__(self):
-        return "<Client: endpoint=%s, user=%r>" % (self.endpoint_url,
-                                                   self.auth)
+        return "Client(transport=%r, auth=%r)" % (self.transport, self.auth)
 
     __str__ = __repr__
 

--- a/SoftLayer/API.py
+++ b/SoftLayer/API.py
@@ -68,17 +68,19 @@ class Client(object):
                                               endpoint_url=endpoint_url,
                                               timeout=timeout,
                                               auth=auth,
+                                              transport=transport,
                                               proxy=proxy,
                                               config_file=config_file)
         self.auth = settings.get('auth')
+        self.version = settings.get('version')
 
-        self.endpoint_url = (settings.get('endpoint_url') or
-                             API_PUBLIC_ENDPOINT).rstrip('/')
-        self.transport = transport or transports.XmlRpcTransport()
+        self.endpoint_url = (settings.get('endpoint_url') or '').rstrip('/')
+        self.transport = settings.get('transport')
 
         self.timeout = None
         if settings.get('timeout'):
             self.timeout = float(settings.get('timeout'))
+
         self.proxy = None
         if settings.get('proxy'):
             self.proxy = settings.get('proxy')

--- a/SoftLayer/CLI/config/__init__.py
+++ b/SoftLayer/CLI/config/__init__.py
@@ -12,12 +12,18 @@ def get_settings_from_client(client):
     settings = {
         'username': '',
         'api_key': '',
-        'timeout': client.timeout or None,
-        'endpoint_url': client.endpoint_url,
+        'timeout': '',
+        'endpoint_url': '',
     }
     try:
         settings['username'] = client.auth.username
         settings['api_key'] = client.auth.api_key
+    except AttributeError:
+        pass
+
+    try:
+        settings['timeout'] = client.transport.transport.timeout
+        settings['endpoint_url'] = client.transport.transport.endpoint_url
     except AttributeError:
         pass
 

--- a/SoftLayer/auth.py
+++ b/SoftLayer/auth.py
@@ -74,3 +74,23 @@ class BasicAuthentication(AuthenticationBase):
 
     def __repr__(self):
         return "<BasicAuthentication: %s>" % (self.username)
+
+
+class BasicHTTPAuthentication(AuthenticationBase):
+    """Token-based authentication class.
+
+        :param username str: a user's username
+        :param api_key str: a user's API key
+    """
+    def __init__(self, username, api_key):
+        self.username = username
+        self.api_key = api_key
+
+    def get_request(self, request):
+        """Sets token-based auth headers."""
+        request.transport_user = self.username
+        request.transport_password = self.api_key
+        return request
+
+    def __repr__(self):
+        return "<BasicHTTPAuthentication: %s>" % (self.username)

--- a/SoftLayer/auth.py
+++ b/SoftLayer/auth.py
@@ -7,7 +7,12 @@
 """
 # pylint: disable=no-self-use
 
-__all__ = ['BasicAuthentication', 'TokenAuthentication', 'AuthenticationBase']
+__all__ = [
+    'BasicAuthentication',
+    'TokenAuthentication',
+    'BasicHTTPAuthentication',
+    'AuthenticationBase',
+]
 
 
 class AuthenticationBase(object):
@@ -51,7 +56,7 @@ class TokenAuthentication(AuthenticationBase):
         return request
 
     def __repr__(self):
-        return "<TokenAuthentication: %s %s>" % (self.user_id, self.auth_token)
+        return "TokenAuthentication(%r)" % self.user_id
 
 
 class BasicAuthentication(AuthenticationBase):
@@ -73,7 +78,7 @@ class BasicAuthentication(AuthenticationBase):
         return request
 
     def __repr__(self):
-        return "<BasicAuthentication: %s>" % (self.username)
+        return "BasicAuthentication(username=%r)" % self.username
 
 
 class BasicHTTPAuthentication(AuthenticationBase):
@@ -93,4 +98,4 @@ class BasicHTTPAuthentication(AuthenticationBase):
         return request
 
     def __repr__(self):
-        return "<BasicHTTPAuthentication: %s>" % (self.username)
+        return "BasicHTTPAuthentication(username=%r)" % self.username

--- a/SoftLayer/config.py
+++ b/SoftLayer/config.py
@@ -18,7 +18,7 @@ def get_client_settings_args(**kwargs):
     """
     return {
         'endpoint_url': kwargs.get('endpoint_url'),
-        'timeout': kwargs.get('timeout'),
+        'timeout': float(kwargs.get('timeout') or 0),
         'proxy': kwargs.get('proxy'),
         'username': kwargs.get('username'),
         'api_key': kwargs.get('api_key'),
@@ -51,7 +51,7 @@ def get_client_settings_config_file(**kwargs):
         'username': '',
         'api_key': '',
         'endpoint_url': '',
-        'timeout': '',
+        'timeout': '0',
         'proxy': '',
     })
     config.read(config_files)
@@ -61,7 +61,7 @@ def get_client_settings_config_file(**kwargs):
 
     return {
         'endpoint_url': config.get('softlayer', 'endpoint_url'),
-        'timeout': config.get('softlayer', 'timeout'),
+        'timeout': config.getfloat('softlayer', 'timeout'),
         'proxy': config.get('softlayer', 'proxy'),
         'username': config.get('softlayer', 'username'),
         'api_key': config.get('softlayer', 'api_key'),

--- a/SoftLayer/managers/metadata.py
+++ b/SoftLayer/managers/metadata.py
@@ -56,11 +56,12 @@ class MetadataManager(object):
     attribs = METADATA_MAPPING
 
     def __init__(self, client=None, timeout=5):
-        url = consts.API_PRIVATE_ENDPOINT_REST.rstrip('/')
         if client is None:
-            client = SoftLayer.Client(endpoint_url=url,
-                                      timeout=timeout,
-                                      transport=transports.RestTransport())
+            transport = transports.RestTransport(
+                timeout=timeout,
+                endpoint_url=consts.API_PRIVATE_ENDPOINT_REST,
+            )
+            client = SoftLayer.BaseClient(transport=transport)
         self.client = client
 
     def get(self, name, param=None):

--- a/SoftLayer/tests/CLI/modules/config_tests.py
+++ b/SoftLayer/tests/CLI/modules/config_tests.py
@@ -24,8 +24,8 @@ class TestHelpShow(testing.TestCase):
         self.assertEqual(json.loads(result.output),
                          {'Username': 'default-user',
                           'API Key': 'default-key',
-                          'Endpoint URL': 'default-endpoint-url',
-                          'Timeout': 10.0})
+                          'Endpoint URL': 'not set',
+                          'Timeout': 'not set'})
 
 
 class TestHelpSetup(testing.TestCase):
@@ -80,7 +80,6 @@ class TestHelpSetup(testing.TestCase):
         self.assertEqual(username, 'user')
         self.assertEqual(secret, 'A' * 64)
         self.assertEqual(endpoint_url, consts.API_PRIVATE_ENDPOINT)
-        self.assertEqual(timeout, 10)
 
     @mock.patch('SoftLayer.CLI.environment.Environment.getpass')
     @mock.patch('SoftLayer.CLI.environment.Environment.input')

--- a/SoftLayer/tests/api_tests.py
+++ b/SoftLayer/tests/api_tests.py
@@ -32,11 +32,10 @@ class Inititialization(testing.TestCase):
     def test_env(self, get_client_settings):
         auth = mock.Mock()
         get_client_settings.return_value = {
-            'auth': auth,
             'timeout': 10,
             'endpoint_url': 'http://endpoint_url/',
         }
-        client = SoftLayer.Client()
+        client = SoftLayer.Client(auth=auth)
         self.assertEqual(client.auth.get_headers(), auth.get_headers())
         self.assertEqual(client.timeout, 10)
         self.assertEqual(client.endpoint_url, 'http://endpoint_url')

--- a/SoftLayer/tests/auth_tests.py
+++ b/SoftLayer/tests/auth_tests.py
@@ -63,4 +63,23 @@ class TestTokenAuthentication(testing.TestCase):
         s = repr(self.auth)
         self.assertIn('TokenAuthentication', s)
         self.assertIn('12345', s)
-        self.assertIn('TOKEN', s)
+
+
+class TestBasicHTTPAuthentication(testing.TestCase):
+    def set_up(self):
+        self.auth = auth.BasicHTTPAuthentication('USERNAME', 'APIKEY')
+
+    def test_attribs(self):
+        self.assertEqual(self.auth.username, 'USERNAME')
+        self.assertEqual(self.auth.api_key, 'APIKEY')
+
+    def test_get_request(self):
+        req = transports.Request()
+        authed_req = self.auth.get_request(req)
+        self.assertEqual(authed_req.transport_user, 'USERNAME')
+        self.assertEqual(authed_req.transport_password, 'APIKEY')
+
+    def test_repr(self):
+        s = repr(self.auth)
+        self.assertIn('BasicHTTPAuthentication', s)
+        self.assertIn('USERNAME', s)

--- a/SoftLayer/tests/config_tests.py
+++ b/SoftLayer/tests/config_tests.py
@@ -50,27 +50,9 @@ class TestGetClientSettingsArgs(testing.TestCase):
 
         self.assertEqual(result['endpoint_url'], 'http://endpoint/')
         self.assertEqual(result['timeout'], 10)
-        self.assertEqual(result['auth'].username, 'username')
-        self.assertEqual(result['auth'].api_key, 'api_key')
+        self.assertEqual(result['username'], 'username')
+        self.assertEqual(result['api_key'], 'api_key')
         self.assertEqual(result['proxy'], 'https://localhost:3128')
-
-    def test_no_auth(self):
-        result = config.get_client_settings_args()
-
-        self.assertEqual(result, {
-            'endpoint_url': None,
-            'timeout': None,
-            'proxy': None,
-            'auth': None,
-        })
-
-    def test_with_auth(self):
-        auth = mock.Mock()
-        result = config.get_client_settings_args(auth=auth)
-
-        self.assertEqual(result['endpoint_url'], None)
-        self.assertEqual(result['timeout'], None)
-        self.assertEqual(result['auth'], auth)
 
 
 class TestGetClientSettingsEnv(testing.TestCase):
@@ -81,15 +63,8 @@ class TestGetClientSettingsEnv(testing.TestCase):
     def test_username_api_key(self):
         result = config.get_client_settings_env()
 
-        self.assertEqual(result['auth'].username, 'username')
-        self.assertEqual(result['auth'].api_key, 'api_key')
-
-    @mock.patch.dict('os.environ', {'SL_USERNAME': '', 'SL_API_KEY': ''})
-    def test_no_auth(self):
-        result = config.get_client_settings_env()
-
-        # proxy might get ANY value depending on test env.
-        self.assertEqual(result, {'proxy': mock.ANY})
+        self.assertEqual(result['username'], 'username')
+        self.assertEqual(result['api_key'], 'api_key')
 
 
 class TestGetClientSettingsConfigFile(testing.TestCase):
@@ -101,8 +76,8 @@ class TestGetClientSettingsConfigFile(testing.TestCase):
         self.assertEqual(result['endpoint_url'], config_parser().get())
         self.assertEqual(result['timeout'], config_parser().get())
         self.assertEqual(result['proxy'], config_parser().get())
-        self.assertEqual(result['auth'].username, config_parser().get())
-        self.assertEqual(result['auth'].api_key, config_parser().get())
+        self.assertEqual(result['username'], config_parser().get())
+        self.assertEqual(result['api_key'], config_parser().get())
 
     @mock.patch('six.moves.configparser.RawConfigParser')
     def test_no_section(self, config_parser):

--- a/SoftLayer/tests/config_tests.py
+++ b/SoftLayer/tests/config_tests.py
@@ -74,7 +74,7 @@ class TestGetClientSettingsConfigFile(testing.TestCase):
         result = config.get_client_settings_config_file()
 
         self.assertEqual(result['endpoint_url'], config_parser().get())
-        self.assertEqual(result['timeout'], config_parser().get())
+        self.assertEqual(result['timeout'], config_parser().getfloat())
         self.assertEqual(result['proxy'], config_parser().get())
         self.assertEqual(result['username'], config_parser().get())
         self.assertEqual(result['api_key'], config_parser().get())

--- a/SoftLayer/tests/functional_tests.py
+++ b/SoftLayer/tests/functional_tests.py
@@ -38,13 +38,14 @@ class UnauthedUser(FunctionalTest):
     def test_no_hostname(self):
         try:
             request = transports.Request()
-            request.endpoint = 'http://notvalidsoftlayer.com'
             request.service = 'SoftLayer_Account'
             request.method = 'getObject'
             request.id = 1234
 
             # This test will fail if 'notvalidsoftlayer.com' becomes a thing
-            transport = transports.XmlRpcTransport()
+            transport = transports.XmlRpcTransport(
+                endpoint_url='http://notvalidsoftlayer.com',
+            )
             transport(request)
         except SoftLayer.SoftLayerAPIError as ex:
             self.assertIn('not known', str(ex))

--- a/SoftLayer/tests/managers/metadata_tests.py
+++ b/SoftLayer/tests/managers/metadata_tests.py
@@ -21,7 +21,6 @@ class MetadataTests(testing.TestCase):
 
         self.assertEqual('dal01', resp)
         self.assert_called_with('SoftLayer_Resource_Metadata', 'Datacenter',
-                                timeout=10.0,
                                 identifier=None)
 
     def test_no_param(self):

--- a/SoftLayer/tests/transport_tests.py
+++ b/SoftLayer/tests/transport_tests.py
@@ -263,6 +263,9 @@ class TestRestAPICall(testing.TestCase):
             'GET', 'http://something.com/SoftLayer_Service/Resource.json',
             headers={},
             verify=True,
+            params={},
+            auth=None,
+            data=None,
             cert=None,
             proxies=None,
             timeout=None)
@@ -309,6 +312,9 @@ class TestRestAPICall(testing.TestCase):
                      'http': 'http://localhost:3128'},
             verify=True,
             cert=None,
+            params={},
+            auth=None,
+            data=None,
             timeout=mock.ANY,
             headers=mock.ANY)
 
@@ -330,6 +336,9 @@ class TestRestAPICall(testing.TestCase):
             'http://something.com/SoftLayer_Service/getObject/2.json',
             headers={},
             verify=True,
+            params={},
+            auth=None,
+            data=None,
             cert=None,
             proxies=None,
             timeout=None)

--- a/SoftLayer/tests/transport_tests.py
+++ b/SoftLayer/tests/transport_tests.py
@@ -331,7 +331,7 @@ class TestRestAPICall(testing.TestCase):
         self.assertEqual(resp, {})
         request.assert_called_with(
             'GET',
-            'http://something.com/SoftLayer_Service/getObject/2.json',
+            'http://something.com/SoftLayer_Service/2/getObject.json',
             headers=mock.ANY,
             verify=True,
             params={},

--- a/SoftLayer/tests/transport_tests.py
+++ b/SoftLayer/tests/transport_tests.py
@@ -4,6 +4,7 @@
 
     :license: MIT, see LICENSE for more details.
 """
+import json
 import warnings
 
 import mock
@@ -353,8 +354,7 @@ class TestRestAPICall(testing.TestCase):
         resp = self.transport(req)
 
         self.assertEqual(resp, {})
-        expected_body = ('{"parameters": '
-                         '[{"domain": "test.com", "hostname": "example"}]}')
+        expected_body = json.dumps({'parameters': req.args})
         request.assert_called_with(
             'GET',
             'http://something.com/SoftLayer_Service/createObject.json',

--- a/SoftLayer/tests/transport_tests.py
+++ b/SoftLayer/tests/transport_tests.py
@@ -342,6 +342,32 @@ class TestRestAPICall(testing.TestCase):
             timeout=None)
 
     @mock.patch('requests.request')
+    def test_with_args(self, request):
+        request().content = '{}'
+
+        req = transports.Request()
+        req.service = 'SoftLayer_Service'
+        req.method = 'createObject'
+        req.args = ({'domain': 'test.com', 'hostname': 'example'}, )
+
+        resp = self.transport(req)
+
+        self.assertEqual(resp, {})
+        expected_body = ('{"parameters": '
+                         '[{"domain": "test.com", "hostname": "example"}]}')
+        request.assert_called_with(
+            'GET',
+            'http://something.com/SoftLayer_Service/createObject.json',
+            headers=mock.ANY,
+            verify=True,
+            data=expected_body,
+            params={},
+            auth=None,
+            cert=None,
+            proxies=None,
+            timeout=None)
+
+    @mock.patch('requests.request')
     def test_unknown_error(self, request):
         e = requests.RequestException('error')
         e.response = mock.MagicMock()

--- a/SoftLayer/transports.py
+++ b/SoftLayer/transports.py
@@ -201,10 +201,8 @@ class RestTransport(object):
             params['objectMask'] = _format_object_mask(request.mask)
 
         if request.limit:
-            params['limit'] = request.limit
-
-        if request.offset:
-            params['offset'] = request.offset
+            params['resultLimit'] = '%s,%s' % (request.offset or 0,
+                                               request.limit)
 
         if request.filter:
             params['objectFilter'] = json.dumps(request.filter)

--- a/SoftLayer/transports.py
+++ b/SoftLayer/transports.py
@@ -208,7 +208,7 @@ class RestTransport(object):
             params['objectFilter'] = json.dumps(request.filter)
 
         if request.args:
-            body['parameters'] = json.dumps(request.args)
+            body['parameters'] = json.dumps({'parameters': request.args})
 
         auth = None
         if request.transport_user:

--- a/SoftLayer/transports.py
+++ b/SoftLayer/transports.py
@@ -323,6 +323,7 @@ def _format_object_mask_xmlrpc(objectmask, service):
 
 
 def _format_object_mask(mask):
+    """Format object mask (wrap with mask[] if it isn't already)."""
     objectmask = mask.strip()
     if not mask.startswith('mask') and not mask.startswith('['):
         mask = "mask[%s]" % objectmask

--- a/SoftLayer/transports.py
+++ b/SoftLayer/transports.py
@@ -103,8 +103,8 @@ class XmlRpcTransport(object):
             headers[header_name] = {'id': request.identifier}
 
         if request.mask is not None:
-            headers.update(_format_object_mask(request.mask,
-                                               request.service))
+            headers.update(_format_object_mask_xmlrpc(request.mask,
+                                                      request.service))
 
         if request.filter is not None:
             headers['%sObjectFilter' % request.service] = request.filter
@@ -198,7 +198,7 @@ class RestTransport(object):
         body = {}
 
         if request.mask:
-            params['objectMask'] = request.mask
+            params['objectMask'] = _format_object_mask(request.mask)
 
         if request.limit:
             params['limit'] = request.limit
@@ -308,7 +308,7 @@ def _proxies_dict(proxy):
     return {'http': proxy, 'https': proxy}
 
 
-def _format_object_mask(objectmask, service):
+def _format_object_mask_xmlrpc(objectmask, service):
     """Format new and old style object masks into proper headers.
 
     :param objectmask: a string- or dict-based object mask
@@ -319,10 +319,13 @@ def _format_object_mask(objectmask, service):
         mheader = '%sObjectMask' % service
     else:
         mheader = 'SoftLayer_ObjectMask'
-
-        objectmask = objectmask.strip()
-        if (not objectmask.startswith('mask') and
-                not objectmask.startswith('[')):
-            objectmask = "mask[%s]" % objectmask
+        objectmask = _format_object_mask(objectmask)
 
     return {mheader: {'mask': objectmask}}
+
+
+def _format_object_mask(mask):
+    objectmask = mask.strip()
+    if not mask.startswith('mask') and not mask.startswith('['):
+        mask = "mask[%s]" % objectmask
+    return mask

--- a/SoftLayer/transports.py
+++ b/SoftLayer/transports.py
@@ -208,7 +208,7 @@ class RestTransport(object):
             params['objectFilter'] = json.dumps(request.filter)
 
         if request.args:
-            body['parameters'] = json.dumps({'parameters': request.args})
+            body['parameters'] = request.args
 
         auth = None
         if request.transport_user:

--- a/SoftLayer/transports.py
+++ b/SoftLayer/transports.py
@@ -189,9 +189,11 @@ class RestTransport(object):
 
         :param request request: Request object
         """
-        url_parts = [self.endpoint_url, request.service, request.method]
+        url_parts = [self.endpoint_url, request.service]
         if request.identifier is not None:
             url_parts.append(str(request.identifier))
+        if request.method is not None:
+            url_parts.append(request.method)
 
         url = '%s.%s' % ('/'.join(url_parts), 'json')
         params = {}
@@ -228,6 +230,7 @@ class RestTransport(object):
         LOGGER.debug("=== REQUEST ===")
         LOGGER.info(url)
         LOGGER.debug(request.transport_headers)
+        LOGGER.debug(raw_body)
         try:
             resp = requests.request('GET', url,
                                     auth=auth,


### PR DESCRIPTION
Fully implements the REST transport to support masks, filters, limit, offset, auth. Also implements #514, which should make building the API client a bit less confusing long-term.