### PR TITLE
VS upgrade should use gb not mb for memory.

### DIFF
--- a/SoftLayer/CLI/virt/upgrade.py
+++ b/SoftLayer/CLI/virt/upgrade.py
@@ -35,7 +35,7 @@ def cli(env, identifier, cpu, private, memory, network):
 
     if not vsi.upgrade(vs_id,
                        cpus=cpu,
-                       memory=memory,
+                       memory=memory/1024,
                        nic_speed=network,
                        public=not private):
         raise exceptions.CLIAbort('VS Upgrade Failed')


### PR DESCRIPTION
This aims to address issue #620, where requests to upgrade the memory of a virtual server fails.

It seems that the CLI ensures that the memory is defined in megabytes, but the manager expects memory to be defined in gigabytes.