### PR TITLE
Changes VSManager.wait_for_ready() to behave more intuitively

### DIFF
--- a/SoftLayer/CLI/virt/create.py
+++ b/SoftLayer/CLI/virt/create.py
@@ -270,9 +270,11 @@ def cli(env, **args):
         output.append(table)
 
         if args.get('wait'):
-            ready = vsi.wait_for_ready(
-                result['id'], int(args.get('wait') or 1))
+            ready = vsi.wait_for_ready(result['id'], args.get('wait') or 1)
             table.add_row(['ready', ready])
+            if ready is False:
+                env.out(env.fmt(output))
+                raise exceptions.CLIHalt(code=1)
 
     env.fout(output)
 

--- a/SoftLayer/tests/managers/vs_tests.py
+++ b/SoftLayer/tests/managers/vs_tests.py
@@ -688,7 +688,7 @@ class VSWaitReadyGoTests(testing.TestCase):
         self.guestObject.side_effect = [
             {'activeTransaction': {'id': 1}},
         ]
-        value = self.vs.wait_for_ready(1, 1)
+        value = self.vs.wait_for_ready(1, 0)
         self.assertFalse(value)
 
     def test_active_and_provisiondate(self):
@@ -704,10 +704,9 @@ class VSWaitReadyGoTests(testing.TestCase):
         # active transaction and provision date
         # and pending should be false
         self.guestObject.side_effect = [
-            {'activeTransaction': {'id': 1},
-             'provisionDate': 'aaa'},
+            {'activeTransaction': {'id': 1}, 'provisionDate': 'aaa'},
         ]
-        value = self.vs.wait_for_ready(1, 1, pending=True)
+        value = self.vs.wait_for_ready(1, 0, pending=True)
         self.assertFalse(value)
 
     def test_active_reload(self):
@@ -719,7 +718,7 @@ class VSWaitReadyGoTests(testing.TestCase):
                 'lastOperatingSystemReload': {'id': 1},
             },
         ]
-        value = self.vs.wait_for_ready(1, 1)
+        value = self.vs.wait_for_ready(1, 0)
         self.assertFalse(value)
 
     def test_reload_no_pending(self):
@@ -743,7 +742,7 @@ class VSWaitReadyGoTests(testing.TestCase):
                 'lastOperatingSystemReload': {'id': 1},
             },
         ]
-        value = self.vs.wait_for_ready(1, 1, pending=True)
+        value = self.vs.wait_for_ready(1, 0, pending=True)
         self.assertFalse(value)
 
     @mock.patch('time.sleep')
@@ -754,7 +753,7 @@ class VSWaitReadyGoTests(testing.TestCase):
         self.guestObject.side_effect = [
             {'activeTransaction': {'id': 1}},
         ]
-        value = self.vs.wait_for_ready(1, 1)
+        value = self.vs.wait_for_ready(1, 0)
         self.assertFalse(value)
         self.assertFalse(_sleep.called)
 
@@ -786,49 +785,32 @@ class VSWaitReadyGoTests(testing.TestCase):
             mock.call(id=1, mask=mock.ANY), mock.call(id=1, mask=mock.ANY),
         ])
 
+    @mock.patch('time.time')
     @mock.patch('time.sleep')
-    def test_iter_two_incomplete(self, _sleep):
+    def test_iter_two_incomplete(self, _sleep, _time):
         # test 2 iterations, with no matches
         self.guestObject.side_effect = [
             {'activeTransaction': {'id': 1}},
             {'activeTransaction': {'id': 1}},
             {'provisionDate': 'aaa'}
         ]
+        _time.side_effect = [0, 1, 2]
         value = self.vs.wait_for_ready(1, 2)
         self.assertFalse(value)
         _sleep.assert_called_once_with(1)
         self.guestObject.assert_has_calls([
-            mock.call(id=1, mask=mock.ANY), mock.call(id=1, mask=mock.ANY),
+            mock.call(id=1, mask=mock.ANY),
+            mock.call(id=1, mask=mock.ANY),
         ])
 
+    @mock.patch('time.time')
     @mock.patch('time.sleep')
-    def test_iter_ten_incomplete(self, _sleep):
-        # 10 iterations at 10 second sleeps with no
-        # matching values.
-        self.guestObject.side_effect = [
-            {},
-            {'activeTransaction': {'id': 1}},
-            {'activeTransaction': {'id': 1}},
-            {'activeTransaction': {'id': 1}},
-            {'activeTransaction': {'id': 1}},
-            {'activeTransaction': {'id': 1}},
-            {'activeTransaction': {'id': 1}},
-            {'activeTransaction': {'id': 1}},
-            {'activeTransaction': {'id': 1}},
-            {'activeTransaction': {'id': 1}},
-        ]
-        value = self.vs.wait_for_ready(1, 10, delay=10)
+    def test_iter_20_incomplete(self, _sleep, _time):
+        """Wait for up to 20 seconds (sleeping for 10 seconds) for a server."""
+        self.guestObject.return_value = {'activeTransaction': {'id': 1}}
+        _time.side_effect = [0, 10, 20]
+        value = self.vs.wait_for_ready(1, 20, delay=10)
         self.assertFalse(value)
-        self.guestObject.assert_has_calls([
-            mock.call(id=1, mask=mock.ANY), mock.call(id=1, mask=mock.ANY),
-            mock.call(id=1, mask=mock.ANY), mock.call(id=1, mask=mock.ANY),
-            mock.call(id=1, mask=mock.ANY), mock.call(id=1, mask=mock.ANY),
-            mock.call(id=1, mask=mock.ANY), mock.call(id=1, mask=mock.ANY),
-            mock.call(id=1, mask=mock.ANY), mock.call(id=1, mask=mock.ANY),
-        ])
-        # should only be 9 calls to sleep, last iteration
-        # should return a value and skip the sleep
-        _sleep.assert_has_calls([
-            mock.call(10), mock.call(10), mock.call(10), mock.call(10),
-            mock.call(10), mock.call(10), mock.call(10), mock.call(10),
-            mock.call(10)])
+        self.guestObject.assert_has_calls([mock.call(id=1, mask=mock.ANY)])
+
+        _sleep.assert_has_calls([mock.call(10)])


### PR DESCRIPTION
 * when calling wait_for_ready() it will wait until the given time period and no more (except maybe with the additionally time of an API call)
 * changes `slcli vs create` with the --wait option to give a non-zero exit code if the provision isn't finished in the specified time.
 * Uses a mask to only pull in the relevant information

Resolves #587 