### PR TITLE
Remove Python 2.6 Testing. Add python 3.5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 matrix:
   include:
     - python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - python: "2.7"
       env: TOX_ENV=coverage
 install:
- - pip install tox --use-mirrors
+ - pip install tox
  - pip install coveralls
 script:
  - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
 language: python
-python: 2.7
-env:
-  - TOX_ENV=py27
-  - TOX_ENV=py33
-  - TOX_ENV=py34
-  - TOX_ENV=py35
-  - TOX_ENV=pypy
-  - TOX_ENV=analysis
-  - TOX_ENV=coverage
+matrix:
+  include:
+    - python: "2.7"
+      env: TOX_ENV=py27
+    - python: "3.3"
+      env: TOX_ENV=py33
+    - python: "3.4"
+      env: TOX_ENV=py34
+    - python: "nightly"
+      env: TOX_ENV=py35
+    - python: "pypy"
+      env: TOX_ENV=pypy
+    - python: "2.7"
+      env: TOX_ENV=analysis
+    - python: "2.7"
+      env: TOX_ENV=coverage
 install:
  - pip install tox --use-mirrors
  - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python: 2.7
 env:
-  - TOX_ENV=py26
   - TOX_ENV=py27
   - TOX_ENV=py33
   - TOX_ENV=py34
+  - TOX_ENV=py35
   - TOX_ENV=pypy
   - TOX_ENV=analysis
   - TOX_ENV=coverage

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ library.
 
 System Requirements
 -------------------
-* This library has been tested on Python 2.6, 2.7, 3.3 and 3.4.
+* This library has been tested on Python 2.7, 3.3 and 3.4.
 * A valid SoftLayer API username and key are required to call SoftLayer's API.
 * A connection to SoftLayer's private network is required to connect to
   SoftLayer’s private network API endpoints.

--- a/SoftLayer/tests/CLI/helper_tests.py
+++ b/SoftLayer/tests/CLI/helper_tests.py
@@ -7,7 +7,7 @@
 """
 import json
 import os
-import sys
+import tempfile
 
 import mock
 
@@ -16,11 +16,6 @@ from SoftLayer.CLI import formatting
 from SoftLayer.CLI import helpers
 from SoftLayer.CLI import template
 from SoftLayer import testing
-
-if sys.version_info >= (3,):
-    open_path = 'builtins.open'
-else:
-    open_path = '__builtin__.open'
 
 
 class CLIJSONEncoderTest(testing.TestCase):
@@ -403,8 +398,9 @@ class TestTemplateArgs(testing.TestCase):
 
 class TestExportToTemplate(testing.TestCase):
     def test_export_to_template(self):
-        with mock.patch(open_path, mock.mock_open(), create=True) as open_:
-            template.export_to_template('filename', {
+        with tempfile.NamedTemporaryFile() as tmp:
+
+            template.export_to_template(tmp.name, {
                 'os': None,
                 'datacenter': 'ams01',
                 'disk': ('disk1', 'disk2'),
@@ -417,8 +413,9 @@ class TestExportToTemplate(testing.TestCase):
                 'test': 'test',
             }, exclude=['test'])
 
-            open_.assert_called_with('filename', 'w')
-            open_().write.assert_has_calls([
-                mock.call('datacenter=ams01\n'),
-                mock.call('disk=disk1,disk2\n'),
-            ], any_order=True)  # Order isn't really guaranteed
+            with open(tmp.name) as f:
+                data = f.read()
+
+                self.assertEquals(len(data.splitlines()), 2)
+                self.assertIn('datacenter=ams01\n', data)
+                self.assertIn('disk=disk1,disk2\n', data)

--- a/SoftLayer/tests/CLI/helper_tests.py
+++ b/SoftLayer/tests/CLI/helper_tests.py
@@ -416,6 +416,6 @@ class TestExportToTemplate(testing.TestCase):
             with open(tmp.name) as f:
                 data = f.read()
 
-                self.assertEquals(len(data.splitlines()), 2)
+                self.assertEqual(len(data.splitlines()), 2)
                 self.assertIn('datacenter=ams01\n', data)
                 self.assertIn('disk=disk1,disk2\n', data)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,pypy,analysis,coverage
+envlist = py27,py33,py34,py35,pypy,analysis,coverage
 
 [testenv]
 setenv =


### PR DESCRIPTION
Mock, the mocking library that is used to test with has stopped support python 2.6. This is now causing travis-ci builds to fail. This change removes python 2.6 from tox and adds python 3.5 since travis-ci now supports testing the beta version of python 3.5.