### PR TITLE
Don't clear tags when running `slcli vs edit`  without any `--tag` option

### DIFF
--- a/SoftLayer/CLI/virt/edit.py
+++ b/SoftLayer/CLI/virt/edit.py
@@ -39,7 +39,9 @@ def cli(env, identifier, domain, userfile, tag, hostname, userdata):
 
     data['hostname'] = hostname
     data['domain'] = domain
-    data['tags'] = ','.join(tag)
+
+    if tag:
+        data['tags'] = ','.join(tag)
 
     vsi = SoftLayer.VSManager(env.client)
     vs_id = helpers.resolve_id(vsi.resolve_ids, identifier, 'VS')


### PR DESCRIPTION
Running `slcli vs edit instance` without any option currently clears all tags, which is expected behavior according to the documentation. Only `slcli vs edit --tag '' instance` should clear the tags.