### PR TITLE
Fix for issue#582. 

### DIFF
--- a/SoftLayer/CLI/server/create.py
+++ b/SoftLayer/CLI/server/create.py
@@ -42,14 +42,9 @@ import click
 @click.option('--postinstall', '-i', help="Post-install script to download")
 @helpers.multi_option('--key', '-k',
                       help="SSH keys to add to the root user")
-@click.option('--vlan-public',
-              help="The ID of the public VLAN on which you want the virtual "
-              "server placed",
-              type=click.INT)
-@click.option('--vlan-private',
-              help="The ID of the private VLAN on which you want the virtual "
-                   "server placed",
-              type=click.INT)
+@click.option('--no_public',
+              is_flag=True,
+              help="Private network only")
 @helpers.multi_option('--extra', '-e', help="Extra options")
 @click.option('--test',
               is_flag=True,

--- a/SoftLayer/tests/CLI/modules/server_tests.py
+++ b/SoftLayer/tests/CLI/modules/server_tests.py
@@ -257,8 +257,6 @@ class ServerCLITests(testing.TestCase):
                                    '--datacenter=TEST00',
                                    '--port-speed=100',
                                    '--os=UBUNTU_12_64',
-                                   '--vlan-public=10234',
-                                   '--vlan-private=20468',
                                    '--test'],
                                   fmt='raw')
 
@@ -296,8 +294,6 @@ class ServerCLITests(testing.TestCase):
                                    '--datacenter=TEST00',
                                    '--port-speed=100',
                                    '--os=UBUNTU_12_64',
-                                   '--vlan-public=10234',
-                                   '--vlan-private=20468',
                                    '--key=10',
                                    ])
 
@@ -329,8 +325,6 @@ class ServerCLITests(testing.TestCase):
                                    '--datacenter=TEST00',
                                    '--port-speed=100',
                                    '--os=UBUNTU_12_64',
-                                   '--vlan-public=10234',
-                                   '--vlan-private=20468',
                                    '--export=/path/to/test_file.txt'],
                                   fmt='raw')
 
@@ -349,8 +343,6 @@ class ServerCLITests(testing.TestCase):
                                         'postinstall': None,
                                         'size': 'S1270_8GB_2X1TBSATA_NORAID',
                                         'test': False,
-                                        'vlan_private': 20468,
-                                        'vlan_public': 10234,
                                         'wait': None,
                                         'template': None},
                                        exclude=['wait', 'test'])


### PR DESCRIPTION
Fixed slcli server create options: added no_public option to allow ordering servers with private only uplink, removed --vlan-public, --vlan-private options which are not applicable for the standard configuration bare metal servers. 