### PR TITLE
Changes to File volume list and detail commands to display NFS MounPoint for Volumes

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -21,6 +21,7 @@ Ryan Hanson <ryan@megacosm.net>
 Scott Thompson <sthompson@softlayer.com>
 Sergio Carlos <carloschilazo@gmail.com>
 Shane Poage <spoage@softlayer.com>
+Shravan Kumar Raghu <sraghu@us.ibm.com>
 simplydave <dgjohns@gmail.com>
 SoftLayer <sldn@softlayer.com>
 suppandi <suppandi@gmail.com>

--- a/SoftLayer/CLI/file/detail.py
+++ b/SoftLayer/CLI/file/detail.py
@@ -55,6 +55,12 @@ def cli(env, volume_id):
         file_volume['serviceResourceBackendIpAddress'],
     ])
 
+    if file_volume['fileNetworkMountAddress']:
+        table.add_row([
+            'Mount Address',
+            file_volume['fileNetworkMountAddress'],
+        ])
+
     if file_volume['snapshotCapacityGb']:
         table.add_row([
             'Snapshot Capacity (GB)',

--- a/SoftLayer/CLI/file/list.py
+++ b/SoftLayer/CLI/file/list.py
@@ -27,6 +27,8 @@ COLUMNS = [
                          mask="serviceResourceBackendIpAddress"),
     column_helper.Column('active_transactions', ('activeTransactionCount',),
                          mask="activeTransactionCount"),
+    column_helper.Column('mount_addr', ('fileNetworkMountAddress',),
+                         mask="fileNetworkMountAddress",),
     column_helper.Column(
         'created_by',
         ('billingItem', 'orderItem', 'order', 'userRecord', 'username')),
@@ -40,7 +42,8 @@ DEFAULT_COLUMNS = [
     'capacity_gb',
     'bytes_used',
     'ip_addr',
-    'active_transactions'
+    'active_transactions',
+    'mount_addr'
 ]
 
 

--- a/SoftLayer/fixtures/SoftLayer_Account.py
+++ b/SoftLayer/fixtures/SoftLayer_Account.py
@@ -479,6 +479,7 @@ getNasNetworkStorage = [{
     'password': 'pass',
     'serviceResourceBackendIpAddress': '127.0.0.1',
     'storageType': {'keyName': 'ENDURANCE_STORAGE'},
+    'fileNetworkMountAddress': '127.0.0.1:/TEST',
 }]
 
 getActiveQuotes = [{

--- a/SoftLayer/fixtures/SoftLayer_Network_Storage.py
+++ b/SoftLayer/fixtures/SoftLayer_Network_Storage.py
@@ -31,6 +31,7 @@ getObject = {
     }],
     'serviceResource': {'datacenter': {'id': 449500, 'name': 'dal05'}},
     'serviceResourceBackendIpAddress': '10.1.2.3',
+    'fileNetworkMountAddress': '127.0.0.1:/TEST',
     'serviceResourceName': 'Storage Type 01 Aggregate staaspar0101_pc01',
     'username': 'username',
     'storageType': {'keyName': 'ENDURANCE_STORAGE'},

--- a/SoftLayer/managers/file.py
+++ b/SoftLayer/managers/file.py
@@ -35,7 +35,8 @@ class FileStorageManager(utils.IdentifierMixin, object):
                 'bytesUsed',
                 'serviceResource.datacenter[name]',
                 'serviceResourceBackendIpAddress',
-                'activeTransactionCount'
+                'activeTransactionCount',
+                'fileNetworkMountAddress'
             ]
             kwargs['mask'] = ','.join(items)
 
@@ -81,6 +82,7 @@ class FileStorageManager(utils.IdentifierMixin, object):
                 'storageType.keyName',
                 'serviceResource.datacenter[name]',
                 'serviceResourceBackendIpAddress',
+                'fileNetworkMountAddress',
                 'storageTierLevel',
                 'iops',
                 'lunId',

--- a/tests/CLI/modules/file_tests.py
+++ b/tests/CLI/modules/file_tests.py
@@ -86,7 +86,8 @@ class FileTests(testing.TestCase):
                 'ip_addr': '127.0.0.1',
                 'storage_type': 'ENDURANCE',
                 'username': 'user',
-                'active_transactions': None
+                'active_transactions': None,
+                'mount_addr': '127.0.0.1:/TEST'
             }],
             json.loads(result.output))
 
@@ -122,6 +123,7 @@ class FileTests(testing.TestCase):
             'Used Space': '0B',
             'Endurance Tier': '2 IOPS per GB',
             'IOPs': 1000,
+            'Mount Address': '127.0.0.1:/TEST',
             'Snapshot Capacity (GB)': '10',
             'Snapshot Used (Bytes)': 1024,
             'Capacity (GB)': '20GB',


### PR DESCRIPTION
This change would enable the `slcli file volume-list` and `slcli file volume-detail` commands to display the NFS Mount Point Address for each volume that it shows.
