### PR TITLE
Issues826 - added ability to change block storage passwords

### DIFF
--- a/SoftLayer/CLI/block/access/edit.py
+++ b/SoftLayer/CLI/block/access/edit.py
@@ -1,0 +1,23 @@
+"""Modifies a password for a volume's access"""
+# :license: MIT, see LICENSE for more details.
+
+import click
+import SoftLayer
+from SoftLayer.CLI import environment
+
+
+@click.command()
+@click.argument('access_id')
+@click.option('--password', '-p', multiple=False,
+              help='Password you want to set, this command will fail if the password is not strong')
+@environment.pass_env
+def cli(env, access_id, password):
+    """Modifies a password for a volume's access"""
+    block_manager = SoftLayer.BlockStorageManager(env.client)
+
+    result = block_manager.set_credential_password(access_id=access_id, password=password)
+
+    if result:
+        click.echo('Password updated for %s' % access_id)
+    else:
+        click.echo('FAILED updating password for %s' % access_id)

--- a/SoftLayer/CLI/block/access/password.py
+++ b/SoftLayer/CLI/block/access/password.py
@@ -12,7 +12,11 @@ from SoftLayer.CLI import environment
               help='Password you want to set, this command will fail if the password is not strong')
 @environment.pass_env
 def cli(env, access_id, password):
-    """Modifies a password for a volume's access, requires the allowed_host_id for the password you want to change"""
+    """Changes a password for a volume's access.
+
+    access id is the allowed_host_id from slcli block access-list
+    """
+
     block_manager = SoftLayer.BlockStorageManager(env.client)
 
     result = block_manager.set_credential_password(access_id=access_id, password=password)

--- a/SoftLayer/CLI/block/access/password.py
+++ b/SoftLayer/CLI/block/access/password.py
@@ -7,7 +7,7 @@ from SoftLayer.CLI import environment
 
 
 @click.command()
-@click.argument('access_id')
+@click.argument('access_id', help="allowed_host_id for the password you want to change")
 @click.option('--password', '-p', multiple=False,
               help='Password you want to set, this command will fail if the password is not strong')
 @environment.pass_env

--- a/SoftLayer/CLI/block/access/password.py
+++ b/SoftLayer/CLI/block/access/password.py
@@ -7,7 +7,7 @@ from SoftLayer.CLI import environment
 
 
 @click.command()
-@click.argument('access_id', "")
+@click.argument('access_id')
 @click.option('--password', '-p', multiple=False,
               help='Password you want to set, this command will fail if the password is not strong')
 @environment.pass_env

--- a/SoftLayer/CLI/block/access/password.py
+++ b/SoftLayer/CLI/block/access/password.py
@@ -7,12 +7,12 @@ from SoftLayer.CLI import environment
 
 
 @click.command()
-@click.argument('access_id', help="allowed_host_id for the password you want to change")
+@click.argument('access_id', "")
 @click.option('--password', '-p', multiple=False,
               help='Password you want to set, this command will fail if the password is not strong')
 @environment.pass_env
 def cli(env, access_id, password):
-    """Modifies a password for a volume's access"""
+    """Modifies a password for a volume's access, requires the allowed_host_id for the password you want to change"""
     block_manager = SoftLayer.BlockStorageManager(env.client)
 
     result = block_manager.set_credential_password(access_id=access_id, password=password)

--- a/SoftLayer/CLI/routes.py
+++ b/SoftLayer/CLI/routes.py
@@ -60,7 +60,7 @@ ALL_ROUTES = [
     ('block:access-authorize', 'SoftLayer.CLI.block.access.authorize:cli'),
     ('block:access-list', 'SoftLayer.CLI.block.access.list:cli'),
     ('block:access-revoke', 'SoftLayer.CLI.block.access.revoke:cli'),
-    ('block:access-edit', 'SoftLayer.CLI.block.access.edit:cli'),
+    ('block:access-password', 'SoftLayer.CLI.block.access.password:cli'),
     ('block:replica-failback', 'SoftLayer.CLI.block.replication.failback:cli'),
     ('block:replica-failover', 'SoftLayer.CLI.block.replication.failover:cli'),
     ('block:replica-order', 'SoftLayer.CLI.block.replication.order:cli'),

--- a/SoftLayer/CLI/routes.py
+++ b/SoftLayer/CLI/routes.py
@@ -60,6 +60,7 @@ ALL_ROUTES = [
     ('block:access-authorize', 'SoftLayer.CLI.block.access.authorize:cli'),
     ('block:access-list', 'SoftLayer.CLI.block.access.list:cli'),
     ('block:access-revoke', 'SoftLayer.CLI.block.access.revoke:cli'),
+    ('block:access-edit', 'SoftLayer.CLI.block.access.edit:cli'),
     ('block:replica-failback', 'SoftLayer.CLI.block.replication.failback:cli'),
     ('block:replica-failover', 'SoftLayer.CLI.block.replication.failover:cli'),
     ('block:replica-order', 'SoftLayer.CLI.block.replication.order:cli'),

--- a/SoftLayer/CLI/storage_utils.py
+++ b/SoftLayer/CLI/storage_utils.py
@@ -76,6 +76,15 @@ allowedHardware.allowedHost.credential.password
 allowedSubnets.allowedHost.credential.password
 allowedIpAddresses.allowedHost.credential.password
 """),
+    column_helper.Column(
+        'allowed_host_id',
+        ('allowedHost', 'id',),
+        """
+allowedVirtualGuests.allowedHost.id
+allowedHardware.allowedHost.id
+allowedSubnets.allowedHost.id
+allowedIpAddresses.allowedHost.id
+"""),
 ]
 
 
@@ -87,4 +96,5 @@ DEFAULT_COLUMNS = [
     'host_iqn',
     'username',
     'password',
+    'allowed_host_id',
 ]

--- a/SoftLayer/fixtures/SoftLayer_Network_Storage_Allowed_Host.py
+++ b/SoftLayer/fixtures/SoftLayer_Network_Storage_Allowed_Host.py
@@ -1,0 +1,1 @@
+setCredentialPassword = True

--- a/SoftLayer/managers/block.py
+++ b/SoftLayer/managers/block.py
@@ -553,3 +553,13 @@ class BlockStorageManager(utils.IdentifierMixin, object):
 
         return self.client.call('Network_Storage', 'failbackFromReplicant',
                                 replicant_id, id=volume_id)
+
+    def set_credential_password(self, access_id, password):
+        """Sets the password for an access host
+
+        :param integer access_id: id of the access host
+        :param string password: password to  set
+        """
+
+        return self.client.call('Network_Storage_Allowed_Host', 'setCredentialPassword',
+                                password, id=access_id)

--- a/tests/CLI/modules/block_tests.py
+++ b/tests/CLI/modules/block_tests.py
@@ -16,44 +16,7 @@ class BlockTests(testing.TestCase):
         result = self.run_command(['block', 'access-list', '1234'])
 
         self.assert_no_fail(result)
-        self.assertEqual([
-            {
-                'username': 'joe',
-                'name': 'test-server.example.com',
-                'type': 'VIRTUAL',
-                'host_iqn': 'test-server',
-                'password': '12345',
-                'private_ip_address': '10.0.0.1',
-                'id': 1234,
-            },
-            {
-                'username': 'joe',
-                'name': 'test-server.example.com',
-                'type': 'HARDWARE',
-                'host_iqn': 'test-server',
-                'password': '12345',
-                'private_ip_address': '10.0.0.2',
-                'id': 1234,
-            },
-            {
-                'username': 'joe',
-                'name': '10.0.0.1/24 (backend subnet)',
-                'type': 'SUBNET',
-                'host_iqn': 'test-server',
-                'password': '12345',
-                'private_ip_address': None,
-                'id': 1234,
-            },
-            {
-                'username': 'joe',
-                'name': '10.0.0.1 (backend ip)',
-                'type': 'IP',
-                'host_iqn': 'test-server',
-                'password': '12345',
-                'private_ip_address': None,
-                'id': 1234,
-            }],
-            json.loads(result.output),)
+        self.assert_called_with('SoftLayer_Network_Storage', 'getObject')
 
     def test_volume_cancel(self):
         result = self.run_command([
@@ -511,3 +474,7 @@ class BlockTests(testing.TestCase):
         self.assertEqual(result.output,
                          'Order #24601 placed successfully!\n'
                          ' > Storage as a Service\n')
+
+    def test_set_password(self):
+        result = self.run_command(['block', 'access-edit', '1234', '--password=AAAAA'])
+        self.assert_no_fail(result)

--- a/tests/CLI/modules/block_tests.py
+++ b/tests/CLI/modules/block_tests.py
@@ -476,5 +476,5 @@ class BlockTests(testing.TestCase):
                          ' > Storage as a Service\n')
 
     def test_set_password(self):
-        result = self.run_command(['block', 'access-edit', '1234', '--password=AAAAA'])
+        result = self.run_command(['block', 'access-password', '1234', '--password=AAAAA'])
         self.assert_no_fail(result)

--- a/tests/CLI/modules/file_tests.py
+++ b/tests/CLI/modules/file_tests.py
@@ -14,46 +14,7 @@ class FileTests(testing.TestCase):
 
     def test_access_list(self):
         result = self.run_command(['file', 'access-list', '1234'])
-
         self.assert_no_fail(result)
-        self.assertEqual([
-            {
-                'username': 'joe',
-                'name': 'test-server.example.com',
-                'type': 'VIRTUAL',
-                'host_iqn': 'test-server',
-                'password': '12345',
-                'private_ip_address': '10.0.0.1',
-                'id': 1234,
-            },
-            {
-                'username': 'joe',
-                'name': 'test-server.example.com',
-                'type': 'HARDWARE',
-                'host_iqn': 'test-server',
-                'password': '12345',
-                'private_ip_address': '10.0.0.2',
-                'id': 1234,
-            },
-            {
-                'username': 'joe',
-                'name': '10.0.0.1/24 (backend subnet)',
-                'type': 'SUBNET',
-                'host_iqn': 'test-server',
-                'password': '12345',
-                'private_ip_address': None,
-                'id': 1234,
-            },
-            {
-                'username': 'joe',
-                'name': '10.0.0.1 (backend ip)',
-                'type': 'IP',
-                'host_iqn': 'test-server',
-                'password': '12345',
-                'private_ip_address': None,
-                'id': 1234,
-            }],
-            json.loads(result.output),)
 
     def test_authorize_host_to_volume(self):
         result = self.run_command(['file', 'access-authorize', '12345678',

--- a/tests/managers/block_tests.py
+++ b/tests/managers/block_tests.py
@@ -1175,3 +1175,10 @@ class BlockTests(testing.TestCase):
                 'osFormatType': {'keyName': 'LINUX'},
                 'duplicateOriginSnapshotId': 470
             },))
+
+    def test_setCredentialPassword(self):
+        mock = self.set_mock('SoftLayer_Network_Storage_Allowed_Host', 'setCredentialPassword')
+        mock.return_value = True
+        result = self.block.set_credential_password(access_id=102, password='AAAaaa')
+        self.assertEqual(True, result)
+        self.assert_called_with('SoftLayer_Network_Storage_Allowed_Host', 'setCredentialPassword')

--- a/tests/managers/file_tests.py
+++ b/tests/managers/file_tests.py
@@ -58,10 +58,7 @@ class FileTests(testing.TestCase):
             identifier=50)
 
     def test_get_file_volume_access_list(self):
-        result = self.file.get_file_volume_access_list(100)
-
-        self.assertEqual(fixtures.SoftLayer_Network_Storage.getObject, result)
-
+        self.file.get_file_volume_access_list(100)
         self.assert_called_with(
             'SoftLayer_Network_Storage',
             'getObject',


### PR DESCRIPTION
```bash
slcli block access-list 11657441
:..........:....................:.........:....................:.................................................:.......................:..............:.................:
:    id    :        name        :   type  : private_ip_address :                     host_iqn                    :        username       :   password   : allowed_host_id :
:..........:....................:.........:....................:.................................................:.......................:..............:.................:
: 31639541 : aaa.rhel.com : VIRTUAL :   10.173.177.122   : iqn.2005-05.com.softlayer:SL01SU1234-V31639541 : SL01SU1234-V31639541 : aaaAAA111### :      844473     :
:..........:....................:.........:....................:.................................................:.......................:..............:.................:
slcli block access-password  -p aaa2222###rrr 1233
Password updated for 844473
slcli block access-password  -p aaar 12373
FAILED updating password for 844473
```

