### PR TITLE
Hardware cancel consolidation

### DIFF
--- a/SoftLayer/CLI/server/detail.py
+++ b/SoftLayer/CLI/server/detail.py
@@ -35,7 +35,7 @@ def cli(env, identifier, passwords, price):
     result = utils.NestedDict(result)
 
     table.add_row(['id', result['id']])
-    table.add_row(['guid', result['globalIdentifier']] or formatting.blank())
+    table.add_row(['guid', result['globalIdentifier'] or formatting.blank()])
     table.add_row(['hostname', result['hostname']])
     table.add_row(['domain', result['domain']])
     table.add_row(['fqdn', result['fullyQualifiedDomainName']])

--- a/SoftLayer/tests/managers/hardware_tests.py
+++ b/SoftLayer/tests/managers/hardware_tests.py
@@ -281,7 +281,6 @@ class HardwareTests(testing.TestCase):
                                 identifier=6327,
                                 args=(False, False, 'No longer needed', ''))
 
-
     def test_cancel_hardware_no_billing_item(self):
         mock = self.set_mock('SoftLayer_Hardware_Server', 'getObject')
         mock.return_value = {'id': 987}
@@ -289,6 +288,8 @@ class HardwareTests(testing.TestCase):
         ex = self.assertRaises(SoftLayer.SoftLayerError,
                                self.hardware.cancel_hardware,
                                6327)
+        self.assertEqual("No billing item found for hardware",
+                         str(ex))
 
     def test_change_port_speed_public(self):
         self.hardware.change_port_speed(2, True, 100)

--- a/SoftLayer/tests/managers/hardware_tests.py
+++ b/SoftLayer/tests/managers/hardware_tests.py
@@ -243,57 +243,52 @@ class HardwareTests(testing.TestCase):
         self.assert_called_with('SoftLayer_Product_Order', 'placeOrder',
                                 args=({'test': 1, 'verify': 1},))
 
-    def test_cancel_metal_immediately(self):
-
-        result = self.hardware.cancel_metal(6327, immediate=True)
-
-        self.assertEqual(result, True)
-        self.assert_called_with('SoftLayer_Billing_Item', 'cancelService',
-                                identifier=6327)
-
-    def test_cancel_metal_on_anniversary(self):
-
-        result = self.hardware.cancel_metal(6327, False)
-
-        self.assertEqual(result, True)
-        self.assert_called_with('SoftLayer_Billing_Item',
-                                'cancelServiceOnAnniversaryDate',
-                                identifier=6327)
-
     def test_cancel_hardware_without_reason(self):
         mock = self.set_mock('SoftLayer_Hardware_Server', 'getObject')
-        mock.return_value = {'id': 987, 'bareMetalInstanceFlag': False}
+        mock.return_value = {'id': 987, 'billingItem': {'id': 1234}}
 
         result = self.hardware.cancel_hardware(987)
 
-        self.assertEqual(result,
-                         fixtures.SoftLayer_Ticket.createCancelServerTicket)
+        self.assertEqual(result, True)
         reasons = self.hardware.get_cancellation_reasons()
-        args = (987, reasons['unneeded'], '', True, 'HARDWARE')
-        self.assert_called_with('SoftLayer_Ticket', 'createCancelServerTicket',
+        args = (False, False, reasons['unneeded'], '')
+        self.assert_called_with('SoftLayer_Billing_Item', 'cancelItem',
+                                identifier=1234,
                                 args=args)
 
     def test_cancel_hardware_with_reason_and_comment(self):
         mock = self.set_mock('SoftLayer_Hardware_Server', 'getObject')
-        mock.return_value = {'id': 987, 'bareMetalInstanceFlag': False}
+        mock.return_value = {'id': 987, 'billingItem': {'id': 1234}}
 
-        result = self.hardware.cancel_hardware(987, 'sales', 'Test Comment')
+        result = self.hardware.cancel_hardware(6327,
+                                               reason='sales',
+                                               comment='Test Comment')
 
-        self.assertEqual(result,
-                         fixtures.SoftLayer_Ticket.createCancelServerTicket)
+        self.assertEqual(result, True)
         reasons = self.hardware.get_cancellation_reasons()
-        args = (987, reasons['sales'], 'Test Comment', True, 'HARDWARE')
-        self.assert_called_with('SoftLayer_Ticket', 'createCancelServerTicket',
+        args = (False, False, reasons['sales'], 'Test Comment')
+        self.assert_called_with('SoftLayer_Billing_Item', 'cancelItem',
+                                identifier=1234,
                                 args=args)
 
-    def test_cancel_hardware_on_bmc(self):
+    def test_cancel_hardware(self):
 
         result = self.hardware.cancel_hardware(6327)
 
         self.assertEqual(result, True)
         self.assert_called_with('SoftLayer_Billing_Item',
-                                'cancelServiceOnAnniversaryDate',
-                                identifier=6327)
+                                'cancelItem',
+                                identifier=6327,
+                                args=(False, False, 'No longer needed', ''))
+
+
+    def test_cancel_hardware_no_billing_item(self):
+        mock = self.set_mock('SoftLayer_Hardware_Server', 'getObject')
+        mock.return_value = {'id': 987}
+
+        ex = self.assertRaises(SoftLayer.SoftLayerError,
+                               self.hardware.cancel_hardware,
+                               6327)
 
     def test_change_port_speed_public(self):
         self.hardware.change_port_speed(2, True, 100)


### PR DESCRIPTION
This should resolve #522.

* HardwareManager.cancel_metal() is removed in favor of HardwareManager.cancel_hardware()
* HardwareManager.cancel_hardware() now uses SoftLayer_Billing_Item::cancelItem() which (I think) works on most cancelable items.