### PR TITLE
Improve summary information

### DIFF
--- a/SoftLayer/CLI/summary.py
+++ b/SoftLayer/CLI/summary.py
@@ -13,12 +13,11 @@ import click
               help='Column to sort by',
               default='datacenter',
               type=click.Choice(['datacenter',
+                                 'hardware',
+                                 'virtual_servers',
                                  'vlans',
                                  'subnets',
-                                 'ips',
-                                 'networking',
-                                 'hardware',
-                                 'vs']))
+                                 'public_ips']))
 @environment.pass_env
 def cli(env, sortby):
     """Account summary."""
@@ -27,19 +26,23 @@ def cli(env, sortby):
     datacenters = mgr.summary_by_datacenter()
 
     table = formatting.Table([
-        'datacenter', 'vlans', 'subnets', 'ips', 'networking', 'hardware', 'vs'
+        'datacenter',
+        'hardware',
+        'virtual_servers',
+        'vlans',
+        'subnets',
+        'public_ips',
     ])
     table.sortby = sortby
 
     for name, datacenter in datacenters.items():
         table.add_row([
             name,
-            datacenter['vlanCount'],
-            datacenter['subnetCount'],
-            datacenter['primaryIpCount'],
-            datacenter['networkingCount'],
-            datacenter['hardwareCount'],
-            datacenter['virtualGuestCount'],
+            datacenter['hardware_count'],
+            datacenter['virtual_guest_count'],
+            datacenter['vlan_count'],
+            datacenter['subnet_count'],
+            datacenter['public_ip_count'],
         ])
 
     env.fout(table)

--- a/SoftLayer/managers/network.py
+++ b/SoftLayer/managers/network.py
@@ -5,6 +5,7 @@
 
     :license: MIT, see LICENSE for more details.
 """
+import collections
 
 from SoftLayer import exceptions
 from SoftLayer import utils
@@ -13,14 +14,14 @@ DEFAULT_SUBNET_MASK = ','.join(['hardware',
                                 'datacenter',
                                 'ipAddressCount',
                                 'virtualGuests'])
-DEFAULT_VLAN_MASK = ','.join(['firewallInterfaces',
-                              'hardware',
-                              'networkComponents',
-                              'primaryRouter'  # Lack of comma intential
-                              '[id, fullyQualifiedDomainName, datacenter]',
-                              'subnets',
-                              'totalPrimaryIpAddressCount',
-                              'virtualGuests'])
+DEFAULT_VLAN_MASK = ','.join([
+    'firewallInterfaces',
+    'hardware',
+    'primaryRouter[id, fullyQualifiedDomainName, datacenter]',
+    'subnets',
+    'totalPrimaryIpAddressCount',
+    'virtualGuests',
+])
 
 
 class NetworkManager(object):
@@ -333,45 +334,35 @@ class NetworkManager(object):
                   other objects residing within that data center.
 
         """
-        datacenters = {}
-        unique_vms = []
-        unique_servers = []
-        unique_network = []
+        datacenters = collections.defaultdict(lambda: {
+            'hardware_count': 0,
+            'public_ip_count': 0,
+            'subnet_count': 0,
+            'virtual_guest_count': 0,
+            'vlan_count': 0,
+        })
+        unique_vms = set()
+        unique_servers = set()
 
         for vlan in self.list_vlans():
             name = utils.lookup(vlan, 'primaryRouter', 'datacenter', 'name')
-            if name not in datacenters:
-                datacenters[name] = {
-                    'hardwareCount': 0,
-                    'networkingCount': 0,
-                    'primaryIpCount': 0,
-                    'subnetCount': 0,
-                    'virtualGuestCount': 0,
-                    'vlanCount': 0,
-                }
 
-            datacenters[name]['vlanCount'] += 1
+            datacenters[name]['vlan_count'] += 1
+            datacenters[name]['public_ip_count'] += (
+                vlan['totalPrimaryIpAddressCount'])
+            datacenters[name]['vlan_count'] += len(vlan['subnets'])
 
             for hardware in vlan['hardware']:
                 if hardware['id'] not in unique_servers:
-                    datacenters[name]['hardwareCount'] += 1
-                    unique_servers.append(hardware['id'])
-
-            for net in vlan['networkComponents']:
-                if net['id'] not in unique_network:
-                    datacenters[name]['networkingCount'] += 1
-                    unique_network.append(net['id'])
+                    datacenters[name]['hardware_count'] += 1
+                    unique_servers.add(hardware['id'])
 
             for virtual_guest in vlan['virtualGuests']:
                 if virtual_guest['id'] not in unique_vms:
-                    datacenters[name]['virtualGuestCount'] += 1
-                    unique_vms.append(virtual_guest['id'])
+                    datacenters[name]['virtual_guest_count'] += 1
+                    unique_vms.add(virtual_guest['id'])
 
-            datacenters[name]['primaryIpCount'] += (
-                vlan['totalPrimaryIpAddressCount'])
-            datacenters[name]['subnetCount'] += len(vlan['subnets'])
-
-        return datacenters
+        return dict(datacenters)
 
     def unassign_global_ip(self, global_ip_id):
         """Unassigns a global IP address from a target.

--- a/tests/CLI/modules/summary_tests.py
+++ b/tests/CLI/modules/summary_tests.py
@@ -17,11 +17,10 @@ class SummaryTests(testing.TestCase):
         expected = [
             {
                 'datacenter': 'dal00',
-                'networking': 1,
                 'subnets': 0,
                 'hardware': 1,
-                'ips': 6,
-                'vs': 1,
+                'public_ips': 6,
+                'virtual_servers': 1,
                 'vlans': 3
             }
         ]

--- a/tests/managers/network_tests.py
+++ b/tests/managers/network_tests.py
@@ -241,12 +241,11 @@ class NetworkTests(testing.TestCase):
     def test_summary_by_datacenter(self):
         result = self.network.summary_by_datacenter()
 
-        expected = {'dal00': {'hardwareCount': 1,
-                              'networkingCount': 1,
-                              'virtualGuestCount': 1,
-                              'subnetCount': 0,
-                              'primaryIpCount': 6,
-                              'vlanCount': 3}}
+        expected = {'dal00': {'hardware_count': 1,
+                              'virtual_guest_count': 1,
+                              'subnet_count': 0,
+                              'public_ip_count': 6,
+                              'vlan_count': 3}}
         self.assertEqual(expected, result)
 
     def test_resolve_global_ip_ids(self):


### PR DESCRIPTION
 * Removes ambiguous 'networking' count
 * Uses more idiomatic underscores in the dictionary returned instead of camel case
 * Uses defaultdict to make the code a bit cleaner
 * Renames 'vs' to 'virtual_server' and 'ips' to 'public_ips'
 * Orders the columns differently

Resolves issue #642.