### PR TITLE
Filter env vars that start with underscore

### DIFF
--- a/SoftLayer/CLI/core.py
+++ b/SoftLayer/CLI/core.py
@@ -146,8 +146,8 @@ def cli(env,
             )
         env.client = client
 
-    env.vars['timings'] = SoftLayer.TimingTransport(env.client.transport)
-    env.client.transport = env.vars['timings']
+    env.vars['_timings'] = SoftLayer.TimingTransport(env.client.transport)
+    env.client.transport = env.vars['_timings']
 
 
 @cli.resultcallback()
@@ -155,10 +155,10 @@ def cli(env,
 def output_result(env, timings=False, *args, **kwargs):
     """Outputs the results returned by the CLI and also outputs timings."""
 
-    if timings and env.vars.get('timings'):
+    if timings and env.vars.get('_timings'):
         timing_table = formatting.Table(['service', 'method', 'time'])
 
-        calls = env.vars['timings'].get_last_calls()
+        calls = env.vars['_timings'].get_last_calls()
         for call, _, duration in calls:
             timing_table.add_row([call.service, call.method, duration])
 

--- a/SoftLayer/shell/cmd_env.py
+++ b/SoftLayer/shell/cmd_env.py
@@ -11,4 +11,7 @@ from SoftLayer.CLI import formatting
 @environment.pass_env
 def cli(env):
     """Print environment variables."""
-    env.fout(formatting.iter_to_table(env.vars))
+    filtered_vars = dict([(k, v)
+                          for k, v in env.vars.items()
+                          if not k.startswith('_')])
+    env.fout(formatting.iter_to_table(filtered_vars))


### PR DESCRIPTION
This is a minor nit-pick. When in the shell, if you show environment variables (`env`) you will see a variable that wasn't intended to be seen/displayed. This change makes it so prefixing an underscore will allow those kinds of variables to be excluded when displaying them.