### PR TITLE
Switch capturing of CDROMs

### DIFF
--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -583,7 +583,7 @@ class VSManager(utils.IdentifierMixin, object):
         disk_filter = lambda x: x['device'] == '0'
         # Disk 1 is swap partition.  Need to skip its capture.
         if additional_disks:
-            disk_filter = lambda x: x['device'] != '1'
+            disk_filter = lambda x: x['device'] != '1' and x['mountType'] != 'CD'
 
         disks = [block_device for block_device in vsi['blockDevices']
                  if disk_filter(block_device)]


### PR DESCRIPTION
If images of Windows server are created the -all disks flag will lead to an error because CDROM can't be imaged. Added skip for mountType equals CD