### PR TITLE
Fixed reload helper text

### DIFF
--- a/SoftLayer/CLI/hardware/reload.py
+++ b/SoftLayer/CLI/hardware/reload.py
@@ -13,8 +13,8 @@ from SoftLayer.CLI import helpers
 @click.command()
 @click.argument('identifier')
 @helpers.multi_option('--postinstall', '-i',
-              help=("Post-install script to download "
-                    "(Only HTTPS executes, HTTP leaves file in /root"))
+                      help=("Post-install script to download "
+                            "(Only HTTPS executes, HTTP leaves file in /root"))
 @helpers.multi_option('--key', '-k', help="SSH keys to add to the root user")
 @environment.pass_env
 def cli(env, identifier, postinstall, key):

--- a/SoftLayer/CLI/hardware/reload.py
+++ b/SoftLayer/CLI/hardware/reload.py
@@ -12,7 +12,7 @@ from SoftLayer.CLI import helpers
 
 @click.command()
 @click.argument('identifier')
-@click.option('--postinstall', '-i',
+@helpers.multi_option('--postinstall', '-i',
               help=("Post-install script to download "
                     "(Only HTTPS executes, HTTP leaves file in /root"))
 @helpers.multi_option('--key', '-k', help="SSH keys to add to the root user")


### PR DESCRIPTION
Currently the helper text for reload is out of order

```
Options:
  -i, --postinstall TEXT  SSH keys to add to the root user
  -k, --key TEXT          Post-install script to download
                          (Only HTTPS
                          executes, HTTP leaves file in /root) (multiple
                          occurrence permitted)
  -h, --help              Show this message and exit.
```