### PR TITLE
Fixes a failing CLI setup test.

### DIFF
--- a/SoftLayer/testing/__init__.py
+++ b/SoftLayer/testing/__init__.py
@@ -85,6 +85,8 @@ class TestCase(testtools.TestCase):
         """Stand up fixtured/mockable XML-RPC server."""
         cls.mocks = MockableTransport(SoftLayer.FixtureTransport())
         cls.server = xmlrpc.create_test_server(cls.mocks)
+        host, port = cls.server.socket.getsockname()[:2]
+        cls.endpoint_url = "http://%s:%s" % (host, port)
 
     @classmethod
     def tearDownClass(cls):
@@ -104,9 +106,7 @@ class TestCase(testtools.TestCase):
 
         self.mocks.clear()
 
-        host, port = self.server.socket.getsockname()[:2]
-        endpoint_url = "http://%s:%s" % (host, port)
-        transport = SoftLayer.XmlRpcTransport(endpoint_url=endpoint_url)
+        transport = SoftLayer.XmlRpcTransport(endpoint_url=self.endpoint_url)
         wrapped_transport = SoftLayer.TimingTransport(transport)
 
         self.client = SoftLayer.BaseClient(transport=wrapped_transport)

--- a/SoftLayer/tests/CLI/modules/config_tests.py
+++ b/SoftLayer/tests/CLI/modules/config_tests.py
@@ -41,6 +41,15 @@ class TestHelpShow(testing.TestCase):
 
 class TestHelpSetup(testing.TestCase):
 
+    def set_up(self):
+        super(TestHelpSetup, self).set_up()
+
+        # NOTE(kmcdonald): since the endpoint_url is changed with the client
+        # in these commands, we need to ensure that a fixtured transport is
+        # used.
+        transport = testing.MockableTransport(SoftLayer.FixtureTransport())
+        self.env.client = SoftLayer.BaseClient(transport=transport)
+
     @mock.patch('SoftLayer.CLI.formatting.confirm')
     @mock.patch('SoftLayer.CLI.environment.Environment.getpass')
     @mock.patch('SoftLayer.CLI.environment.Environment.input')


### PR DESCRIPTION
This test is failing because of two PRs interacting in unexpected ways.
One change changes the tests to use a real XML-RPC transport against a real HTTP
server which responds with stubbed data. The other change fixes a bug where the endpoint
being used to validate credentials was simply using the default.

Now, the tests be sure to use a stubbed transport so that changing the endpoint will not
cause `slcli setup` to use the default endpoint and make real API calls against it.