### PR TITLE
Ticket CLI Improvements

### DIFF
--- a/SoftLayer/CLI/ticket/__init__.py
+++ b/SoftLayer/CLI/ticket/__init__.py
@@ -1,7 +1,6 @@
 """Support tickets."""
 
 from SoftLayer.CLI import formatting
-from SoftLayer import utils
 
 import click
 

--- a/SoftLayer/CLI/ticket/__init__.py
+++ b/SoftLayer/CLI/ticket/__init__.py
@@ -32,7 +32,6 @@ def get_ticket_results(mgr, ticket_id, update_count=1):
         ])
 
     table.add_row(['status', ticket['status']['name']])
-
     table.add_row(['created', ticket.get('createDate')])
     table.add_row(['edited', ticket.get('lastEditDate')])
 

--- a/SoftLayer/CLI/ticket/__init__.py
+++ b/SoftLayer/CLI/ticket/__init__.py
@@ -32,6 +32,8 @@ def get_ticket_results(mgr, ticket_id, update_count=1):
             "%s %s" % (user.get('firstName'), user.get('lastName')),
         ])
 
+    table.add_row(['status', ticket['status']['name']])
+
     table.add_row(['created', ticket.get('createDate')])
     table.add_row(['edited', ticket.get('lastEditDate')])
 

--- a/SoftLayer/CLI/ticket/list.py
+++ b/SoftLayer/CLI/ticket/list.py
@@ -25,10 +25,10 @@ def cli(env, is_open):
                               'last_edited', 'status'])
 
     for ticket in tickets:
-        user = 'N/A'
+        user = formatting.blank()
         if ticket.get('assignedUser'):
             user = "%s %s" % (ticket['assignedUser']['firstName'],
-                              ticket['assignedUser']['lastName']),
+                              ticket['assignedUser']['lastName'])
 
         table.add_row([
             ticket['id'],

--- a/SoftLayer/CLI/ticket/list.py
+++ b/SoftLayer/CLI/ticket/list.py
@@ -11,17 +11,18 @@ import click
 
 @click.command()
 @click.option('--open / --closed', 'is_open',
-              help="Display only open or closed tickets")
+              help="Display only open or closed tickets",
+              default=True)
 @environment.pass_env
 def cli(env, is_open):
     """List tickets."""
     ticket_mgr = SoftLayer.TicketManager(env.client)
 
-    tickets = ticket_mgr.list_tickets(open_status=not is_open,
-                                      closed_status=is_open)
+    tickets = ticket_mgr.list_tickets(open_status=is_open,
+                                      closed_status=not is_open)
 
-    table = formatting.Table(['id', 'assigned user', 'title',
-                              'creation date', 'last edit date'])
+    table = formatting.Table(['id', 'assigned_user', 'title',
+                              'last_edited', 'status'])
 
     for ticket in tickets:
         user = 'N/A'
@@ -33,8 +34,8 @@ def cli(env, is_open):
             ticket['id'],
             user,
             click.wrap_text(ticket['title']),
-            ticket['createDate'],
-            ticket['lastEditDate']
+            ticket['lastEditDate'],
+            ticket['status']['name'],
         ])
 
     return table

--- a/SoftLayer/managers/ticket.py
+++ b/SoftLayer/managers/ticket.py
@@ -26,8 +26,8 @@ class TicketManager(utils.IdentifierMixin, object):
         :param boolean open_status: include open tickets
         :param boolean closed_status: include closed tickets
         """
-        mask = ('mask[id, title, assignedUser[firstName, lastName],'
-                'createDate,lastEditDate,accountId]')
+        mask = ('id, title, assignedUser[firstName, lastName],'
+                'createDate,lastEditDate,accountId,status')
 
         call = 'getTickets'
         if not all([open_status, closed_status]):
@@ -36,8 +36,7 @@ class TicketManager(utils.IdentifierMixin, object):
             elif closed_status:
                 call = 'getClosedTickets'
 
-        func = getattr(self.account, call)
-        return func(mask=mask)
+        return self.client.call('Account', call, mask=mask)
 
     def list_subjects(self):
         """List all tickets."""
@@ -52,7 +51,7 @@ class TicketManager(utils.IdentifierMixin, object):
 
         """
         mask = ('mask[id, title, assignedUser[firstName, lastName],'
-                'createDate,lastEditDate,updates[entry],updateCount]')
+                'createDate,lastEditDate,updates[entry,editor],updateCount]')
         return self.ticket.getObject(id=ticket_id, mask=mask)
 
     def create_ticket(self, title=None, body=None, subject=None):

--- a/SoftLayer/managers/ticket.py
+++ b/SoftLayer/managers/ticket.py
@@ -50,8 +50,8 @@ class TicketManager(utils.IdentifierMixin, object):
                   the specified ticket.
 
         """
-        mask = ('mask[id, title, assignedUser[firstName, lastName],'
-                'createDate,lastEditDate,updates[entry,editor],updateCount]')
+        mask = ('id, title, assignedUser[firstName, lastName],status,'
+                'createDate,lastEditDate,updates[entry,editor],updateCount')
         return self.ticket.getObject(id=ticket_id, mask=mask)
 
     def create_ticket(self, title=None, body=None, subject=None):

--- a/SoftLayer/managers/ticket.py
+++ b/SoftLayer/managers/ticket.py
@@ -78,6 +78,4 @@ class TicketManager(utils.IdentifierMixin, object):
         :param integer ticket_id: the id of the ticket to update
         :param string body: entry to update in the ticket
         """
-
-        ticket = self.ticket.getObject(id=ticket_id)
-        return self.ticket.edit(ticket, body, id=ticket_id)
+        return self.ticket.addUpdate({'entry': body}, id=ticket_id)

--- a/SoftLayer/testing/fixtures/SoftLayer_Account.py
+++ b/SoftLayer/testing/fixtures/SoftLayer_Account.py
@@ -361,6 +361,7 @@ getTickets = [
             "id": 1001,
             "name": "Open"
         },
+        'assignedUser': {'firstName': 'John', 'lastName': 'Smith'},
         "statusId": 1001,
         "title": "Cloud Instance Cancellation - 08/01/13"
     }]

--- a/SoftLayer/testing/fixtures/SoftLayer_Ticket.py
+++ b/SoftLayer/testing/fixtures/SoftLayer_Ticket.py
@@ -18,7 +18,8 @@ getObject = {
         {'entry': 'a bot says something'},
         {'entry': 'user says something',
          'editor': {'firstName': 'John', 'lastName': 'Smith'}},
-        {'entry': 'employee says something', 'editor': {'displayName': 'emp1'}},
+        {'entry': 'employee says something',
+         'editor': {'displayName': 'emp1'}},
 
     ]
 }

--- a/SoftLayer/testing/fixtures/SoftLayer_Ticket.py
+++ b/SoftLayer/testing/fixtures/SoftLayer_Ticket.py
@@ -12,7 +12,15 @@ getObject = {
         "name": "Closed"
     },
     "statusId": 1002,
-    "title": "Cloud Instance Cancellation - 08/01/13"
+    "title": "Cloud Instance Cancellation - 08/01/13",
+    'updateCount': 3,
+    'updates': [
+        {'entry': 'a bot says something'},
+        {'entry': 'user says something',
+         'editor': {'firstName': 'John', 'lastName': 'Smith'}},
+        {'entry': 'employee says something', 'editor': {'displayName': 'emp1'}},
+
+    ]
 }
 
 createStandardTicket = {
@@ -23,3 +31,4 @@ createStandardTicket = {
     "title": "Cloud Instance Cancellation - 08/01/13"
 }
 edit = True
+addUpdate = {}

--- a/SoftLayer/tests/CLI/modules/ticket_tests.py
+++ b/SoftLayer/tests/CLI/modules/ticket_tests.py
@@ -1,0 +1,40 @@
+"""
+    SoftLayer.tests.CLI.modules.ticket_tests
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    :license: MIT, see LICENSE for more details.
+"""
+from SoftLayer import testing
+
+import json
+
+
+class TicketTests(testing.TestCase):
+
+    def test_list(self):
+        result = self.run_command(['ticket', 'list'])
+
+        expected = [{
+            'assigned_user': 'John Smith',
+            'id': 102,
+            'last_edited': '2013-08-01T14:16:47-07:00',
+            'status': 'Open',
+            'title': 'Cloud Instance Cancellation - 08/01/13'}]
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(json.loads(result.output), expected)
+
+    def test_detail(self):
+        result = self.run_command(['ticket', 'detail', '1'])
+
+        expected = {
+            'created': '2013-08-01T14:14:04-07:00',
+            'edited': '2013-08-01T14:16:47-07:00',
+            'id': 100,
+            'status': 'Closed',
+            'title': 'Cloud Instance Cancellation - 08/01/13',
+            'update 1': 'a bot says something',
+            'update 2': 'By John Smith\nuser says something',
+            'update 3': 'By emp1 (Employee)\nemployee says something',
+        }
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(json.loads(result.output), expected)

--- a/SoftLayer/tests/managers/ticket_tests.py
+++ b/SoftLayer/tests/managers/ticket_tests.py
@@ -74,23 +74,6 @@ class TicketTests(testing.TestCase):
     def test_update_ticket(self):
         # test a full update
         self.ticket.update_ticket(100, body='Update1')
-        args = (
-            {
-                "accountId": 1234,
-                "assignedUserId": 12345,
-                "createDate": "2013-08-01T14:14:04-07:00",
-                "id": 100,
-                "lastEditDate": "2013-08-01T14:16:47-07:00",
-                "lastEditType": "AUTO",
-                "modifyDate": "2013-08-01T14:16:47-07:00",
-                "status": {
-                    "id": 1002,
-                    "name": "Closed"
-                },
-                "statusId": 1002,
-                "title": "Cloud Instance Cancellation - 08/01/13"
-            },
-            'Update1')
-        self.assert_called_with('SoftLayer_Ticket', 'edit',
-                                args=args,
+        self.assert_called_with('SoftLayer_Ticket', 'addUpdate',
+                                args=({'entry': 'Update1'},),
                                 identifier=100)


### PR DESCRIPTION
* The `limit` option for ticket updates (as shown in `slcli ticket detail <id> --count=10`) will now the last updates instead of the first ones. For example, if there are 20 updates on a ticket and the user specifies a `--count=5` then updates 16-20 will be shown.
* `slcli ticket detail <id>` will now show the author for each update at the beginning of the update.
* Ticket listing and detail commands now show ticket status
* Several small style issues as well to bring this in line with other commands.