### PR TITLE
Fixed exception on globalip create

### DIFF
--- a/SoftLayer/CLI/globalip/create.py
+++ b/SoftLayer/CLI/globalip/create.py
@@ -10,7 +10,7 @@ from SoftLayer.CLI import formatting
 
 
 @click.command()
-@click.option('--ipv6', '--v6', is_flag=True, help='Order a IPv6 IP')
+@click.option('--v6', '--ipv6', is_flag=True, help='Order a IPv6 IP')
 @click.option('--test', help='test order')
 @environment.pass_env
 def cli(env, ipv6, test):


### PR DESCRIPTION
Without this fix, it fails with
```
$ slcli globalip create
An unexpected error has occured:
Traceback (most recent call last):
  File "/Library/Python/2.7/site-packages/SoftLayer/CLI/core.py", line 173, in main
    cli.main(**kwargs)
  File "/Library/Python/2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/Library/Python/2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Library/Python/2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Library/Python/2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Library/Python/2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/Library/Python/2.7/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "/Library/Python/2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
TypeError: cli() got an unexpected keyword argument 'v6'

Feel free to report this error as it is likely a bug:
    https://github.com/softlayer/softlayer-python/issues
```