### PR TITLE
Explicitly check for duplicated columns when using tables in the cli

### DIFF
--- a/SoftLayer/CLI/formatting.py
+++ b/SoftLayer/CLI/formatting.py
@@ -7,6 +7,7 @@
     :license: MIT, see LICENSE for more details.
 """
 # pylint: disable=E0202
+import collections
 import json
 import os
 
@@ -252,6 +253,13 @@ class Table(object):
     :param list columns: a list of column names
     """
     def __init__(self, columns):
+        duplicated_cols = [col for col, count
+                           in collections.Counter(columns).items()
+                           if count > 1]
+        if len(duplicated_cols) > 0:
+            raise exceptions.CLIAbort("Duplicated columns are not allowed: %s"
+                                      % ','.join(duplicated_cols))
+
         self.columns = columns
         self.rows = []
         self.align = {}

--- a/tests/CLI/helper_tests.py
+++ b/tests/CLI/helper_tests.py
@@ -265,6 +265,12 @@ class ResolveIdTests(testing.TestCase):
             exceptions.CLIAbort, helpers.resolve_id, resolver, 'test')
 
 
+class TestTable(testing.TestCase):
+
+    def test_table_with_duplicated_columns(self):
+        self.assertRaises(exceptions.CLIHalt, formatting.Table, ['col', 'col'])
+
+
 class TestFormatOutput(testing.TestCase):
 
     def test_format_output_string(self):


### PR DESCRIPTION
Resolves #744 