### PR TITLE
CLI Usability Tweeks

### DIFF
--- a/SoftLayer/CLI/cdn/detail.py
+++ b/SoftLayer/CLI/cdn/detail.py
@@ -17,9 +17,9 @@ def cli(env, account_id):
     manager = SoftLayer.CDNManager(env.client)
     account = manager.get_account(account_id)
 
-    table = formatting.KeyValueTable(['Name', 'Value'])
-    table.align['Name'] = 'r'
-    table.align['Value'] = 'l'
+    table = formatting.KeyValueTable(['name', 'value'])
+    table.align['name'] = 'r'
+    table.align['value'] = 'l'
 
     table.add_row(['id', account['id']])
     table.add_row(['account_name', account['cdnAccountName']])

--- a/SoftLayer/CLI/cdn/origin_add.py
+++ b/SoftLayer/CLI/cdn/origin_add.py
@@ -14,7 +14,8 @@ from SoftLayer.CLI import environment
 @click.argument('content_url')
 @click.option('--type',
               help='The media type for this mapping (http, flash, wm, ...)',
-              default='http')
+              default='http',
+              show_default=True)
 @click.option('--cname',
               help='An optional CNAME to attach to the mapping')
 @environment.pass_env

--- a/SoftLayer/CLI/config/__init__.py
+++ b/SoftLayer/CLI/config/__init__.py
@@ -42,9 +42,9 @@ def get_settings_from_client(client):
 
 def config_table(settings):
     """Returns a config table."""
-    table = formatting.KeyValueTable(['Name', 'Value'])
-    table.align['Name'] = 'r'
-    table.align['Value'] = 'l'
+    table = formatting.KeyValueTable(['name', 'value'])
+    table.align['name'] = 'r'
+    table.align['value'] = 'l'
     table.add_row(['Username', settings['username'] or 'not set'])
     table.add_row(['API Key', settings['api_key'] or 'not set'])
     table.add_row(['Endpoint URL', settings['endpoint_url'] or 'not set'])

--- a/SoftLayer/CLI/core.py
+++ b/SoftLayer/CLI/core.py
@@ -150,7 +150,8 @@ def output_diagnostics(env, verbose=0, **kwargs):
 
     if verbose > 0:
         diagnostic_table = formatting.Table(['name', 'value'])
-        diagnostic_table.add_row(['execution_time', time.time() - START_TIME])
+        diagnostic_table.add_row(['execution_time',
+                                  '%fs' % (time.time() - START_TIME)])
 
         api_call_value = []
         for call, _, duration in env.vars['_timings'].get_last_calls():

--- a/SoftLayer/CLI/dns/record_add.py
+++ b/SoftLayer/CLI/dns/record_add.py
@@ -17,6 +17,7 @@ from SoftLayer.CLI import helpers
 @click.option('--ttl',
               type=click.INT,
               default=7200,
+              show_default=True,
               help='TTL value in seconds, such as 86400')
 @environment.pass_env
 def cli(env, zone, record, type, data, ttl):

--- a/SoftLayer/CLI/formatting.py
+++ b/SoftLayer/CLI/formatting.py
@@ -371,9 +371,9 @@ def iter_to_table(value):
 def _format_dict(result):
     """Format dictionary responses into key-value table."""
 
-    table = KeyValueTable(['Name', 'Value'])
-    table.align['Name'] = 'r'
-    table.align['Value'] = 'l'
+    table = KeyValueTable(['name', 'value'])
+    table.align['name'] = 'r'
+    table.align['value'] = 'l'
 
     for key, value in result.items():
         value = iter_to_table(value)
@@ -391,7 +391,7 @@ def _format_list(result):
     if isinstance(result[0], dict):
         return _format_list_objects(result)
 
-    table = Table(["Value"])
+    table = Table(['value'])
     for item in result:
         table.add_row([iter_to_table(item)])
     return table

--- a/SoftLayer/CLI/image/detail.py
+++ b/SoftLayer/CLI/image/detail.py
@@ -28,9 +28,9 @@ def cli(env, identifier):
         if child.get('datacenter'):
             datacenters.append(utils.lookup(child, 'datacenter', 'name'))
 
-    table = formatting.KeyValueTable(['Name', 'Value'])
-    table.align['Name'] = 'r'
-    table.align['Value'] = 'l'
+    table = formatting.KeyValueTable(['name', 'value'])
+    table.align['name'] = 'r'
+    table.align['value'] = 'l'
 
     table.add_row(['id', image['id']])
     table.add_row(['global_identifier',

--- a/SoftLayer/CLI/image/import.py
+++ b/SoftLayer/CLI/image/import.py
@@ -12,9 +12,11 @@ from SoftLayer.CLI import formatting
 @click.command()
 @click.argument('name')
 @click.argument('uri')
-@click.option('--note', default="",
+@click.option('--note',
+              default="",
               help="The note to be applied to the imported template")
-@click.option('--os-code', default="",
+@click.option('--os-code',
+              default="",
               help="The referenceCode of the operating system software"
                    " description for the imported VHD")
 @environment.pass_env

--- a/SoftLayer/CLI/iscsi/detail.py
+++ b/SoftLayer/CLI/iscsi/detail.py
@@ -25,9 +25,9 @@ def cli(env, identifier, password):
     result = iscsi_mgr.get_iscsi(iscsi_id)
     result = utils.NestedDict(result)
 
-    table = formatting.KeyValueTable(['Name', 'Value'])
-    table.align['Name'] = 'r'
-    table.align['Value'] = 'l'
+    table = formatting.KeyValueTable(['name', 'value'])
+    table.align['name'] = 'r'
+    table.align['value'] = 'l'
 
     table.add_row(['id', result['id']])
     table.add_row(['serviceResourceName', result['serviceResourceName']])

--- a/SoftLayer/CLI/loadbal/detail.py
+++ b/SoftLayer/CLI/loadbal/detail.py
@@ -20,9 +20,9 @@ def cli(env, identifier):
 
     load_balancer = mgr.get_local_lb(loadbal_id)
 
-    table = formatting.KeyValueTable(['Name', 'Value'])
-    table.align['Name'] = 'l'
-    table.align['Value'] = 'l'
+    table = formatting.KeyValueTable(['name', 'value'])
+    table.align['name'] = 'l'
+    table.align['value'] = 'l'
     table.add_row(['General properties', '----------'])
     table.add_row([' ID', 'local:%s' % load_balancer['id']])
     table.add_row([' IP Address', load_balancer['ipAddress']['ipAddress']])

--- a/SoftLayer/CLI/metadata.py
+++ b/SoftLayer/CLI/metadata.py
@@ -72,8 +72,8 @@ def get_network():
         network = network_func()
 
         table = formatting.KeyValueTable(['name', 'value'])
-        table.align['Name'] = 'r'
-        table.align['Value'] = 'l'
+        table.align['name'] = 'r'
+        table.align['value'] = 'l'
         table.add_row(['mac addresses',
                        formatting.listing(network['mac_addresses'],
                                           separator=',')])

--- a/SoftLayer/CLI/mq/queue_add.py
+++ b/SoftLayer/CLI/mq/queue_add.py
@@ -19,11 +19,13 @@ from SoftLayer.CLI import mq
 @click.option('--visibility-interval',
               type=click.INT,
               default=30,
+              show_default=True,
               help="Time in seconds that messages will re-appear after being "
                    "popped")
 @click.option('--expiration',
               type=click.INT,
               default=604800,
+              show_default=True,
               help="Time in seconds that messages will live")
 @helpers.multi_option('--tag', '-g', help="Tags to add to the queue")
 @environment.pass_env

--- a/SoftLayer/CLI/mq/queue_edit.py
+++ b/SoftLayer/CLI/mq/queue_edit.py
@@ -19,11 +19,13 @@ from SoftLayer.CLI import mq
 @click.option('--visibility-interval',
               type=click.INT,
               default=30,
+              show_default=True,
               help="Time in seconds that messages will re-appear after being "
                    "popped")
 @click.option('--expiration',
               type=click.INT,
               default=604800,
+              show_default=True,
               help="Time in seconds that messages will live")
 @helpers.multi_option('--tag', '-g', help="Tags to add to the queue")
 @environment.pass_env

--- a/SoftLayer/CLI/mq/queue_pop.py
+++ b/SoftLayer/CLI/mq/queue_pop.py
@@ -13,6 +13,7 @@ from SoftLayer.CLI import mq
 @click.argument('queue-name')
 @click.option('--count',
               default=1,
+              show_default=True,
               type=click.INT,
               help="Count of messages to pop")
 @click.option('--delete-after',

--- a/SoftLayer/CLI/mq/topic_add.py
+++ b/SoftLayer/CLI/mq/topic_add.py
@@ -19,11 +19,13 @@ from SoftLayer.CLI import mq
 @click.option('--visibility-interval',
               type=click.INT,
               default=30,
+              show_default=True,
               help="Time in seconds that messages will re-appear after being "
                    "popped")
 @click.option('--expiration',
               type=click.INT,
               default=604800,
+              show_default=True,
               help="Time in seconds that messages will live")
 @helpers.multi_option('--tag', '-g', help="Tags to add to the topic")
 @environment.pass_env

--- a/SoftLayer/CLI/rwhois/show.py
+++ b/SoftLayer/CLI/rwhois/show.py
@@ -16,9 +16,9 @@ def cli(env):
     mgr = SoftLayer.NetworkManager(env.client)
     result = mgr.get_rwhois()
 
-    table = formatting.KeyValueTable(['Name', 'Value'])
-    table.align['Name'] = 'r'
-    table.align['Value'] = 'l'
+    table = formatting.KeyValueTable(['name', 'value'])
+    table.align['name'] = 'r'
+    table.align['value'] = 'l'
     table.add_row(['Name', result['firstName'] + ' ' + result['lastName']])
     table.add_row(['Company', result['companyName']])
     table.add_row(['Abuse Email', result['abuseEmail']])

--- a/SoftLayer/CLI/server/create.py
+++ b/SoftLayer/CLI/server/create.py
@@ -38,6 +38,7 @@ from SoftLayer.CLI import template
 @click.option('--billing',
               type=click.Choice(['hourly', 'monthly']),
               default='hourly',
+              show_default=True,
               help="Billing rate")
 @click.option('--postinstall', '-i', help="Post-install script to download")
 @helpers.multi_option('--key', '-k',

--- a/SoftLayer/CLI/server/detail.py
+++ b/SoftLayer/CLI/server/detail.py
@@ -24,9 +24,9 @@ def cli(env, identifier, passwords, price):
 
     hardware = SoftLayer.HardwareManager(env.client)
 
-    table = formatting.KeyValueTable(['Name', 'Value'])
-    table.align['Name'] = 'r'
-    table.align['Value'] = 'l'
+    table = formatting.KeyValueTable(['name', 'value'])
+    table.align['name'] = 'r'
+    table.align['value'] = 'l'
 
     hardware_id = helpers.resolve_id(hardware.resolve_ids,
                                      identifier,

--- a/SoftLayer/CLI/server/list.py
+++ b/SoftLayer/CLI/server/list.py
@@ -52,12 +52,15 @@ DEFAULT_COLUMNS = [
 @click.option('--memory', '-m', help='Filter by memory in gigabytes')
 @click.option('--network', '-n', help='Filter by network port speed in Mbps')
 @helpers.multi_option('--tag', help='Filter by tags')
-@click.option('--sortby', help='Column to sort by', default='hostname')
+@click.option('--sortby', help='Column to sort by',
+              default='hostname',
+              show_default=True)
 @click.option('--columns',
               callback=column_helper.get_formatter(COLUMNS),
-              help='Columns to display. Options: %s'
+              help='Columns to display. [options: %s]'
               % ', '.join(column.name for column in COLUMNS),
-              default=','.join(DEFAULT_COLUMNS))
+              default=','.join(DEFAULT_COLUMNS),
+              show_default=True)
 @environment.pass_env
 def cli(env, sortby, cpu, domain, datacenter, hostname, memory, network, tag,
         columns):

--- a/SoftLayer/CLI/sshkey/print.py
+++ b/SoftLayer/CLI/sshkey/print.py
@@ -29,7 +29,7 @@ def cli(env, identifier, out_file):
         with open(path.expanduser(out_file), 'w') as pub_file:
             pub_file.write(key['key'])
 
-    table = formatting.KeyValueTable(['Name', 'Value'])
+    table = formatting.KeyValueTable(['name', 'value'])
     table.add_row(['id', key['id']])
     table.add_row(['label', key.get('label')])
     table.add_row(['notes', key.get('notes', '-')])

--- a/SoftLayer/CLI/ssl/list.py
+++ b/SoftLayer/CLI/ssl/list.py
@@ -11,6 +11,7 @@ from SoftLayer.CLI import formatting
 @click.command()
 @click.option('--status',
               default="all",
+              show_default=True,
               type=click.Choice(['all', 'valid', 'expired']),
               help="Show certificates with this status")
 @click.option('--sortby',

--- a/SoftLayer/CLI/subnet/detail.py
+++ b/SoftLayer/CLI/subnet/detail.py
@@ -26,9 +26,9 @@ def cli(env, identifier, no_vs, no_hardware):
                                    name='subnet')
     subnet = mgr.get_subnet(subnet_id)
 
-    table = formatting.KeyValueTable(['Name', 'Value'])
-    table.align['Name'] = 'r'
-    table.align['Value'] = 'l'
+    table = formatting.KeyValueTable(['name', 'value'])
+    table.align['name'] = 'r'
+    table.align['value'] = 'l'
 
     table.add_row(['id', subnet['id']])
     table.add_row(['identifier',

--- a/SoftLayer/CLI/subnet/lookup.py
+++ b/SoftLayer/CLI/subnet/lookup.py
@@ -22,16 +22,16 @@ def cli(env, ip_address):
     if not addr_info:
         raise exceptions.CLIAbort('Not found')
 
-    table = formatting.KeyValueTable(['Name', 'Value'])
-    table.align['Name'] = 'r'
-    table.align['Value'] = 'l'
+    table = formatting.KeyValueTable(['name', 'value'])
+    table.align['name'] = 'r'
+    table.align['value'] = 'l'
 
     table.add_row(['id', addr_info['id']])
     table.add_row(['ip', addr_info['ipAddress']])
 
-    subnet_table = formatting.KeyValueTable(['Name', 'Value'])
-    subnet_table.align['Name'] = 'r'
-    subnet_table.align['Value'] = 'l'
+    subnet_table = formatting.KeyValueTable(['name', 'value'])
+    subnet_table.align['name'] = 'r'
+    subnet_table.align['value'] = 'l'
     subnet_table.add_row(['id', addr_info['subnet']['id']])
     subnet_table.add_row(['identifier',
                           '%s/%s' % (addr_info['subnet']['networkIdentifier'],
@@ -44,9 +44,9 @@ def cli(env, ip_address):
     table.add_row(['subnet', subnet_table])
 
     if addr_info.get('virtualGuest') or addr_info.get('hardware'):
-        device_table = formatting.KeyValueTable(['Name', 'Value'])
-        device_table.align['Name'] = 'r'
-        device_table.align['Value'] = 'l'
+        device_table = formatting.KeyValueTable(['name', 'value'])
+        device_table.align['name'] = 'r'
+        device_table.align['value'] = 'l'
         if addr_info.get('virtualGuest'):
             device = addr_info['virtualGuest']
             device_type = 'vs'

--- a/SoftLayer/CLI/summary.py
+++ b/SoftLayer/CLI/summary.py
@@ -12,6 +12,7 @@ from SoftLayer.CLI import formatting
 @click.option('--sortby',
               help='Column to sort by',
               default='datacenter',
+              show_default=True,
               type=click.Choice(['datacenter',
                                  'hardware',
                                  'virtual_servers',

--- a/SoftLayer/CLI/ticket/__init__.py
+++ b/SoftLayer/CLI/ticket/__init__.py
@@ -18,9 +18,9 @@ def get_ticket_results(mgr, ticket_id, update_count=1):
     """
     ticket = mgr.get_ticket(ticket_id)
 
-    table = formatting.KeyValueTable(['Name', 'Value'])
-    table.align['Name'] = 'r'
-    table.align['Value'] = 'l'
+    table = formatting.KeyValueTable(['name', 'value'])
+    table.align['name'] = 'r'
+    table.align['value'] = 'l'
 
     table.add_row(['id', ticket['id']])
     table.add_row(['title', ticket['title']])

--- a/SoftLayer/CLI/ticket/detail.py
+++ b/SoftLayer/CLI/ticket/detail.py
@@ -11,7 +11,11 @@ from SoftLayer.CLI import ticket
 
 @click.command()
 @click.argument('identifier')
-@click.option('--count', type=click.INT, help="Number of updates", default=10)
+@click.option('--count',
+              type=click.INT,
+              help="Number of updates",
+              show_default=True,
+              default=10)
 @environment.pass_env
 def cli(env, identifier, count):
     """Get details for a ticket."""

--- a/SoftLayer/CLI/virt/capture.py
+++ b/SoftLayer/CLI/virt/capture.py
@@ -25,9 +25,9 @@ def cli(env, identifier, name, all, note):
 
     capture = vsi.capture(vs_id, name, all, note)
 
-    table = formatting.KeyValueTable(['Name', 'Value'])
-    table.align['Name'] = 'r'
-    table.align['Value'] = 'l'
+    table = formatting.KeyValueTable(['name', 'value'])
+    table.align['name'] = 'r'
+    table.align['value'] = 'l'
 
     table.add_row(['vs_id', capture['guestId']])
     table.add_row(['date', capture['createDate'][:10]])

--- a/SoftLayer/CLI/virt/create.py
+++ b/SoftLayer/CLI/virt/create.py
@@ -149,6 +149,7 @@ def _parse_create_args(client, args):
 @click.option('--billing',
               type=click.Choice(['hourly', 'monthly']),
               default='hourly',
+              show_default=True,
               help="Billing rate")
 @click.option('--dedicated/--public',
               is_flag=True,

--- a/SoftLayer/CLI/virt/create_options.py
+++ b/SoftLayer/CLI/virt/create_options.py
@@ -18,9 +18,9 @@ def cli(env):
     vsi = SoftLayer.VSManager(env.client)
     result = vsi.get_create_options()
 
-    table = formatting.KeyValueTable(['Name', 'Value'])
-    table.align['Name'] = 'r'
-    table.align['Value'] = 'l'
+    table = formatting.KeyValueTable(['name', 'value'])
+    table.align['name'] = 'r'
+    table.align['value'] = 'l'
 
     # Datacenters
     datacenters = [dc['template']['datacenter']['name']

--- a/SoftLayer/CLI/virt/detail.py
+++ b/SoftLayer/CLI/virt/detail.py
@@ -21,9 +21,9 @@ def cli(env, identifier, passwords=False, price=False):
     """Get details for a virtual server."""
 
     vsi = SoftLayer.VSManager(env.client)
-    table = formatting.KeyValueTable(['Name', 'Value'])
-    table.align['Name'] = 'r'
-    table.align['Value'] = 'l'
+    table = formatting.KeyValueTable(['name', 'value'])
+    table.align['name'] = 'r'
+    table.align['value'] = 'l'
 
     vs_id = helpers.resolve_id(vsi.resolve_ids, identifier, 'VS')
     result = vsi.get_instance(vs_id)

--- a/SoftLayer/CLI/virt/dns.py
+++ b/SoftLayer/CLI/virt/dns.py
@@ -21,6 +21,7 @@ the records updated.""")
 @click.option('--ptr', is_flag=True, help="Sync the PTR record for the host")
 @click.option('--ttl',
               default=7200,
+              show_default=True,
               type=click.INT,
               help="Sets the TTL for the A and/or PTR records")
 @environment.pass_env

--- a/SoftLayer/CLI/virt/list.py
+++ b/SoftLayer/CLI/virt/list.py
@@ -52,12 +52,16 @@ DEFAULT_COLUMNS = [
 @click.option('--hourly', is_flag=True, help='Show only hourly instances')
 @click.option('--monthly', is_flag=True, help='Show only monthly instances')
 @helpers.multi_option('--tag', help='Filter by tags')
-@click.option('--sortby', help='Column to sort by', default='hostname')
+@click.option('--sortby',
+              help='Column to sort by',
+              default='hostname',
+              show_default=True)
 @click.option('--columns',
               callback=column_helper.get_formatter(COLUMNS),
-              help='Columns to display. Options: %s'
+              help='Columns to display. [options: %s]'
               % ', '.join(column.name for column in COLUMNS),
-              default=','.join(DEFAULT_COLUMNS))
+              default=','.join(DEFAULT_COLUMNS),
+              show_default=True)
 @environment.pass_env
 def cli(env, sortby, cpu, domain, datacenter, hostname, memory, network,
         hourly, monthly, tag, columns):

--- a/SoftLayer/CLI/virt/ready.py
+++ b/SoftLayer/CLI/virt/ready.py
@@ -11,7 +11,11 @@ from SoftLayer.CLI import helpers
 
 @click.command()
 @click.argument('identifier')
-@click.option('--wait', default=0, type=click.INT, help="Name of the image")
+@click.option('--wait',
+              default=0,
+              show_default=True,
+              type=click.INT,
+              help="Name of the image")
 @environment.pass_env
 def cli(env, identifier, wait):
     """Check if a virtual server is ready."""

--- a/SoftLayer/CLI/vlan/detail.py
+++ b/SoftLayer/CLI/vlan/detail.py
@@ -26,9 +26,9 @@ def cli(env, identifier, no_vs, no_hardware):
     vlan_id = helpers.resolve_id(mgr.resolve_vlan_ids, identifier, 'VLAN')
     vlan = mgr.get_vlan(vlan_id)
 
-    table = formatting.KeyValueTable(['Name', 'Value'])
-    table.align['Name'] = 'r'
-    table.align['Value'] = 'l'
+    table = formatting.KeyValueTable(['name', 'value'])
+    table.align['name'] = 'r'
+    table.align['value'] = 'l'
 
     table.add_row(['id', vlan['id']])
     table.add_row(['number', vlan['vlanNumber']])
@@ -40,9 +40,9 @@ def cli(env, identifier, no_vs, no_hardware):
                    'Yes' if vlan['firewallInterfaces'] else 'No'])
     subnets = []
     for subnet in vlan['subnets']:
-        subnet_table = formatting.KeyValueTable(['Name', 'Value'])
-        subnet_table.align['Name'] = 'r'
-        subnet_table.align['Value'] = 'l'
+        subnet_table = formatting.KeyValueTable(['name', 'value'])
+        subnet_table.align['name'] = 'r'
+        subnet_table.align['value'] = 'l'
         subnet_table.add_row(['id', subnet['id']])
         subnet_table.add_row(['identifier', subnet['networkIdentifier']])
         subnet_table.add_row(['netmask', subnet['netmask']])

--- a/SoftLayer/testing/__init__.py
+++ b/SoftLayer/testing/__init__.py
@@ -162,7 +162,7 @@ class TestCase(testtools.TestCase):
         args = args or []
 
         if fixtures is True:
-            args.insert(0, '--fixtures')
+            args.insert(0, '--demo')
         args.insert(0, '--format=%s' % fmt)
 
         runner = testing.CliRunner()

--- a/tests/CLI/core_tests.py
+++ b/tests/CLI/core_tests.py
@@ -27,14 +27,6 @@ class CoreTests(testing.TestCase):
                 if ex.code != 0:
                     self.fail("Non-zero exit code for command: %s" % path)
 
-    def test_debug_max(self):
-        with mock.patch('logging.getLogger') as log_mock:
-            result = self.run_command(['--debug=3', 'vs', 'list'])
-
-            self.assertEqual(result.exit_code, 0)
-            log_mock().addHandler.assert_called_with(mock.ANY)
-            log_mock().setLevel.assert_called_with(logging.DEBUG)
-
     def test_verbose_max(self):
         with mock.patch('logging.getLogger') as log_mock:
             result = self.run_command(['-vvv', 'vs', 'list'])
@@ -50,13 +42,16 @@ class CoreTests(testing.TestCase):
         self.assertEqual(result.exit_code, 0)
         self.assertIsNotNone(env.client)
 
-    def test_timings(self):
-        result = self.run_command(['--timings', 'vs', 'list'])
+    def test_diagnostics(self):
+        result = self.run_command(['-v', 'vs', 'list'])
 
         self.assertEqual(result.exit_code, 0)
-        self.assertIn('"method": "getVirtualGuests"', result.output)
-        self.assertIn('"service": "SoftLayer_Account"', result.output)
-        self.assertIn('"time":', result.output)
+        self.assertIn('SoftLayer_Account::getVirtualGuests', result.output)
+        self.assertIn('"execution_time"', result.output)
+        self.assertIn('"api_calls"', result.output)
+        self.assertIn('"version"', result.output)
+        self.assertIn('"python_version"', result.output)
+        self.assertIn('"library_location"', result.output)
 
 
 class CoreMainTests(testing.TestCase):

--- a/tests/CLI/helper_tests.py
+++ b/tests/CLI/helper_tests.py
@@ -423,7 +423,7 @@ class IterToTableTests(testing.TestCase):
         result = formatting._format_dict({'key': 'value'})
 
         self.assertIsInstance(result, formatting.Table)
-        self.assertEqual(result.columns, ['Name', 'Value'])
+        self.assertEqual(result.columns, ['name', 'value'])
         self.assertEqual(result.rows, [['key', 'value']])
 
     def test_format_api_list(self):
@@ -437,5 +437,5 @@ class IterToTableTests(testing.TestCase):
         result = formatting._format_list(['a', 'b', 'c'])
 
         self.assertIsInstance(result, formatting.Table)
-        self.assertEqual(result.columns, ['Value'])
+        self.assertEqual(result.columns, ['value'])
         self.assertEqual(result.rows, [['a'], ['b'], ['c']])

--- a/tests/CLI/modules/call_api_tests.py
+++ b/tests/CLI/modules/call_api_tests.py
@@ -61,7 +61,7 @@ class CallCliTests(testing.TestCase):
         self.assertEqual(result.exit_code, 0)
         # NOTE(kmcdonald): Order is not guaranteed
         self.assertIn(":........:........:", result.output)
-        self.assertIn(":   Name : Value  :", result.output)
+        self.assertIn(":   name : value  :", result.output)
         self.assertIn(":    int : 10     :", result.output)
         self.assertIn(":   None : None   :", result.output)
         self.assertIn(":  float : 1.0    :", result.output)


### PR DESCRIPTION
* **Removes global `--debug` option in favor of `--verbose` | `-v`.** -v can be specified multiple times to increase verbosity. For example, `-vvv` will the same as `--debug=3`
* Removes global `--timings` option
* Renames global `--fixtures` option to `--demo`
* Adds more diagnostics whenever the verbose (-v) flag is set including the info that was displayed with `--timings`
* Converts to using lowercase name/value for tables instead of upper-case since lower-case is generally preferred for this tool at the moment
* Shows default values for many CLI options