### PR TITLE
Fixed helper text

### DIFF
--- a/SoftLayer/CLI/hardware/reload.py
+++ b/SoftLayer/CLI/hardware/reload.py
@@ -12,9 +12,9 @@ from SoftLayer.CLI import helpers
 
 @click.command()
 @click.argument('identifier')
-@click.option('--postinstall', '-i',
-              help=("Post-install script to download "
-                    "(Only HTTPS executes, HTTP leaves file in /root"))
+@helpers.multi_option('--postinstall', '-i',
+                      help=("Post-install script to download "
+                            "(Only HTTPS executes, HTTP leaves file in /root"))
 @helpers.multi_option('--key', '-k', help="SSH keys to add to the root user")
 @environment.pass_env
 def cli(env, identifier, postinstall, key):

--- a/tests/CLI/modules/server_tests.py
+++ b/tests/CLI/modules/server_tests.py
@@ -127,7 +127,7 @@ class ServerCLITests(testing.TestCase):
                                    '--key=4567'])
 
         self.assertEqual(result.exit_code, 0)
-        reload_mock.assert_called_with(12345, None, [4567])
+        reload_mock.assert_called_with(12345, (), [4567])
 
         # Now check to make sure we properly call CLIAbort in the negative case
         result = self.run_command(['server', 'reload', '12345'])


### PR DESCRIPTION
Currently the helper text for the server reload function has the descriptions swapped:

```
❯ slcli server reload --help
Usage: slcli server reload [OPTIONS] IDENTIFIER

  Reload operating system on a server.

Options:
  -i, --postinstall TEXT  SSH keys to add to the root user
  -k, --key TEXT          Post-install script to download
                          (Only HTTPS
                          executes, HTTP leaves file in /root) (multiple
                          occurrence permitted)
  -h, --help              Show this message and exit
```.
