### PR TITLE
Update slcli doc with new subcommands

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -58,48 +58,54 @@ To discover the available commands, simply type `slcli`.
 ::
 
 	$ slcli
-	Usage: slcli [OPTIONS] COMMAND [ARGS]...
-
-	  SoftLayer Command-line Client
-
-	Options:
-	  --format [table|raw|json]  Output format
-	  -C, --config PATH          Config file location
-	  --debug [0|1|2|3]          Sets the debug noise level
-	  -v, --verbose              Sets the debug noise level
-	  --timings                  Time each API call and display after results
-	  --proxy TEXT               HTTP[S] proxy to be use to make API calls
-	  -y, --really               Confirm all prompt actions
-	  --fixtures                 Use fixtures instead of actually making API calls
-	  --version                  Show the version and exit.
-	  --help                     Show this message and exit.
-
-	Commands:
-	  call-api   Call arbitrary API endpoints.
-	  cdn        Content Delivery Network.
-	  config     CLI configuration.
-	  dns        Domain Name System.
-	  firewall   Firewalls.
-	  globalip   Global IP addresses.
-	  image      Compute images.
-	  iscsi      iSCSI storage.
-	  loadbal    Load balancers.
-	  messaging  Message queue service.
-	  metadata   Find details about this machine.
-	  nas        Network Attached Storage.
-	  rwhois     Referral Whois.
-	  server     Hardware servers.
-	  snapshot   Snapshots.
-	  sshkey     SSH Keys.
-	  ssl        SSL Certificates.
-	  subnet     Network subnets.
-	  summary    Account summary.
-	  ticket     Support tickets.
-	  vlan       Network VLANs.
-	  vs         Virtual Servers.
-
-	  To use most commands your SoftLayer username and api_key need to be
-	  configured. The easiest way to do that is to use: 'slcli setup'
+        Usage: slcli [OPTIONS] COMMAND [ARGS]...
+        
+          SoftLayer Command-line Client
+        
+        Options:
+          --format [table|raw|json|jsonraw]
+                                          Output format  [default: table]
+          -C, --config PATH               Config file location  [default:
+                                          ~/.softlayer]
+          -v, --verbose                   Sets the debug noise level, specify multiple
+                                          times for more verbosity.
+          --proxy TEXT                    HTTP[S] proxy to be use to make API calls
+          -y, --really / --not-really     Confirm all prompt actions
+          --demo / --no-demo              Use demo data instead of actually making API
+                                          calls
+          --version                       Show the version and exit.
+          -h, --help                      Show this message and exit.
+        
+        Commands:
+          block           Block Storage.
+          call-api        Call arbitrary API endpoints.
+          cdn             Content Delivery Network.
+          config          CLI configuration.
+          dns             Domain Name System.
+          file            File Storage.
+          firewall        Firewalls.
+          globalip        Global IP addresses.
+          hardware        Hardware servers.
+          image           Compute images.
+          loadbal         Load balancers.
+          messaging       Message queue service.
+          metadata        Find details about this machine.
+          nas             Network Attached Storage.
+          object-storage  Object Storage.
+          report          Reports.
+          rwhois          Referral Whois.
+          setup           Edit configuration.
+          shell           Enters a shell for slcli.
+          sshkey          SSH Keys.
+          ssl             SSL Certificates.
+          subnet          Network subnets.
+          summary         Account summary.
+          ticket          Support tickets.
+          virtual         Virtual Servers.
+          vlan            Network VLANs.
+        
+          To use most commands your SoftLayer username and api_key need to be
+          configured. The easiest way to do that is to use: 'slcli setup'
 
 As you can see, there are a number of commands/sections. To look at the list of
 subcommands for virtual servers type `slcli vs`. For example:


### PR DESCRIPTION
The CLI doc still had some old commands in it, so those have been
removed. There have also been new commands added to slcli that weren't
reflected in the doc.