### PR TITLE
STORAUTO-62 support for setting LUN ID on block volumes

### DIFF
--- a/SoftLayer/CLI/block/lun.py
+++ b/SoftLayer/CLI/block/lun.py
@@ -1,0 +1,36 @@
+"""Set the LUN ID on an iSCSI volume."""
+# :license: MIT, see LICENSE for more details.
+
+import click
+
+import SoftLayer
+from SoftLayer.CLI import environment
+
+
+@click.command()
+@click.argument('volume-id')
+@click.argument('lun-id')
+@environment.pass_env
+def cli(env, volume_id, lun_id):
+    """Set the LUN ID on an existing block storage volume.
+
+    The LUN ID only takes effect during the Host Authorization process. It is
+    recommended (but not necessary) to de-authorize all hosts before using this
+    method. See `block access-revoke`.
+
+    VOLUME_ID - the volume ID on which to set the LUN ID.
+
+    LUN_ID - recommended range is an integer between 0 and 255. Advanced users
+    can use an integer between 0 and 4095.
+    """
+
+    block_storage_manager = SoftLayer.BlockStorageManager(env.client)
+
+    res = block_storage_manager.create_or_update_lun_id(volume_id, lun_id)
+
+    if 'value' in res and lun_id == res['value']:
+        click.echo(
+            'Block volume with id %s is reporting LUN ID %s' % (res['volumeId'], res['value']))
+    else:
+        click.echo(
+            'Failed to confirm the new LUN ID on volume %s' % (volume_id))

--- a/SoftLayer/CLI/routes.py
+++ b/SoftLayer/CLI/routes.py
@@ -80,6 +80,7 @@ ALL_ROUTES = [
     ('block:volume-duplicate', 'SoftLayer.CLI.block.duplicate:cli'),
     ('block:volume-list', 'SoftLayer.CLI.block.list:cli'),
     ('block:volume-order', 'SoftLayer.CLI.block.order:cli'),
+    ('block:volume-set-lun-id', 'SoftLayer.CLI.block.lun:cli'),
 
     ('file', 'SoftLayer.CLI.file'),
     ('file:access-authorize', 'SoftLayer.CLI.file.access.authorize:cli'),

--- a/SoftLayer/managers/block.py
+++ b/SoftLayer/managers/block.py
@@ -547,7 +547,7 @@ class BlockStorageManager(utils.IdentifierMixin, object):
         """Failback from a volume replicant.
 
         :param integer volume_id: The id of the volume
-        :param integer: ID of replicant to failback from
+        :param integer replicant_id: ID of replicant to failback from
         :return: Returns whether failback was successful or not
         """
 
@@ -563,3 +563,13 @@ class BlockStorageManager(utils.IdentifierMixin, object):
 
         return self.client.call('Network_Storage_Allowed_Host', 'setCredentialPassword',
                                 password, id=access_id)
+
+    def create_or_update_lun_id(self, volume_id, lun_id):
+        """Set the LUN ID on a volume.
+
+        :param integer volume_id: The id of the volume
+        :param integer lun_id: LUN ID to set on the volume
+        :return: a SoftLayer_Network_Storage_Property object
+        """
+        return self.client.call('Network_Storage', 'createOrUpdateLunId',
+                                lun_id, id=volume_id)


### PR DESCRIPTION
This depends on FBLOCK-3 being released, but I would like to address any comments in the meantime so it can be ready to go when FBLOCK-3 is released.