### PR TITLE
MemoryType returns gigabytes instead of megabytes.

### DIFF
--- a/SoftLayer/CLI/virt/__init__.py
+++ b/SoftLayer/CLI/virt/__init__.py
@@ -13,7 +13,7 @@ class MemoryType(click.ParamType):
     name = 'integer'
 
     def convert(self, value, param, ctx):
-        """Validate memory argument. Returns the memory value in megabytes."""
+        """Validate memory argument. Returns the memory value in gigabytes."""
         matches = MEMORY_RE.match(value.lower())
         if matches is None:
             self.fail('%s is not a valid value for memory amount'
@@ -23,13 +23,13 @@ class MemoryType(click.ParamType):
         if unit in [None, 'm', 'mb']:
             # Assume the user intends gigabytes if they specify a number < 1024
             if amount < 1024:
-                return amount * 1024
+                return amount
             else:
                 if amount % 1024 != 0:
                     self.fail('%s is not an integer that is divisable by 1024'
                               % value, param, ctx)
-                return amount
+                return amount / 1024
         elif unit in ['g', 'gb']:
-            return amount * 1024
+            return amount
 
 MEM_TYPE = MemoryType()


### PR DESCRIPTION
This aims to address issue #620, where requests to upgrade the memory of a virtual server fails.

I've updated MemoryType to return gigabytes instead of megabytes. The user may still specify either megabytes or gigabytes on the command line, and the type should properly convert it to gigabytes.

This works fine in my brief testing, but I'd certainly appreciate another set of eyes on this to make sure I'm not overlooking something.