### PR TITLE
Handle "empty" tag references

### DIFF
--- a/SoftLayer/CLI/server/detail.py
+++ b/SoftLayer/CLI/server/detail.py
@@ -96,8 +96,10 @@ def cli(env, identifier, passwords, price):
         table.add_row(['remote users', pass_table])
 
     tag_row = []
-    for tag in result['tagReferences']:
-        tag_row.append(tag['tag']['name'])
+    for tag_detail in result['tagReferences']:
+        tag = utils.lookup(tag_detail, 'tag', 'name')
+        if tag is not None:
+            tag_row.append(tag)
 
     if tag_row:
         table.add_row(['tags', formatting.listing(tag_row, separator=',')])

--- a/SoftLayer/CLI/virt/detail.py
+++ b/SoftLayer/CLI/virt/detail.py
@@ -93,8 +93,10 @@ def cli(self, identifier, passwords=False, price=False):
         table.add_row(['users', pass_table])
 
     tag_row = []
-    for tag in result['tagReferences']:
-        tag_row.append(tag['tag']['name'])
+    for tag_detail in result['tagReferences']:
+        tag = utils.lookup(tag_detail, 'tag', 'name')
+        if tag is not None:
+            tag_row.append(tag)
 
     if tag_row:
         table.add_row(['tags', formatting.listing(tag_row, separator=', ')])

--- a/SoftLayer/tests/CLI/modules/server_tests.py
+++ b/SoftLayer/tests/CLI/modules/server_tests.py
@@ -57,6 +57,25 @@ class ServerCLITests(testing.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(json.loads(result.output), expected)
 
+    def test_detail_vs_empty_tag(self):
+        mock = self.set_mock('SoftLayer_Hardware_Server', 'getObject')
+        mock.return_value = {
+            'id': 100,
+            'processorPhysicalCoreAmount': 2,
+            'memoryCapacity': 2,
+            'tagReferences': [
+                {'tag': {'name': 'example-tag'}},
+                {},
+            ],
+        }
+        result = self.run_command(['server', 'detail', '100'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            json.loads(result.output)['tags'],
+            ['example-tag'],
+        )
+
     def test_list_servers(self):
         result = self.run_command(['server', 'list', '--tag=openstack'])
 

--- a/SoftLayer/tests/CLI/modules/vs_tests.py
+++ b/SoftLayer/tests/CLI/modules/vs_tests.py
@@ -66,6 +66,25 @@ class DnsTests(testing.TestCase):
                                      'id': 1}],
                           'owner': 'chechu'})
 
+    def test_detail_vs_empty_tag(self):
+        mock = self.set_mock('SoftLayer_Virtual_Guest', 'getObject')
+        mock.return_value = {
+            'id': 100,
+            'maxCpu': 2,
+            'maxMemory': 1024,
+            'tagReferences': [
+                {'tag': {'name': 'example-tag'}},
+                {},
+            ],
+        }
+        result = self.run_command(['vs', 'detail', '100'])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(
+            json.loads(result.output)['tags'],
+            ['example-tag'],
+        )
+
     def test_create_options(self):
         result = self.run_command(['vs', 'create-options'])
 


### PR DESCRIPTION
There are apparently tag references which don't point to a valid tag.

Resolves #570