### PR TITLE
CLI: Makes the price shown more accurate for virtual and hardware detail

### DIFF
--- a/SoftLayer/CLI/hardware/detail.py
+++ b/SoftLayer/CLI/hardware/detail.py
@@ -81,10 +81,15 @@ def cli(env, identifier, passwords, price):
         table.add_row(['notes', result['notes']])
 
     if price:
-        table.add_row(['price rate',
-                       utils.lookup(result,
-                                    'billingItem',
-                                    'nextInvoiceTotalRecurringAmount')])
+        total_price = utils.lookup(result,
+                                   'billingItem',
+                                   'nextInvoiceTotalRecurringAmount') or 0
+        total_price += sum(p['nextInvoiceTotalRecurringAmount']
+                           for p
+                           in utils.lookup(result,
+                                           'billingItem',
+                                           'children') or [])
+        table.add_row(['price_rate', total_price])
 
     if passwords:
         pass_table = formatting.Table(['username', 'password'])

--- a/SoftLayer/CLI/virt/detail.py
+++ b/SoftLayer/CLI/virt/detail.py
@@ -81,8 +81,15 @@ def cli(env, identifier, passwords=False, price=False):
         table.add_row(['notes', result['notes']])
 
     if price:
-        table.add_row(['price rate',
-                       result['billingItem']['recurringFee']])
+        total_price = utils.lookup(result,
+                                   'billingItem',
+                                   'nextInvoiceTotalRecurringAmount') or 0
+        total_price += sum(p['nextInvoiceTotalRecurringAmount']
+                           for p
+                           in utils.lookup(result,
+                                           'billingItem',
+                                           'children') or [])
+        table.add_row(['price_rate', total_price])
 
     if passwords:
         pass_table = formatting.Table(['software', 'username', 'password'])

--- a/SoftLayer/fixtures/SoftLayer_Hardware_Server.py
+++ b/SoftLayer/fixtures/SoftLayer_Hardware_Server.py
@@ -7,6 +7,13 @@ getObject = {
         'id': 6327,
         'recurringFee': 1.54,
         'nextInvoiceTotalRecurringAmount': 16.08,
+        'children': [
+            {'nextInvoiceTotalRecurringAmount': 1},
+            {'nextInvoiceTotalRecurringAmount': 1},
+            {'nextInvoiceTotalRecurringAmount': 1},
+            {'nextInvoiceTotalRecurringAmount': 1},
+            {'nextInvoiceTotalRecurringAmount': 1},
+        ],
         'orderItem': {
             'order': {
                 'userRecord': {

--- a/SoftLayer/fixtures/SoftLayer_Virtual_Guest.py
+++ b/SoftLayer/fixtures/SoftLayer_Virtual_Guest.py
@@ -6,7 +6,14 @@ getObject = {
     'status': {'keyName': 'ACTIVE', 'name': 'Active'},
     'billingItem': {
         'id': 6327,
-        'recurringFee': 1.54,
+        'nextInvoiceTotalRecurringAmount': 1.54,
+        'children': [
+            {'nextInvoiceTotalRecurringAmount': 1},
+            {'nextInvoiceTotalRecurringAmount': 1},
+            {'nextInvoiceTotalRecurringAmount': 1},
+            {'nextInvoiceTotalRecurringAmount': 1},
+            {'nextInvoiceTotalRecurringAmount': 1},
+        ],
         'orderItem': {
             'order': {
                 'userRecord': {

--- a/SoftLayer/managers/hardware.py
+++ b/SoftLayer/managers/hardware.py
@@ -213,11 +213,14 @@ class HardwareManager(utils.IdentifierMixin, object):
                                                         version,
                                                         referenceCode]],
                     passwords[username,password]],'''
-                'billingItem.nextInvoiceTotalRecurringAmount,'
+                'billingItem['
+                'id,nextInvoiceTotalRecurringAmount,'
+                'children[nextInvoiceTotalRecurringAmount],'
+                'orderItem.order.userRecord[username]'
+                '],'
                 'hourlyBillingFlag,'
                 'tagReferences[id,tag[name,id]],'
                 'networkVlans[id,vlanNumber,networkSpace],'
-                'billingItem.orderItem.order.userRecord[username],'
                 'remoteManagementAccounts[username,password]'
             )
 

--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -214,10 +214,13 @@ class VSManager(utils.IdentifierMixin, object):
                                         referenceCode]]],'''
                 'hourlyBillingFlag,'
                 'userData,'
-                'billingItem.recurringFee,'
+                'billingItem['
+                'id,nextInvoiceTotalRecurringAmount,'
+                'children[categoryCode,nextInvoiceTotalRecurringAmount],'
+                'orderItem.order.userRecord[username]'
+                '],'
                 'tagReferences[id,tag[name,id]],'
-                'networkVlans[id,vlanNumber,networkSpace],'
-                'billingItem.orderItem.order.userRecord[username]'
+                'networkVlans[id,vlanNumber,networkSpace]'
             )
 
         return self.guest.getObject(id=instance_id, **kwargs)

--- a/tests/CLI/modules/server_tests.py
+++ b/tests/CLI/modules/server_tests.py
@@ -43,7 +43,7 @@ class ServerCLITests(testing.TestCase):
             'os': 'Ubuntu',
             'os_version': 'Ubuntu 12.04 LTS',
             'owner': 'chechu',
-            'price rate': 16.08,
+            'price_rate': 21.08,
             'private_ip': '10.1.0.2',
             'ptr': '2.0.1.10.in-addr.arpa',
             'public_ip': '172.16.1.100',

--- a/tests/CLI/modules/vs_tests.py
+++ b/tests/CLI/modules/vs_tests.py
@@ -52,7 +52,7 @@ class VirtTests(testing.TestCase):
                           'os': 'Ubuntu',
                           'os_version': '12.04-64 Minimal for VSI',
                           'notes': 'notes',
-                          'price rate': 1.54,
+                          'price_rate': 6.54,
                           'tags': ['production'],
                           'private_cpu': {},
                           'private_ip': '10.45.19.37',


### PR DESCRIPTION
Incorporates the child prices into the price for virtual and hardware detail.
This impacts:
	`slcli virtual detail [ID] --price`
	`slcli hardware detail [ID] --price`

It also adjusts the default masks for detailing hardware and virtual instances.


Side note: I am on the edge of removing this feature now and coming back to it later with more validation. The biggest issue that I have testing this is that I don't have a normal account and it makes testing parts of the API that have prices harder.

Resolves #749