### PR TITLE
Fix help text and commands for load balancer CLI

### DIFF
--- a/SoftLayer/CLI/loadbal/create_options.py
+++ b/SoftLayer/CLI/loadbal/create_options.py
@@ -11,7 +11,7 @@ from SoftLayer.CLI import formatting
 @click.command()
 @environment.pass_env
 def cli(env):
-    """Reset connections on a certain service group."""
+    """Get price options to create a load balancer with."""
 
     mgr = SoftLayer.LoadBalancerManager(env.client)
 

--- a/SoftLayer/CLI/loadbal/routing_types.py
+++ b/SoftLayer/CLI/loadbal/routing_types.py
@@ -14,11 +14,11 @@ def cli(env):
     """List routing types."""
     mgr = SoftLayer.LoadBalancerManager(env.client)
 
-    routing_methods = mgr.get_routing_methods()
+    routing_types = mgr.get_routing_types()
     table = formatting.KeyValueTable(['ID', 'Name'])
     table.align['ID'] = 'l'
     table.align['Name'] = 'l'
     table.sortby = 'ID'
-    for routing_method in routing_methods:
-        table.add_row([routing_method['id'], routing_method['name']])
+    for routing_type in routing_types:
+        table.add_row([routing_type['id'], routing_type['name']])
     env.fout(table)

--- a/SoftLayer/CLI/loadbal/service_add.py
+++ b/SoftLayer/CLI/loadbal/service_add.py
@@ -12,7 +12,7 @@ from SoftLayer.CLI import loadbal
 @click.argument('identifier')
 @click.option('--enabled / --disabled',
               required=True,
-              help="Create the service as enable or disabled")
+              help="Create the service as enabled or disabled")
 @click.option('--port',
               required=True,
               help="The port number for the service",

--- a/SoftLayer/managers/load_balancer.py
+++ b/SoftLayer/managers/load_balancer.py
@@ -67,18 +67,19 @@ class LoadBalancerManager(utils.IdentifierMixin, object):
                           'LoadBalancer_Routing_Type']
         return svc.getAllObjects()
 
-    def _get_location(self, datacenter):
+    def _get_location(self, datacenter_name):
         """Returns the location of the specified datacenter.
 
-        :param string datacenter: The datacenter to create the loadbalancer in
+        :param string datacenter_name: The datacenter to create
+                                       the loadbalancer in
 
         :returns: the location id of the given datacenter
         """
 
-        dcenters = self.client['Location'].getDataCenters()
-        for dcenter in dcenters:
-            if dcenter['name'] == datacenter:
-                return dcenter['id']
+        datacenters = self.client['Location'].getDataCenters()
+        for datacenter in datacenters:
+            if datacenter['name'] == datacenter_name:
+                return datacenter['id']
         return 'FIRST_AVAILABLE'
 
     def cancel_lb(self, loadbal_id):


### PR DESCRIPTION
Ensure getting load balancer service types uses the correct manager method.
Correct help text for create-options load balancer command.
Refactor some variable names, fix a misspelling in help text.

Addresses #678