### PR TITLE
Improves Virtual Reload

### DIFF
--- a/SoftLayer/CLI/image/list.py
+++ b/SoftLayer/CLI/image/list.py
@@ -24,11 +24,13 @@ def cli(env, name, public):
 
     images = []
     if public in [False, None]:
-        for image in image_mgr.list_private_images(name=name, mask=image_mod.MASK):
+        for image in image_mgr.list_private_images(name=name,
+                                                   mask=image_mod.MASK):
             images.append(image)
 
     if public in [True, None]:
-        for image in image_mgr.list_public_images(name=name, mask=image_mod.MASK):
+        for image in image_mgr.list_public_images(name=name,
+                                                  mask=image_mod.MASK):
             images.append(image)
 
     table = formatting.Table(['id',

--- a/SoftLayer/CLI/image/list.py
+++ b/SoftLayer/CLI/image/list.py
@@ -11,26 +11,27 @@ import click
 
 
 @click.command()
+@click.option('--name', default=None, help='Filter on image name')
 @click.option('--public/--private',
               is_flag=True,
               default=None,
               help='Display only public or private images')
 @environment.pass_env
-def cli(env, public):
+def cli(env, name, public):
     """List images."""
 
     image_mgr = SoftLayer.ImageManager(env.client)
 
     images = []
     if public in [False, None]:
-        for image in image_mgr.list_private_images(mask=image_mod.MASK):
+        for image in image_mgr.list_private_images(name=name, mask=image_mod.MASK):
             images.append(image)
 
     if public in [True, None]:
-        for image in image_mgr.list_public_images(mask=image_mod.MASK):
+        for image in image_mgr.list_public_images(name=name, mask=image_mod.MASK):
             images.append(image)
 
-    table = formatting.Table(['guid',
+    table = formatting.Table(['id',
                               'name',
                               'type',
                               'visibility',
@@ -42,7 +43,7 @@ def cli(env, public):
         visibility = (image_mod.PUBLIC_TYPE if image['publicFlag']
                       else image_mod.PRIVATE_TYPE)
         table.add_row([
-            image.get('globalIdentifier', formatting.blank()),
+            image.get('id', formatting.blank()),
             formatting.FormattedItem(image['name'],
                                      click.wrap_text(image['name'], width=50)),
             formatting.FormattedItem(

--- a/SoftLayer/CLI/virt/create.py
+++ b/SoftLayer/CLI/virt/create.py
@@ -145,7 +145,7 @@ def _parse_create_args(client, args):
 @click.option('--os', '-o',
               help="OS install code. Tip: you can specify <OS>_LATEST")
 @click.option('--image',
-              help="Image GUID. See: 'slcli image list' for reference")
+              help="Image ID. See: 'slcli image list' for reference")
 @click.option('--billing',
               type=click.Choice(['hourly', 'monthly']),
               default='hourly',

--- a/SoftLayer/CLI/virt/reload.py
+++ b/SoftLayer/CLI/virt/reload.py
@@ -13,10 +13,14 @@ import click
 @click.command()
 @click.argument('identifier')
 @click.option('--postinstall', '-i', help="Post-install script to download")
+@click.option(
+    '--image',
+    help="""Image ID. The default is to use the current operating system.
+See: 'slcli image list' for reference""")
 @helpers.multi_option('--key', '-k',
                       help="SSH keys to add to the root user")
 @environment.pass_env
-def cli(env, identifier, postinstall, key):
+def cli(env, identifier, postinstall, key, image):
     """Reload operating system on a virtual server."""
 
     vsi = SoftLayer.VSManager(env.client)
@@ -30,4 +34,7 @@ def cli(env, identifier, postinstall, key):
     if not (env.skip_confirmations or formatting.no_going_back(vs_id)):
         raise exceptions.CLIAbort('Aborted')
 
-    vsi.reload_instance(vs_id, postinstall, keys)
+    vsi.reload_instance(vs_id,
+                        post_uri=postinstall,
+                        ssh_keys=keys,
+                        image_id=image)

--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -240,17 +240,21 @@ class VSManager(utils.IdentifierMixin, object):
         """
         return self.guest.deleteObject(id=instance_id)
 
-    def reload_instance(self, instance_id, post_uri=None, ssh_keys=None):
-        """Perform an OS reload of an instance with its current configuration.
+    def reload_instance(self, instance_id,
+                        post_uri=None,
+                        ssh_keys=None,
+                        image_id=None):
+        """Perform an OS reload of an instance.
 
         :param integer instance_id: the instance ID to reload
         :param string post_url: The URI of the post-install script to run
                                 after reload
         :param list ssh_keys: The SSH keys to add to the root user
+        :param int image_id: The ID of the image to load onto the server
 
         .. warning::
-            Post-provision script MUST be HTTPS for it to be executed.
             This will reformat the primary drive.
+            Post-provision script MUST be HTTPS for it to be executed.
 
         Example::
 
@@ -268,8 +272,11 @@ class VSManager(utils.IdentifierMixin, object):
         if ssh_keys:
             config['sshKeyIds'] = [key_id for key_id in ssh_keys]
 
-        return self.guest.reloadOperatingSystem('FORCE', config,
-                                                id=instance_id)
+        if image_id:
+            config['imageTemplateId'] = image_id
+
+        return self.client.call('Virtual_Guest', 'reloadOperatingSystem',
+                                'FORCE', config, id=instance_id)
 
     def _generate_create_dict(
             self, cpus=None, memory=None, hourly=True,

--- a/tests/managers/vs_tests.py
+++ b/tests/managers/vs_tests.py
@@ -126,12 +126,29 @@ class VSTests(testing.TestCase):
                                 identifier=1)
 
     def test_reload_instance(self):
+        self.vs.reload_instance(1)
+
+        self.assert_called_with('SoftLayer_Virtual_Guest',
+                                'reloadOperatingSystem',
+                                args=('FORCE', {}),
+                                identifier=1)
+
+    def test_reload_instance_posturi_sshkeys(self):
         post_uri = 'http://test.sftlyr.ws/test.sh'
 
         self.vs.reload_instance(1, post_uri=post_uri, ssh_keys=[1701])
 
         args = ('FORCE', {'customProvisionScriptUri': post_uri,
                           'sshKeyIds': [1701]})
+        self.assert_called_with('SoftLayer_Virtual_Guest',
+                                'reloadOperatingSystem',
+                                args=args,
+                                identifier=1)
+
+    def test_reload_instance_with_new_os(self):
+        self.vs.reload_instance(1, image_id=1234)
+
+        args = ('FORCE', {'imageTemplateId': 1234})
         self.assert_called_with('SoftLayer_Virtual_Guest',
                                 'reloadOperatingSystem',
                                 args=args,


### PR DESCRIPTION
Adds name filter to `slcli image list` command
Uses image id over guid again in `slcli image list`
Allow users to specify an image_id when issuing an os reload

Resolves #485