### PR TITLE
Add support for dedicated host instances to virtual server upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ build/*
 dist/*
 *.egg-info
 .cache
-
+.idea

--- a/SoftLayer/fixtures/SoftLayer_Virtual_Guest.py
+++ b/SoftLayer/fixtures/SoftLayer_Virtual_Guest.py
@@ -252,3 +252,85 @@ reloadOperatingSystem = 'OK'
 setTags = True
 createArchiveTransaction = {}
 executeRescueLayer = True
+
+getUpgradeItemPrices = [
+    {
+        'id': 1007,
+        'categories': [{'id': 80,
+                        'name': 'Computing Instance',
+                        'categoryCode': 'guest_core'}],
+        'item': {
+            'capacity': '4',
+            'units': 'PRIVATE_CORE',
+            'description': 'Computing Instance (Dedicated)',
+        }
+    },
+    {
+        'id': 1144,
+        'locationGroupId': None,
+        'categories': [{'id': 80,
+                        'name': 'Computing Instance',
+                        'categoryCode': 'guest_core'}],
+        'item': {
+            'capacity': '4',
+            'units': 'CORE',
+            'description': 'Computing Instance',
+        }
+    },
+    {
+        'id': 332211,
+        'locationGroupId': 1,
+        'categories': [{'id': 80,
+                        'name': 'Computing Instance',
+                        'categoryCode': 'guest_core'}],
+        'item': {
+            'capacity': '4',
+            'units': 'CORE',
+            'description': 'Computing Instance',
+        }
+    },
+    {
+        'id': 1122,
+        'categories': [{'id': 26,
+                        'name': 'Uplink Port Speeds',
+                        'categoryCode': 'port_speed'}],
+        'item': {
+            'capacity': '1000',
+            'description': 'Public & Private Networks',
+        }
+    },
+    {
+        'id': 1144,
+        'categories': [{'id': 26,
+                        'name': 'Uplink Port Speeds',
+                        'categoryCode': 'port_speed'}],
+        'item': {
+            'capacity': '1000',
+            'description': 'Private Networks',
+        }
+    },
+    {
+        'id': 1133,
+        'categories': [{'id': 3,
+                        'name': 'RAM',
+                        'categoryCode': 'ram'}],
+        'item': {
+            'capacity': '2',
+            'description': 'RAM',
+        }
+    },
+]
+
+DEDICATED_GET_UPGRADE_ITEM_PRICES = [
+    {
+        'id': 115566,
+        'categories': [{'id': 80,
+                        'name': 'Computing Instance',
+                        'categoryCode': 'guest_core'}],
+        'item': {
+            'capacity': '4',
+            'units': 'DEDICATED_CORE',
+            'description': 'Computing Instance (Dedicated Host)',
+        }
+    },
+]

--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -816,7 +816,12 @@ class VSManager(utils.IdentifierMixin, object):
         return False
 
     def _get_package_items(self):
-        """Following Method gets all the item ids related to VS."""
+        """Following Method gets all the item ids related to VS.
+
+        Deprecated in favor of _get_upgrade_prices()
+        """
+        warnings.warn("use _get_upgrade_prices() instead",
+                      DeprecationWarning)
         mask = [
             'description',
             'capacity',
@@ -834,7 +839,7 @@ class VSManager(utils.IdentifierMixin, object):
         package_service = self.client['Product_Package']
         return package_service.getItems(id=package['id'], mask=mask)
 
-    def _get_upgrade_prices(self, instance_id):
+    def _get_upgrade_prices(self, instance_id, include_downgrade_options=True):
         """Following Method gets all the price ids related to upgrading a VS.
 
         :param int instance_id: Instance id of the VS to be upgraded
@@ -848,7 +853,7 @@ class VSManager(utils.IdentifierMixin, object):
             'item[description,capacity,units]'
         ]
         mask = "mask[%s]" % ','.join(mask)
-        return self.guest.getUpgradeItemPrices(id=instance_id, mask=mask)
+        return self.guest.getUpgradeItemPrices(include_downgrade_options, id=instance_id, mask=mask)
 
     def _get_price_id_for_upgrade_option(self, upgrade_prices, option, value,
                                          public=True):

--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -9,6 +9,7 @@ import datetime
 import itertools
 import socket
 import time
+import warnings
 
 from SoftLayer import exceptions
 from SoftLayer.managers import ordering
@@ -901,6 +902,8 @@ class VSManager(utils.IdentifierMixin, object):
         :param int value: The value of the parameter to be upgraded
         :param bool public: CPU will be in Private/Public Node.
         """
+        warnings.warn("use _get_price_id_for_upgrade_option() instead",
+                      DeprecationWarning)
         option_category = {
             'memory': 'ram',
             'cpus': 'guest_core',

--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -789,9 +789,9 @@ class VSManager(utils.IdentifierMixin, object):
             if not value:
                 continue
             price_id = self._get_price_id_for_upgrade_option(upgrade_prices,
-                                                      option,
-                                                      value,
-                                                      public)
+                                                             option,
+                                                             value,
+                                                             public)
             if not price_id:
                 # Every option provided is expected to have a price
                 raise exceptions.SoftLayerError(
@@ -851,7 +851,7 @@ class VSManager(utils.IdentifierMixin, object):
         return self.guest.getUpgradeItemPrices(id=instance_id, mask=mask)
 
     def _get_price_id_for_upgrade_option(self, upgrade_prices, option, value,
-                                  public=True):
+                                         public=True):
         """Find the price id for the option and value to upgrade. This
 
         :param list upgrade_prices: Contains all the prices related to a VS upgrade


### PR DESCRIPTION
Changing to use SL_Virtual_Guest.getUpgradeItemPrices which returns only the prices available for upgrade. This allows for upgrading without duplicating business logic in the client.