### PR TITLE
Returns the new record when calling DNSManager.create_record

### DIFF
--- a/SoftLayer/managers/dns.py
+++ b/SoftLayer/managers/dns.py
@@ -92,7 +92,7 @@ class DNSManager(utils.IdentifierMixin, object):
         :param integer ttl: the TTL or time-to-live value (default: 60)
 
         """
-        self.record.createObject({
+        return self.record.createObject({
             'domainId': zone_id,
             'ttl': ttl,
             'host': record,

--- a/tests/managers/dns_tests.py
+++ b/tests/managers/dns_tests.py
@@ -77,7 +77,7 @@ class DNSTests(testing.TestCase):
                                 args=('example.com',))
 
     def test_create_record(self):
-        self.dns_client.create_record(1, 'test', 'TXT', 'testing', ttl=1200)
+        res = self.dns_client.create_record(1, 'test', 'TXT', 'testing', ttl=1200)
 
         self.assert_called_with('SoftLayer_Dns_Domain_ResourceRecord',
                                 'createObject',
@@ -88,6 +88,7 @@ class DNSTests(testing.TestCase):
                                     'type': 'TXT',
                                     'data': 'testing'
                                 },))
+        self.assertEqual(res, {'name': 'example.com'})
 
     def test_delete_record(self):
         self.dns_client.delete_record(1)

--- a/tests/managers/dns_tests.py
+++ b/tests/managers/dns_tests.py
@@ -77,7 +77,8 @@ class DNSTests(testing.TestCase):
                                 args=('example.com',))
 
     def test_create_record(self):
-        res = self.dns_client.create_record(1, 'test', 'TXT', 'testing', ttl=1200)
+        res = self.dns_client.create_record(1, 'test', 'TXT', 'testing',
+                                            ttl=1200)
 
         self.assert_called_with('SoftLayer_Dns_Domain_ResourceRecord',
                                 'createObject',


### PR DESCRIPTION
Resolves issue #660 