### PR TITLE
Adds XML-RPC proxy server to be used for tests

### DIFF
--- a/SoftLayer/API.py
+++ b/SoftLayer/API.py
@@ -192,11 +192,12 @@ class BaseClient(object):
         if self._prefix and not service.startswith(self._prefix):
             service = self._prefix + service
 
-        http_headers = {}
+        http_headers = {'Accept': '*/*'}
 
         if kwargs.get('compress', True):
-            http_headers['Accept'] = '*/*'
             http_headers['Accept-Encoding'] = 'gzip, deflate, compress'
+        else:
+            http_headers['Accept-Encoding'] = None
 
         if kwargs.get('raw_headers'):
             http_headers.update(kwargs.get('raw_headers'))

--- a/SoftLayer/testing/fixtures/SoftLayer_Network_Subnet.py
+++ b/SoftLayer/testing/fixtures/SoftLayer_Network_Subnet.py
@@ -1,1 +1,1 @@
-getObject = {'id': id, 'billingItem': {'id': 1056}}
+getObject = {'id': 1234, 'billingItem': {'id': 1056}}

--- a/SoftLayer/testing/xmlrpc.py
+++ b/SoftLayer/testing/xmlrpc.py
@@ -55,7 +55,7 @@ class TestHandler(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):
 
             response_body = utils.xmlrpc_client.dumps((response,),
                                                       allow_none=True,
-                                                      methodresponse=1)
+                                                      methodresponse=True)
 
             self.send_response(200)
             self.send_header("Content-type", "application/xml")
@@ -63,12 +63,12 @@ class TestHandler(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):
             self.wfile.write(response_body.encode('utf-8'))
 
         except SoftLayer.SoftLayerAPIError as ex:
-            self.send_response(ex.faultCode or 500)
+            self.send_response(200)
             self.end_headers()
             response = utils.xmlrpc_client.Fault(ex.faultCode, str(ex.reason))
-            response_body = utils.xmlrpc_client.dumps((response,),
+            response_body = utils.xmlrpc_client.dumps(response,
                                                       allow_none=True,
-                                                      methodresponse=1)
+                                                      methodresponse=True)
             self.wfile.write(response_body.encode('utf-8'))
         except Exception as ex:
             self.send_response(500)

--- a/SoftLayer/testing/xmlrpc.py
+++ b/SoftLayer/testing/xmlrpc.py
@@ -1,0 +1,97 @@
+"""
+    SoftLayer.testing.xmprpc
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+    XMP-RPC server which can use a transport to proxy requests for testing.
+
+    :license: MIT, see LICENSE for more details.
+"""
+import logging
+import threading
+
+import six
+
+import SoftLayer
+from SoftLayer import transports
+from SoftLayer import utils
+
+# pylint: disable=invalid-name, broad-except
+
+
+class TestServer(six.moves.BaseHTTPServer.HTTPServer):
+    """Test HTTP server which holds a given transport."""
+
+    def __init__(self, transport, *args, **kw):
+        six.moves.BaseHTTPServer.HTTPServer.__init__(self, *args, **kw)
+        self.transport = transport
+
+
+class TestHandler(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):
+    """Test XML-RPC Handler which converts XML-RPC to transport requests."""
+
+    def do_POST(self):
+        """Handle XML-RPC POSTs."""
+        try:
+            length = int(self.headers['Content-Length'])
+            data = self.rfile.read(length).decode('utf-8')
+            args, method = utils.xmlrpc_client.loads(data)
+            headers = args[0].get('headers', {})
+
+            # Form Request for the transport
+            req = transports.Request()
+            req.service = self.path.lstrip('/')
+            req.method = method
+            req.limit = utils.lookup(headers, 'resultLimit', 'limit')
+            req.offset = utils.lookup(headers, 'resultLimit', 'offset')
+            req.args = args[1:]
+            req.filter = _item_by_key_postfix(headers, 'ObjectFilter') or None
+            req.mask = _item_by_key_postfix(headers, 'ObjectMask').get('mask')
+            req.identifier = _item_by_key_postfix(headers,
+                                                  'InitParameters').get('id')
+            req.transport_headers = dict(((k.lower(), v)
+                                          for k, v in self.headers.items()))
+
+            # Get response
+            response = self.server.transport(req)
+
+            response_body = utils.xmlrpc_client.dumps((response,),
+                                                      allow_none=True,
+                                                      methodresponse=1)
+
+            self.send_response(200)
+            self.send_header("Content-type", "application/xml")
+            self.end_headers()
+            self.wfile.write(response_body.encode('utf-8'))
+
+        except SoftLayer.SoftLayerAPIError as ex:
+            self.send_response(ex.faultCode or 500)
+            self.end_headers()
+            response = utils.xmlrpc_client.Fault(ex.faultCode, str(ex.reason))
+            response_body = utils.xmlrpc_client.dumps((response,),
+                                                      allow_none=True,
+                                                      methodresponse=1)
+            self.wfile.write(response_body.encode('utf-8'))
+        except Exception as ex:
+            self.send_response(500)
+            logging.exception("Error while handling request")
+
+    def log_message(self, fmt, *args):
+        """Override log_message."""
+        pass
+
+
+def _item_by_key_postfix(dictionary, key_prefix):
+    """Get item from a dictionary which begins with the given prefix."""
+    for key, value in dictionary.items():
+        if key.endswith(key_prefix):
+            return value
+
+    return {}
+
+
+def create_test_server(transport, host='localhost', port=0):
+    """Create a test XML-RPC server in a new thread."""
+    server = TestServer(transport, (host, port), TestHandler)
+    thread = threading.Thread(target=server.serve_forever,
+                              kwargs={'poll_interval': 0.05})
+    thread.start()
+    return server

--- a/SoftLayer/tests/CLI/modules/call_api_tests.py
+++ b/SoftLayer/tests/CLI/modules/call_api_tests.py
@@ -26,7 +26,7 @@ class CallCliTests(testing.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(json.loads(result.output), 'test')
         self.assert_called_with('SoftLayer_Service', 'method',
-                                mask='some.mask',
+                                mask='mask[some.mask]',
                                 limit=20,
                                 offset=40,
                                 identifier='100')

--- a/SoftLayer/tests/api_tests.py
+++ b/SoftLayer/tests/api_tests.py
@@ -189,34 +189,41 @@ class APIClient(testing.TestCase):
             self.client.call, 'SERVICE', 'METHOD', invalid_kwarg='invalid')
 
     def test_call_compression_disabled(self):
-        self.set_mock('SoftLayer_SERVICE', 'METHOD')
+        mocked = self.set_mock('SoftLayer_SERVICE', 'METHOD')
+        mocked.return_value = {}
+
         self.client['SERVICE'].METHOD(compress=False)
 
-        self.assert_called_with('SoftLayer_SERVICE', 'METHOD')
+        calls = self.calls('SoftLayer_SERVICE', 'METHOD')
+        self.assertEqual(len(calls), 1)
+        headers = calls[0].transport_headers
+        self.assertEqual(headers.get('accept-encoding'), 'identity')
 
     def test_call_compression_enabled(self):
-        self.set_mock('SoftLayer_SERVICE', 'METHOD')
+        mocked = self.set_mock('SoftLayer_SERVICE', 'METHOD')
+        mocked.return_value = {}
+
         self.client['SERVICE'].METHOD(compress=True)
 
-        expected_headers = {
-            'Accept-Encoding': 'gzip, deflate, compress',
-            'Accept': '*/*',
-        }
-        self.assert_called_with('SoftLayer_SERVICE', 'METHOD',
-                                transport_headers=expected_headers)
+        calls = self.calls('SoftLayer_SERVICE', 'METHOD')
+        self.assertEqual(len(calls), 1)
+        headers = calls[0].transport_headers
+        self.assertEqual(headers.get('accept-encoding'),
+                         'gzip, deflate, compress')
 
     def test_call_compression_override(self):
         # raw_headers should override compress=False
-        self.set_mock('SoftLayer_SERVICE', 'METHOD')
+        mocked = self.set_mock('SoftLayer_SERVICE', 'METHOD')
+        mocked.return_value = {}
+
         self.client['SERVICE'].METHOD(
             compress=False,
             raw_headers={'Accept-Encoding': 'gzip'})
 
-        expected_headers = {
-            'Accept-Encoding': 'gzip',
-        }
-        self.assert_called_with('SoftLayer_SERVICE', 'METHOD',
-                                transport_headers=expected_headers)
+        calls = self.calls('SoftLayer_SERVICE', 'METHOD')
+        self.assertEqual(len(calls), 1)
+        headers = calls[0].transport_headers
+        self.assertEqual(headers.get('accept-encoding'), 'gzip')
 
 
 class UnauthenticatedAPIClient(testing.TestCase):

--- a/SoftLayer/tests/managers/dns_tests.py
+++ b/SoftLayer/tests/managers/dns_tests.py
@@ -27,7 +27,7 @@ class DNSTests(testing.TestCase):
         self.assertEqual(res, fixtures.SoftLayer_Dns_Domain.getObject)
         self.assert_called_with('SoftLayer_Dns_Domain', 'getObject',
                                 identifier=12345,
-                                mask='resourceRecords')
+                                mask='mask[resourceRecords]')
 
     def test_get_zone_without_records(self):
         self.dns_client.get_zone(12345, records=False)

--- a/SoftLayer/tests/managers/firewall_tests.py
+++ b/SoftLayer/tests/managers/firewall_tests.py
@@ -59,7 +59,7 @@ class FirewallTests(testing.TestCase):
 
         self.assert_called_with('SoftLayer_Virtual_Guest', 'getObject',
                                 identifier=1234,
-                                mask='primaryNetworkComponent[maxSpeed]')
+                                mask='mask[primaryNetworkComponent[maxSpeed]]')
 
         _filter = {
             'items': {
@@ -77,7 +77,7 @@ class FirewallTests(testing.TestCase):
 
         # we should ask for the frontEndNetworkComponents to get
         # the firewall port speed
-        mask = 'id,maxSpeed,networkComponentGroup.networkComponents'
+        mask = 'mask[id,maxSpeed,networkComponentGroup.networkComponents]'
         self.assert_called_with('SoftLayer_Hardware_Server',
                                 'getFrontendNetworkComponents',
                                 identifier=1234,
@@ -154,7 +154,7 @@ class FirewallTests(testing.TestCase):
         self.firewall.add_standard_firewall(6327, is_virt=True)
 
         self.assert_called_with('SoftLayer_Virtual_Guest', 'getObject',
-                                mask='primaryNetworkComponent[maxSpeed]',
+                                mask='mask[primaryNetworkComponent[maxSpeed]]',
                                 identifier=6327)
 
         _filter = {
@@ -195,7 +195,7 @@ class FirewallTests(testing.TestCase):
 
         # we should ask for the frontEndNetworkComponents to get
         # the firewall port speed
-        mask = 'id,maxSpeed,networkComponentGroup.networkComponents'
+        mask = 'mask[id,maxSpeed,networkComponentGroup.networkComponents]'
         self.assert_called_with('SoftLayer_Hardware_Server',
                                 'getFrontendNetworkComponents',
                                 mask=mask,

--- a/SoftLayer/tests/managers/loadbal_tests.py
+++ b/SoftLayer/tests/managers/loadbal_tests.py
@@ -87,7 +87,7 @@ class LoadBalancerTests(testing.TestCase):
         result = self.lb_mgr.get_local_lbs()
 
         self.assertEqual(len(result), 0)
-        mask = 'loadBalancerHardware[datacenter],ipAddress'
+        mask = 'mask[loadBalancerHardware[datacenter],ipAddress]'
         self.assert_called_with('SoftLayer_Account', 'getAdcLoadBalancers',
                                 mask=mask)
 
@@ -95,11 +95,12 @@ class LoadBalancerTests(testing.TestCase):
         result = self.lb_mgr.get_local_lb(22348)
 
         self.assertEqual(result['id'], 22348)
-        mask = ('loadBalancerHardware[datacenter], '
+        mask = ('mask['
+                'loadBalancerHardware[datacenter], '
                 'ipAddress, virtualServers[serviceGroups'
                 '[routingMethod,routingType,services'
                 '[healthChecks[type], groupReferences,'
-                ' ipAddress]]]')
+                ' ipAddress]]]]')
         self.assert_called_with(VIRT_IP_SERVICE, 'getObject',
                                 identifier=22348,
                                 mask=mask)
@@ -142,7 +143,7 @@ class LoadBalancerTests(testing.TestCase):
                 }
             }
         }
-        mask = 'serviceGroups[services[groupReferences,healthChecks]]'
+        mask = 'mask[serviceGroups[services[groupReferences,healthChecks]]]'
         self.assert_called_with(VIRT_IP_SERVICE, 'getVirtualServers',
                                 identifier=12345,
                                 filter=_filter,
@@ -153,7 +154,7 @@ class LoadBalancerTests(testing.TestCase):
     def test_add_service(self):
         self.lb_mgr.add_service(12345, 50718, 123, 80, True, 21, 1)
 
-        mask = 'virtualServers[serviceGroups[services[groupReferences]]]'
+        mask = 'mask[virtualServers[serviceGroups[services[groupReferences]]]]'
         self.assert_called_with(VIRT_IP_SERVICE, 'getObject',
                                 mask=mask,
                                 identifier=12345)
@@ -173,7 +174,7 @@ class LoadBalancerTests(testing.TestCase):
                                        routing_type=2,
                                        routing_method=10)
 
-        mask = 'virtualServers[serviceGroups[services[groupReferences]]]'
+        mask = 'mask[virtualServers[serviceGroups[services[groupReferences]]]]'
         self.assert_called_with(VIRT_IP_SERVICE, 'getObject',
                                 identifier=12345,
                                 mask=mask)
@@ -183,7 +184,7 @@ class LoadBalancerTests(testing.TestCase):
     def test_add_service_group(self):
         self.lb_mgr.add_service_group(12345, 100, 80, 2, 10)
 
-        mask = 'virtualServers[serviceGroups[services[groupReferences]]]'
+        mask = 'mask[virtualServers[serviceGroups[services[groupReferences]]]]'
         self.assert_called_with(VIRT_IP_SERVICE, 'getObject',
                                 mask=mask,
                                 identifier=12345)
@@ -201,7 +202,7 @@ class LoadBalancerTests(testing.TestCase):
         self.assert_called_with(VIRT_IP_SERVICE, 'getVirtualServers',
                                 identifier=12345,
                                 filter=_filter,
-                                mask='serviceGroups')
+                                mask='mask[serviceGroups]')
 
         service = ('SoftLayer_Network_Application_Delivery_Controller_'
                    'LoadBalancer_Service_Group')

--- a/SoftLayer/tests/managers/network_tests.py
+++ b/SoftLayer/tests/managers/network_tests.py
@@ -153,7 +153,7 @@ class NetworkTests(testing.TestCase):
 
         self.assertEqual(result,
                          fixtures.SoftLayer_Account.getGlobalIpRecords)
-        mask = 'destinationIpAddress[hardware, virtualGuest],ipAddress'
+        mask = 'mask[destinationIpAddress[hardware, virtualGuest],ipAddress]'
         self.assert_called_with('SoftLayer_Account', 'getGlobalIpRecords',
                                 mask=mask)
 
@@ -162,7 +162,7 @@ class NetworkTests(testing.TestCase):
 
         self.assertEqual(result,
                          fixtures.SoftLayer_Account.getGlobalIpRecords)
-        mask = 'destinationIpAddress[hardware, virtualGuest],ipAddress'
+        mask = 'mask[destinationIpAddress[hardware, virtualGuest],ipAddress]'
         _filter = {
             'globalIpRecords': {
                 'ipAddress': {
@@ -172,7 +172,7 @@ class NetworkTests(testing.TestCase):
                 }
             }
         }
-        mask = 'destinationIpAddress[hardware, virtualGuest],ipAddress'
+        mask = 'mask[destinationIpAddress[hardware, virtualGuest],ipAddress]'
         self.assert_called_with('SoftLayer_Account', 'getGlobalIpRecords',
                                 mask=mask,
                                 filter=_filter)
@@ -182,7 +182,7 @@ class NetworkTests(testing.TestCase):
 
         self.assertEqual(result, fixtures.SoftLayer_Account.getSubnets)
         _filter = {'subnets': {'subnetType': {'operation': '!= GLOBAL_IP'}}}
-        mask = 'hardware,datacenter,ipAddressCount,virtualGuests'
+        mask = 'mask[hardware,datacenter,ipAddressCount,virtualGuests]'
         self.assert_called_with('SoftLayer_Account', 'getSubnets',
                                 mask=mask,
                                 filter=_filter)
@@ -206,7 +206,7 @@ class NetworkTests(testing.TestCase):
                 'networkIdentifier': {'operation': '_= 10.0.0.1'}
             }
         }
-        mask = 'hardware,datacenter,ipAddressCount,virtualGuests'
+        mask = 'mask[hardware,datacenter,ipAddressCount,virtualGuests]'
         self.assert_called_with('SoftLayer_Account', 'getSubnets',
                                 mask=mask,
                                 filter=_filter)


### PR DESCRIPTION
This allows the bindings to be used without a special transport in order to run tests.

* Setting compression off would still send compression headers. That is now fixed.
* Fixes minor testing errors.