### PR TITLE
Improve rest support, add total items to list results

### DIFF
--- a/SoftLayer/API.py
+++ b/SoftLayer/API.py
@@ -95,11 +95,21 @@ def create_client_from_env(username=None,
 
     # If we have enough information to make an auth driver, let's do it
     if auth is None and settings.get('username') and settings.get('api_key'):
+        # NOTE(kmcdonald): some transports mask other transports, so this is
+        # a way to find the 'real' one
+        real_transport = getattr(transport, 'transport', transport)
 
-        auth = slauth.BasicAuthentication(
-            settings.get('username'),
-            settings.get('api_key'),
-        )
+        if isinstance(real_transport, transports.XmlRpcTransport):
+            auth = slauth.BasicAuthentication(
+                settings.get('username'),
+                settings.get('api_key'),
+            )
+
+        elif isinstance(real_transport, transports.RestTransport):
+            auth = slauth.BasicHTTPAuthentication(
+                settings.get('username'),
+                settings.get('api_key'),
+            )
 
     return BaseClient(auth=auth, transport=transport)
 

--- a/SoftLayer/CLI/core.py
+++ b/SoftLayer/CLI/core.py
@@ -141,6 +141,7 @@ def cli(env,
         else:
             # Create SL Client
             client = SoftLayer.create_client_from_env(
+                transport=SoftLayer.RestTransport(),
                 proxy=proxy,
                 config_file=config,
             )

--- a/SoftLayer/CLI/core.py
+++ b/SoftLayer/CLI/core.py
@@ -141,7 +141,6 @@ def cli(env,
         else:
             # Create SL Client
             client = SoftLayer.create_client_from_env(
-                transport=SoftLayer.RestTransport(),
                 proxy=proxy,
                 config_file=config,
             )

--- a/SoftLayer/config.py
+++ b/SoftLayer/config.py
@@ -19,6 +19,7 @@ def get_client_settings_args(**kwargs):
     timeout = kwargs.get('timeout')
     if timeout is not None:
         timeout = float(timeout)
+
     return {
         'endpoint_url': kwargs.get('endpoint_url'),
         'timeout': timeout,

--- a/SoftLayer/managers/load_balancer.py
+++ b/SoftLayer/managers/load_balancer.py
@@ -204,7 +204,7 @@ class LoadBalancerManager(utils.IdentifierMixin, object):
                 if ip_address_id is not None:
                     service['ipAddressId'] = ip_address_id
 
-        template = {'virtualServers': virtual_servers}
+        template = {'virtualServers': list(virtual_servers)}
 
         load_balancer = self.lb_svc.editObject(template, id=loadbal_id)
         return load_balancer

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -75,12 +75,12 @@ versions every time you push new code.
 
 Using tox to running the tests in multiple environments can be very time
 consuming. If you wish to quickly run the tests in your own environment, you
-may do so using `nose <https://nose.readthedocs.org>`_.  The command to do that
+may do so using `py.test <http://pytest.org/>`_.  The command to do that
 is:
 
 ::
 
-  nosetests
+  py.test tests
 
 
 Documentation

--- a/tests/transport_tests.py
+++ b/tests/transport_tests.py
@@ -372,12 +372,83 @@ class TestRestAPICall(testing.TestCase):
 
         self.assertEqual(resp, {})
         request.assert_called_with(
-            'GET',
-            'http://something.com/SoftLayer_Service/getObject/test/1.json',
+            'POST',
+            'http://something.com/SoftLayer_Service/getObject.json',
             headers=mock.ANY,
             auth=None,
-            data='{"parameters": "[\\"test\\", 1]"}',
+            data='{"parameters": ["test", 1]}',
             params={},
+            verify=True,
+            cert=None,
+            proxies=None,
+            timeout=None)
+
+
+    @mock.patch('requests.request')
+    def test_with_filter(self, request):
+        request().content = '{}'
+
+        req = transports.Request()
+        req.service = 'SoftLayer_Service'
+        req.method = 'getObject'
+        req.filter = {'TYPE': {'attribute': {'operation': '^= prefix'}}}
+
+        resp = self.transport(req)
+
+        self.assertEqual(resp, {})
+        request.assert_called_with(
+            'GET',
+            'http://something.com/SoftLayer_Service/getObject.json',
+            params={'objectFilter':
+                    '{"TYPE": {"attribute": {"operation": "^= prefix"}}}'},
+            headers=mock.ANY,
+            auth=None,
+            data=None,
+            verify=True,
+            cert=None,
+            proxies=None,
+            timeout=None)
+
+    @mock.patch('requests.request')
+    def test_with_mask(self, request):
+        request().content = '{}'
+
+        req = transports.Request()
+        req.service = 'SoftLayer_Service'
+        req.method = 'getObject'
+        req.mask = 'id,property'
+
+        resp = self.transport(req)
+
+        self.assertEqual(resp, {})
+        request.assert_called_with(
+            'GET',
+            'http://something.com/SoftLayer_Service/getObject.json',
+            params={'objectMask': 'mask[id,property]'},
+            headers=mock.ANY,
+            auth=None,
+            data=None,
+            verify=True,
+            cert=None,
+            proxies=None,
+            timeout=None)
+
+        # Now test with mask[] prefix
+        req = transports.Request()
+        req.service = 'SoftLayer_Service'
+        req.method = 'getObject'
+        req.mask = 'mask[id,property]'
+
+        resp = self.transport(req)
+
+        self.assertEqual(resp, {})
+        request.assert_called_with(
+            'GET',
+            'http://something.com/SoftLayer_Service/getObject.json',
+            params={'objectMask': 'mask[id,property]'},
+            headers=mock.ANY,
+            auth=None,
+            data=None,
             verify=True,
             cert=None,
             proxies=None,

--- a/tests/transport_tests.py
+++ b/tests/transport_tests.py
@@ -4,10 +4,12 @@
 
     :license: MIT, see LICENSE for more details.
 """
+import io
 import warnings
 
 import mock
 import requests
+import six
 
 import SoftLayer
 from SoftLayer import consts
@@ -21,8 +23,8 @@ class TestXmlRpcAPICall(testing.TestCase):
         self.transport = transports.XmlRpcTransport(
             endpoint_url='http://something.com',
         )
-        self.response = mock.MagicMock()
-        self.response.content = '''<?xml version="1.0" encoding="utf-8"?>
+        self.response = requests.Response()
+        list_body = six.b('''<?xml version="1.0" encoding="utf-8"?>
 <params>
 <param>
  <value>
@@ -31,7 +33,10 @@ class TestXmlRpcAPICall(testing.TestCase):
   </array>
  </value>
 </param>
-</params>'''
+</params>''')
+        self.response.raw = io.BytesIO(list_body)
+        self.response.headers['SoftLayer-Total-Items'] = 10
+        self.response.status_code = 200
 
     @mock.patch('requests.request')
     def test_call(self, request):
@@ -69,6 +74,8 @@ class TestXmlRpcAPICall(testing.TestCase):
                                    cert=None,
                                    verify=True)
         self.assertEqual(resp, [])
+        self.assertIsInstance(resp, transports.SoftLayerListResult)
+        self.assertEqual(resp.total_count, 10)
 
     def test_proxy_without_protocol(self):
         req = transports.Request()
@@ -253,21 +260,32 @@ class TestRestAPICall(testing.TestCase):
 
     @mock.patch('requests.request')
     def test_basic(self, request):
-        request().content = '{}'
+        request().content = '[]'
+        request().headers = requests.structures.CaseInsensitiveDict({
+            'SoftLayer-Total-Items': '10',
+        })
+
         req = transports.Request()
         req.service = 'SoftLayer_Service'
         req.method = 'Resource'
-
         resp = self.transport(req)
-        self.assertEqual(resp, {})
+
+        self.assertEqual(resp, [])
+        self.assertIsInstance(resp, transports.SoftLayerListResult)
+        self.assertEqual(resp.total_count, 10)
         request.assert_called_with(
             'GET', 'http://something.com/SoftLayer_Service/Resource.json',
             headers=mock.ANY,
+            auth=None,
+            data=None,
+            params={},
             verify=True,
             cert=None,
             proxies=None,
             timeout=None)
 
+    @mock.patch('requests.request')
+    def test_error(self, request):
         # Test JSON Error
         e = requests.HTTPError('error')
         e.response = mock.MagicMock()
@@ -278,6 +296,9 @@ class TestRestAPICall(testing.TestCase):
         }'''
         request().raise_for_status.side_effect = e
 
+        req = transports.Request()
+        req.service = 'SoftLayer_Service'
+        req.method = 'Resource'
         self.assertRaises(SoftLayer.SoftLayerAPIError, self.transport, req)
 
     def test_proxy_without_protocol(self):
@@ -306,6 +327,9 @@ class TestRestAPICall(testing.TestCase):
             'GET', 'http://something.com/SoftLayer_Service/Resource.json',
             proxies={'https': 'http://localhost:3128',
                      'http': 'http://localhost:3128'},
+            auth=None,
+            data=None,
+            params={},
             verify=True,
             cert=None,
             timeout=mock.ANY,
@@ -327,6 +351,9 @@ class TestRestAPICall(testing.TestCase):
             'GET',
             'http://something.com/SoftLayer_Service/2/getObject.json',
             headers=mock.ANY,
+            auth=None,
+            data=None,
+            params={},
             verify=True,
             cert=None,
             proxies=None,
@@ -348,6 +375,9 @@ class TestRestAPICall(testing.TestCase):
             'GET',
             'http://something.com/SoftLayer_Service/getObject/test/1.json',
             headers=mock.ANY,
+            auth=None,
+            data='{"parameters": "[\\"test\\", 1]"}',
+            params={},
             verify=True,
             cert=None,
             proxies=None,


### PR DESCRIPTION
* Resolves #638 - Lists now return from the client as SoftLayerListResult objects, which should behave like lists except for the fact that there is now a `total_count` attribute available which can tell you how many total items exist which satisfy your list query.
* Resolves #639 - Adds masks, filters, limit, offset, and complex parameters to the REST transport
* Fixes minor documentation issues
* Fixes issue when using the latest version of tox
