### PR TITLE
Corrected helpers text order

### DIFF
--- a/SoftLayer/CLI/hardware/reload.py
+++ b/SoftLayer/CLI/hardware/reload.py
@@ -12,9 +12,9 @@ from SoftLayer.CLI import helpers
 
 @click.command()
 @click.argument('identifier')
-@click.option('--postinstall', '-i',
-              help=("Post-install script to download "
-                    "(Only HTTPS executes, HTTP leaves file in /root"))
+@helpers.multi_option('--postinstall', '-i',
+             help=("Post-install script to download "
+                   "(Only HTTPS executes, HTTP leaves file in /root"))
 @helpers.multi_option('--key', '-k', help="SSH keys to add to the root user")
 @environment.pass_env
 def cli(env, identifier, postinstall, key):


### PR DESCRIPTION
Currently the Post install and SSH-key helper text are swapped 

```
❯ slcli --format raw server reload --help
Usage: slcli server reload [OPTIONS] IDENTIFIER

  Reload operating system on a server.

Options:
  -i, --postinstall TEXT  SSH keys to add to the root user
  -k, --key TEXT          Post-install script to download
                          (Only HTTPS
                          executes, HTTP leaves file in /root) (multiple
                          occurrence permitted)
  -h, --help              Show this message and exit.
```