### PR TITLE
Adds requests[security] as a dep if py version < 2.7.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,15 @@ REQUIRES = [
     'requests',
 ]
 
+# Importlib was introduced in 2.7
 if sys.version_info < (2, 7):
     REQUIRES.append('importlib')
+
+# The security addon for requests is needed to make a proper SSL context in
+# python versions before 2.7.9:
+# https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning
+if sys.version_info < (2, 7, 9):
+    REQUIRES.append('requests[security]')
 
 DESCRIPTION = "A library for SoftLayer's API"
 
@@ -54,7 +61,6 @@ setup(
     keywords=['softlayer', 'cloud'],
     classifiers=[
         'Environment :: Console',
-        'Environment :: Web Environment',
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: MIT License',

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,3 @@
-requests
 requests[security]
 click
 prettytable >= 0.7.0

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,5 @@
 requests
+requests[security]
 click
 prettytable >= 0.7.0
 six >= 1.7.0


### PR DESCRIPTION
Currently, a warning shows if you don't have several packages installed on Python versions before 2.7.9.

This is the warning:
```
/usr/local/lib/python2.7/dist-packages/requests/packages/urllib3/util/ssl_.py:79: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning
```

This change is to help avoid the warning.