### PR TITLE
Check the results from getNetworkStorage before using

### DIFF
--- a/SoftLayer/managers/object_storage.py
+++ b/SoftLayer/managers/object_storage.py
@@ -42,14 +42,17 @@ class ObjectStorageManager(object):
             'hubNetworkStorage': {'vendorName': {'operation': 'Swift'}},
         }
         endpoints = []
-        for node in self.client.call('Account', 'getHubNetworkStorage',
-                                     mask=ENDPOINT_MASK,
-                                     limit=1,
-                                     filter=_filter)['storageNodes']:
-            endpoints.append({
-                'datacenter': node['datacenter'],
-                'public': node['frontendIpAddress'],
-                'private': node['backendIpAddress'],
-            })
+        network_storage = self.client.call('Account',
+                                           'getHubNetworkStorage',
+                                           mask=ENDPOINT_MASK,
+                                           limit=1,
+                                           filter=_filter)
+        if network_storage:
+            for node in network_storage['storageNodes']:
+                endpoints.append({
+                    'datacenter': node['datacenter'],
+                    'public': node['frontendIpAddress'],
+                    'private': node['backendIpAddress'],
+                })
 
         return endpoints

--- a/tests/managers/object_storage_tests.py
+++ b/tests/managers/object_storage_tests.py
@@ -33,3 +33,12 @@ class ObjectStorageTests(testing.TestCase):
                          [{'datacenter': {'name': 'dal05'},
                            'private': 'https://dal05/auth/v1.0/',
                            'public': 'https://dal05/auth/v1.0/'}])
+
+    def test_list_endpoints_no_results(self):
+        accounts = self.set_mock('SoftLayer_Account', 'getHubNetworkStorage')
+        accounts.return_value = {
+            'storageNodes': [],
+        }
+        endpoints = self.object_storage.list_endpoints()
+        self.assertEqual(endpoints,
+                         [])


### PR DESCRIPTION
Check the results from SoftLayer_Account::getNetworkStorage before using the endpoints off of the first network storage that might be returned. Add test to ensure this behavior.