### PR TITLE
Empty all rules notes after push rules from SoftLayer.FirewallManager.get_dedicated_fwl_rules

### DIFF
--- a/SoftLayer/managers/firewall.py
+++ b/SoftLayer/managers/firewall.py
@@ -10,7 +10,7 @@ from SoftLayer import utils
 RULE_MASK = ('mask[orderValue,action,destinationIpAddress,'
              'destinationIpSubnetMask,protocol,destinationPortRangeStart,'
              'destinationPortRangeEnd,sourceIpAddress,sourceIpSubnetMask,'
-             'version]')
+             'version,notes]')
 
 
 def has_firewall(vlan):


### PR DESCRIPTION
If you use something like this to upload your rules, you will empty all rules notes:

```python
[...]
client = SoftLayer.create_client_from_env()
manager = SoftLayer.FirewallManager(client)

vlan = 1234  # your vlan number
firewalls = manager.get_firewalls()

vlan_firewall = [firewall for firewall in firewalls if firewall['vlanNumber'] == vlan][0]

# This output include notes.
# rules = vlan_firewall['firewallRules']

# This output do not include notes.
rules = list(manager.get_dedicated_fwl_rules(vlan_firewall['networkVlanFirewall']['id']))

output = manager.edit_dedicated_fwl_rules(vlan_firewall['networkVlanFirewall']['id'], rules)
```

To fix this use, you need to add notes to RULE_MASK in firewall manager.

