### PR TITLE
pinning pylint at 1.6.5 

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ basepython = python2.7
 deps =
     -r{toxinidir}/tools/test-requirements.txt
     hacking
-    pylint
+    pylint==1.6.5
 commands =
     flake8 SoftLayer tests
 


### PR DESCRIPTION
pinning pylint at 1.6.5 for now since >1.7 has a few new tests that need to be resolved now