### PR TITLE
Better comforms to click.MultiCommand.get_command

### DIFF
--- a/SoftLayer/CLI/environment.py
+++ b/SoftLayer/CLI/environment.py
@@ -7,7 +7,6 @@
 """
 import importlib
 
-from SoftLayer.CLI import exceptions
 from SoftLayer.CLI import formatting
 from SoftLayer.CLI import routes
 
@@ -68,7 +67,7 @@ class Environment(object):
                     len(path) == command.count(":")]):
 
                 # offset is used to exclude the path that the caller requested.
-                offset = len(path_str)+1 if path_str else 0
+                offset = len(path_str) + 1 if path_str else 0
                 commands.append(command[offset:])
 
         return sorted(commands)
@@ -80,7 +79,7 @@ class Environment(object):
         if path_str in self.commands:
             return self.commands[path_str].load()
 
-        raise exceptions.InvalidCommand(path)
+        return None
 
     def resolve_alias(self, path_str):
         """Returns the actual command name. Uses the alias mapping."""

--- a/SoftLayer/CLI/exceptions.py
+++ b/SoftLayer/CLI/exceptions.py
@@ -6,8 +6,6 @@
     :license: MIT, see LICENSE for more details.
 """
 
-import SoftLayer
-
 
 class CLIHalt(SystemExit):
     """Smoothly halt the execution of the command. No error."""
@@ -34,10 +32,3 @@ class ArgumentError(CLIAbort):
     def __init__(self, msg, *args):
         super(ArgumentError, self).__init__(msg, *args)
         self.message = "Argument Error: %s" % msg
-
-
-class InvalidCommand(SoftLayer.SoftLayerError):
-    """Raised when trying to use a command that does not exist."""
-    def __init__(self, path, *args):
-        msg = 'Invalid command: "%s"' % ' '.join(path)
-        SoftLayer.SoftLayerError.__init__(self, msg, *args)

--- a/SoftLayer/tests/CLI/environment_tests.py
+++ b/SoftLayer/tests/CLI/environment_tests.py
@@ -9,7 +9,6 @@ import click
 import mock
 
 from SoftLayer.CLI import environment
-from SoftLayer.CLI import exceptions
 from SoftLayer import testing
 
 
@@ -30,8 +29,8 @@ class EnvironmentTests(testing.TestCase):
         self.assertIn('dns', actions)
 
     def test_get_command_invalid(self):
-        self.assertRaises(exceptions.InvalidCommand,
-                          self.env.get_command, 'invalid', 'command')
+        cmd = self.env.get_command('invalid', 'command')
+        self.assertEqual(cmd, None)
 
     def test_get_command(self):
         mod_path = 'SoftLayer.tests.CLI.environment_tests'


### PR DESCRIPTION
Usually click.MultiCommand.get_command will return None when the command is not found. In slcli, this is handled by raising an exception. Since click handles this condition for us, there's no reason it should be done here.

Removes SoftLayer.CLI.InvalidCommand and its single reference