### PR TITLE
Re-enables the use of custom headers on a per-API-call basis

### DIFF
--- a/SoftLayer/API.py
+++ b/SoftLayer/API.py
@@ -223,6 +223,7 @@ class BaseClient(object):
 
             request = self.auth.get_request(request)
 
+        request.headers.update(kwargs.get('headers', {}))
         return self.transport(request)
 
     __call__ = call

--- a/SoftLayer/testing/xmlrpc.py
+++ b/SoftLayer/testing/xmlrpc.py
@@ -49,6 +49,7 @@ class TestHandler(six.moves.BaseHTTPServer.BaseHTTPRequestHandler):
                                                   'InitParameters').get('id')
             req.transport_headers = dict(((k.lower(), v)
                                           for k, v in self.headers.items()))
+            req.headers = headers
 
             # Get response
             response = self.server.transport(req)

--- a/SoftLayer/tests/api_tests.py
+++ b/SoftLayer/tests/api_tests.py
@@ -89,9 +89,11 @@ class APIClient(testing.TestCase):
             1234,
             id=5678,
             mask={'object': {'attribute': ''}},
+            headers={'header': 'value'},
             raw_headers={'RAW': 'HEADER'},
             filter=_filter,
-            limit=9, offset=10)
+            limit=9,
+            offset=10)
 
         self.assertEqual(resp, {"test": "result"})
         self.assert_called_with('SoftLayer_SERVICE', 'METHOD',
@@ -102,6 +104,10 @@ class APIClient(testing.TestCase):
                                 limit=9,
                                 offset=10,
                                 )
+        calls = self.calls('SoftLayer_SERVICE', 'METHOD')
+        self.assertEqual(len(calls), 1)
+        self.assertIn('header', calls[0].headers)
+        self.assertEqual(calls[0].headers['header'], 'value')
 
     @mock.patch('SoftLayer.API.BaseClient.iter_call')
     def test_iterate(self, _iter_call):


### PR DESCRIPTION
This was unintentionally removed some time in the past