### PR TITLE
Add Python 3.6 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
       env: TOX_ENV=py34
     - python: "3.5"
       env: TOX_ENV=py35
+    - python: "3.6"
+      env: TOX_ENV=py36
     - python: "pypy"
       env: TOX_ENV=pypy
     - python: "2.7"

--- a/SoftLayer/CLI/formatting.py
+++ b/SoftLayer/CLI/formatting.py
@@ -48,7 +48,7 @@ def format_output(data, fmt='table'):  # pylint: disable=R0911,R0912
                 cls=CLIJSONEncoder)
         elif fmt == 'jsonraw':
             return json.dumps(format_output(data, fmt='python'),
-                              CLIJSONEncoder)
+                              cls=CLIJSONEncoder)
         elif fmt == 'python':
             return data.to_python()
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,pypy,analysis,coverage
+envlist = py27,py33,py34,py35,py36,pypy,analysis,coverage
 
 [testenv]
 deps = -r{toxinidir}/tools/test-requirements.txt


### PR DESCRIPTION
Adds Python 3.6 support by including it in the tox environments list, and updating travis configuration to use the tox environment. The `jsonraw` functionality missed using the `cls` keyword argument for the class to encode JSON with, so that has also been fixed so that tests in 3.6 pass.