### PR TITLE
STAAS (File and Block) Hourly billing changes

### DIFF
--- a/SoftLayer/CLI/block/duplicate.py
+++ b/SoftLayer/CLI/block/duplicate.py
@@ -49,14 +49,22 @@ CONTEXT_SETTINGS = {'token_normalize_func': lambda x: x.upper()}
               type=int,
               help='The size of snapshot space to order for the duplicate. '
                    '***If no snapshot space size is specified, the snapshot '
-                   'space size of the origin volume will be used.***\n'
+                   'space size of the origin block volume will be used.***\n'
                    'Input "0" for this parameter to order a duplicate volume '
                    'with no snapshot space.')
+@click.option('--billing',
+              type=click.Choice(['hourly', 'monthly']),
+              default='monthly',
+              help="Optional parameter for Billing rate (default to monthly)")
 @environment.pass_env
 def cli(env, origin_volume_id, origin_snapshot_id, duplicate_size,
-        duplicate_iops, duplicate_tier, duplicate_snapshot_size):
+        duplicate_iops, duplicate_tier, duplicate_snapshot_size, billing):
     """Order a duplicate block storage volume."""
     block_manager = SoftLayer.BlockStorageManager(env.client)
+
+    hourly_billing_flag = False
+    if billing.lower() == "hourly":
+        hourly_billing_flag = True
 
     if duplicate_tier is not None:
         duplicate_tier = float(duplicate_tier)
@@ -68,7 +76,8 @@ def cli(env, origin_volume_id, origin_snapshot_id, duplicate_size,
             duplicate_size=duplicate_size,
             duplicate_iops=duplicate_iops,
             duplicate_tier_level=duplicate_tier,
-            duplicate_snapshot_size=duplicate_snapshot_size
+            duplicate_snapshot_size=duplicate_snapshot_size,
+            hourly_billing_flag=hourly_billing_flag
         )
     except ValueError as ex:
         raise exceptions.ArgumentError(str(ex))

--- a/SoftLayer/CLI/block/order.py
+++ b/SoftLayer/CLI/block/order.py
@@ -56,12 +56,26 @@ CONTEXT_SETTINGS = {'token_normalize_func': lambda x: x.upper()}
                   'storage_as_a_service',
                   'enterprise',
                   'performance']))
+@click.option('--billing',
+              type=click.Choice(['hourly', 'monthly']),
+              default='monthly',
+              help="Optional parameter for Billing rate (default to monthly)")
 @environment.pass_env
 def cli(env, storage_type, size, iops, tier, os_type,
-        location, snapshot_size, service_offering):
+        location, snapshot_size, service_offering, billing):
     """Order a block storage volume."""
     block_manager = SoftLayer.BlockStorageManager(env.client)
     storage_type = storage_type.lower()
+
+    hourly_billing_flag = False
+    if billing.lower() == "hourly":
+        hourly_billing_flag = True
+
+    if hourly_billing_flag and service_offering != 'storage_as_a_service':
+        raise exceptions.CLIAbort(
+            'Hourly billing is only available for the storage_as_a_service '
+            'service offering'
+        )
 
     if storage_type == 'performance':
         if iops is None:
@@ -87,7 +101,8 @@ def cli(env, storage_type, size, iops, tier, os_type,
                 iops=iops,
                 os_type=os_type,
                 snapshot_size=snapshot_size,
-                service_offering=service_offering
+                service_offering=service_offering,
+                hourly_billing_flag=hourly_billing_flag
             )
         except ValueError as ex:
             raise exceptions.ArgumentError(str(ex))
@@ -107,7 +122,8 @@ def cli(env, storage_type, size, iops, tier, os_type,
                 tier_level=float(tier),
                 os_type=os_type,
                 snapshot_size=snapshot_size,
-                service_offering=service_offering
+                service_offering=service_offering,
+                hourly_billing_flag=hourly_billing_flag
             )
         except ValueError as ex:
             raise exceptions.ArgumentError(str(ex))

--- a/SoftLayer/CLI/file/duplicate.py
+++ b/SoftLayer/CLI/file/duplicate.py
@@ -45,14 +45,22 @@ CONTEXT_SETTINGS = {'token_normalize_func': lambda x: x.upper()}
               type=int,
               help='The size of snapshot space to order for the duplicate. '
                    '***If no snapshot space size is specified, the snapshot '
-                   'space size of the origin volume will be used.***\n'
+                   'space size of the origin file volume will be used.***\n'
                    'Input "0" for this parameter to order a duplicate volume '
                    'with no snapshot space.')
+@click.option('--billing',
+              type=click.Choice(['hourly', 'monthly']),
+              default='monthly',
+              help="Optional parameter for Billing rate (default to monthly)")
 @environment.pass_env
 def cli(env, origin_volume_id, origin_snapshot_id, duplicate_size,
-        duplicate_iops, duplicate_tier, duplicate_snapshot_size):
+        duplicate_iops, duplicate_tier, duplicate_snapshot_size, billing):
     """Order a duplicate file storage volume."""
     file_manager = SoftLayer.FileStorageManager(env.client)
+
+    hourly_billing_flag = False
+    if billing.lower() == "hourly":
+        hourly_billing_flag = True
 
     if duplicate_tier is not None:
         duplicate_tier = float(duplicate_tier)
@@ -64,7 +72,8 @@ def cli(env, origin_volume_id, origin_snapshot_id, duplicate_size,
             duplicate_size=duplicate_size,
             duplicate_iops=duplicate_iops,
             duplicate_tier_level=duplicate_tier,
-            duplicate_snapshot_size=duplicate_snapshot_size
+            duplicate_snapshot_size=duplicate_snapshot_size,
+            hourly_billing_flag=hourly_billing_flag
         )
     except ValueError as ex:
         raise exceptions.ArgumentError(str(ex))

--- a/SoftLayer/CLI/file/order.py
+++ b/SoftLayer/CLI/file/order.py
@@ -44,12 +44,26 @@ CONTEXT_SETTINGS = {'token_normalize_func': lambda x: x.upper()}
                   'storage_as_a_service',
                   'enterprise',
                   'performance']))
+@click.option('--billing',
+              type=click.Choice(['hourly', 'monthly']),
+              default='monthly',
+              help="Optional parameter for Billing rate (default to monthly)")
 @environment.pass_env
 def cli(env, storage_type, size, iops, tier,
-        location, snapshot_size, service_offering):
+        location, snapshot_size, service_offering, billing):
     """Order a file storage volume."""
     file_manager = SoftLayer.FileStorageManager(env.client)
     storage_type = storage_type.lower()
+
+    hourly_billing_flag = False
+    if billing.lower() == "hourly":
+        hourly_billing_flag = True
+
+    if hourly_billing_flag and service_offering != 'storage_as_a_service':
+        raise exceptions.CLIAbort(
+            'Hourly billing is only available for the storage_as_a_service '
+            'service offering'
+        )
 
     if storage_type == 'performance':
         if iops is None:
@@ -74,7 +88,8 @@ def cli(env, storage_type, size, iops, tier,
                 size=size,
                 iops=iops,
                 snapshot_size=snapshot_size,
-                service_offering=service_offering
+                service_offering=service_offering,
+                hourly_billing_flag=hourly_billing_flag
             )
         except ValueError as ex:
             raise exceptions.ArgumentError(str(ex))
@@ -93,7 +108,8 @@ def cli(env, storage_type, size, iops, tier,
                 size=size,
                 tier_level=float(tier),
                 snapshot_size=snapshot_size,
-                service_offering=service_offering
+                service_offering=service_offering,
+                hourly_billing_flag=hourly_billing_flag
             )
         except ValueError as ex:
             raise exceptions.ArgumentError(str(ex))

--- a/SoftLayer/fixtures/SoftLayer_Network_Storage.py
+++ b/SoftLayer/fixtures/SoftLayer_Network_Storage.py
@@ -10,6 +10,7 @@ STAAS_TEST_VOLUME = {
         }],
         'cancellationDate': '',
         'categoryCode': 'storage_as_a_service',
+        'hourlyFlag': None,
         'id': 454,
         'location': {'id': 449500}
     },

--- a/SoftLayer/managers/block.py
+++ b/SoftLayer/managers/block.py
@@ -234,9 +234,10 @@ class BlockStorageManager(utils.IdentifierMixin, object):
         :return: Returns a SoftLayer_Container_Product_Order_Receipt
         """
 
-        block_mask = 'billingItem[activeChildren],storageTierLevel,osType,'\
-                     'staasVersion,hasEncryptionAtRest,snapshotCapacityGb,'\
-                     'schedules,hourlySchedule,dailySchedule,weeklySchedule,'\
+        block_mask = 'billingItem[activeChildren,hourlyFlag],'\
+                     'storageTierLevel,osType,staasVersion,'\
+                     'hasEncryptionAtRest,snapshotCapacityGb,schedules,'\
+                     'hourlySchedule,dailySchedule,weeklySchedule,'\
                      'storageType[keyName],provisionedIops'
         block_volume = self.get_block_volume_details(volume_id,
                                                      mask=block_mask)
@@ -261,7 +262,8 @@ class BlockStorageManager(utils.IdentifierMixin, object):
     def order_duplicate_volume(self, origin_volume_id, origin_snapshot_id=None,
                                duplicate_size=None, duplicate_iops=None,
                                duplicate_tier_level=None,
-                               duplicate_snapshot_size=None):
+                               duplicate_snapshot_size=None,
+                               hourly_billing_flag=False):
         """Places an order for a duplicate block volume.
 
         :param origin_volume_id: The ID of the origin volume to be duplicated
@@ -270,10 +272,12 @@ class BlockStorageManager(utils.IdentifierMixin, object):
         :param duplicate_iops: The IOPS per GB for the duplicate volume
         :param duplicate_tier_level: Tier level for the duplicate volume
         :param duplicate_snapshot_size: Snapshot space size for the duplicate
+        :param hourly_billing_flag: Billing type, monthly (False)
+            or hourly (True), default to monthly.
         :return: Returns a SoftLayer_Container_Product_Order_Receipt
         """
 
-        block_mask = 'id,billingItem[location],snapshotCapacityGb,'\
+        block_mask = 'id,billingItem[location,hourlyFlag],snapshotCapacityGb,'\
                      'storageType[keyName],capacityGb,originalVolumeSize,'\
                      'provisionedIops,storageTierLevel,osType[keyName],'\
                      'staasVersion,hasEncryptionAtRest'
@@ -288,7 +292,8 @@ class BlockStorageManager(utils.IdentifierMixin, object):
 
         order = storage_utils.prepare_duplicate_order_object(
             self, origin_volume, duplicate_iops, duplicate_tier_level,
-            duplicate_size, duplicate_snapshot_size, 'block'
+            duplicate_size, duplicate_snapshot_size, 'block',
+            hourly_billing_flag
         )
 
         order['osFormatType'] = {'keyName': os_type}
@@ -308,7 +313,8 @@ class BlockStorageManager(utils.IdentifierMixin, object):
 
     def order_block_volume(self, storage_type, location, size, os_type,
                            iops=None, tier_level=None, snapshot_size=None,
-                           service_offering='storage_as_a_service'):
+                           service_offering='storage_as_a_service',
+                           hourly_billing_flag=False):
         """Places an order for a block volume.
 
         :param storage_type: 'performance' or 'endurance'
@@ -321,10 +327,12 @@ class BlockStorageManager(utils.IdentifierMixin, object):
             if snapshot space should also be ordered (None if not ordered)
         :param service_offering: Requested offering package to use in the order
             ('storage_as_a_service', 'enterprise', or 'performance')
+        :param hourly_billing_flag: Billing type, monthly (False)
+            or hourly (True), default to monthly.
         """
         order = storage_utils.prepare_volume_order_object(
             self, storage_type, location, size, iops, tier_level,
-            snapshot_size, service_offering, 'block'
+            snapshot_size, service_offering, 'block', hourly_billing_flag
         )
 
         order['osFormatType'] = {'keyName': os_type}
@@ -352,8 +360,9 @@ class BlockStorageManager(utils.IdentifierMixin, object):
         :param boolean upgrade: Flag to indicate if this order is an upgrade
         :return: Returns a SoftLayer_Container_Product_Order_Receipt
         """
-        block_mask = 'id,billingItem[location],storageType[keyName],'\
-            'storageTierLevel,provisionedIops,staasVersion,hasEncryptionAtRest'
+        block_mask = 'id,billingItem[location,hourlyFlag],'\
+            'storageType[keyName],storageTierLevel,provisionedIops,'\
+            'staasVersion,hasEncryptionAtRest'
         block_volume = self.get_block_volume_details(volume_id,
                                                      mask=block_mask,
                                                      **kwargs)
@@ -376,7 +385,7 @@ class BlockStorageManager(utils.IdentifierMixin, object):
 
         block_volume = self.get_block_volume_details(
             volume_id,
-            mask='mask[id,billingItem[activeChildren]]')
+            mask='mask[id,billingItem[activeChildren,hourlyFlag]]')
 
         if 'activeChildren' not in block_volume['billingItem']:
             raise exceptions.SoftLayerError(
@@ -393,6 +402,9 @@ class BlockStorageManager(utils.IdentifierMixin, object):
         if not billing_item_id:
             raise exceptions.SoftLayerError(
                 'No snapshot space found to cancel')
+
+        if utils.lookup(block_volume, 'billingItem', 'hourlyFlag'):
+            immediate = True
 
         return self.client['Billing_Item'].cancelItem(
             immediate,
@@ -456,8 +468,11 @@ class BlockStorageManager(utils.IdentifierMixin, object):
         """
         block_volume = self.get_block_volume_details(
             volume_id,
-            mask='mask[id,billingItem[id]]')
+            mask='mask[id,billingItem[id,hourlyFlag]]')
         billing_item_id = block_volume['billingItem']['id']
+
+        if utils.lookup(block_volume, 'billingItem', 'hourlyFlag'):
+            immediate = True
 
         return self.client['Billing_Item'].cancelItem(
             immediate,

--- a/SoftLayer/managers/file.py
+++ b/SoftLayer/managers/file.py
@@ -213,9 +213,10 @@ class FileStorageManager(utils.IdentifierMixin, object):
         :return: Returns a SoftLayer_Container_Product_Order_Receipt
         """
 
-        file_mask = 'billingItem[activeChildren],storageTierLevel,'\
-                    'staasVersion,hasEncryptionAtRest,snapshotCapacityGb,'\
-                    'schedules,hourlySchedule,dailySchedule,weeklySchedule,'\
+        file_mask = 'billingItem[activeChildren,hourlyFlag],'\
+                    'storageTierLevel,staasVersion,'\
+                    'hasEncryptionAtRest,snapshotCapacityGb,schedules,'\
+                    'hourlySchedule,dailySchedule,weeklySchedule,'\
                     'storageType[keyName],provisionedIops'
         file_volume = self.get_file_volume_details(volume_id,
                                                    mask=file_mask)
@@ -249,7 +250,8 @@ class FileStorageManager(utils.IdentifierMixin, object):
     def order_duplicate_volume(self, origin_volume_id, origin_snapshot_id=None,
                                duplicate_size=None, duplicate_iops=None,
                                duplicate_tier_level=None,
-                               duplicate_snapshot_size=None):
+                               duplicate_snapshot_size=None,
+                               hourly_billing_flag=False):
         """Places an order for a duplicate file volume.
 
         :param origin_volume_id: The ID of the origin volume to be duplicated
@@ -258,10 +260,12 @@ class FileStorageManager(utils.IdentifierMixin, object):
         :param duplicate_iops: The IOPS per GB for the duplicate volume
         :param duplicate_tier_level: Tier level for the duplicate volume
         :param duplicate_snapshot_size: Snapshot space size for the duplicate
+        :param hourly_billing_flag: Billing type, monthly (False)
+            or hourly (True), default to monthly.
         :return: Returns a SoftLayer_Container_Product_Order_Receipt
         """
 
-        file_mask = 'id,billingItem[location],snapshotCapacityGb,'\
+        file_mask = 'id,billingItem[location,hourlyFlag],snapshotCapacityGb,'\
                     'storageType[keyName],capacityGb,originalVolumeSize,'\
                     'provisionedIops,storageTierLevel,'\
                     'staasVersion,hasEncryptionAtRest'
@@ -270,7 +274,8 @@ class FileStorageManager(utils.IdentifierMixin, object):
 
         order = storage_utils.prepare_duplicate_order_object(
             self, origin_volume, duplicate_iops, duplicate_tier_level,
-            duplicate_size, duplicate_snapshot_size, 'file'
+            duplicate_size, duplicate_snapshot_size, 'file',
+            hourly_billing_flag
         )
 
         if origin_snapshot_id is not None:
@@ -288,7 +293,8 @@ class FileStorageManager(utils.IdentifierMixin, object):
 
     def order_file_volume(self, storage_type, location, size,
                           iops=None, tier_level=None, snapshot_size=None,
-                          service_offering='storage_as_a_service'):
+                          service_offering='storage_as_a_service',
+                          hourly_billing_flag=False):
         """Places an order for a file volume.
 
         :param storage_type: 'performance' or 'endurance'
@@ -300,10 +306,12 @@ class FileStorageManager(utils.IdentifierMixin, object):
             if snapshot space should also be ordered (None if not ordered)
         :param service_offering: Requested offering package to use in the order
             ('storage_as_a_service', 'enterprise', or 'performance')
+        :param hourly_billing_flag: Billing type, monthly (False)
+            or hourly (True), default to monthly.
         """
         order = storage_utils.prepare_volume_order_object(
             self, storage_type, location, size, iops, tier_level,
-            snapshot_size, service_offering, 'file'
+            snapshot_size, service_offering, 'file', hourly_billing_flag
         )
 
         return self.client.call('Product_Order', 'placeOrder', order)
@@ -367,8 +375,9 @@ class FileStorageManager(utils.IdentifierMixin, object):
         :param boolean upgrade: Flag to indicate if this order is an upgrade
         :return: Returns a SoftLayer_Container_Product_Order_Receipt
         """
-        file_mask = 'id,billingItem[location],storageType[keyName],'\
-            'storageTierLevel,provisionedIops,staasVersion,hasEncryptionAtRest'
+        file_mask = 'id,billingItem[location,hourlyFlag],'\
+            'storageType[keyName],storageTierLevel,provisionedIops,'\
+            'staasVersion,hasEncryptionAtRest'
         file_volume = self.get_file_volume_details(volume_id,
                                                    mask=file_mask,
                                                    **kwargs)
@@ -391,7 +400,7 @@ class FileStorageManager(utils.IdentifierMixin, object):
 
         file_volume = self.get_file_volume_details(
             volume_id,
-            mask='mask[id,billingItem[activeChildren]]')
+            mask='mask[id,billingItem[activeChildren,hourlyFlag]]')
 
         if 'activeChildren' not in file_volume['billingItem']:
             raise exceptions.SoftLayerError(
@@ -408,6 +417,9 @@ class FileStorageManager(utils.IdentifierMixin, object):
         if not billing_item_id:
             raise exceptions.SoftLayerError(
                 'No snapshot space found to cancel')
+
+        if utils.lookup(file_volume, 'billingItem', 'hourlyFlag'):
+            immediate = True
 
         return self.client['Billing_Item'].cancelItem(
             immediate,
@@ -438,8 +450,11 @@ class FileStorageManager(utils.IdentifierMixin, object):
         """
         file_volume = self.get_file_volume_details(
             volume_id,
-            mask='mask[id,billingItem[id]]')
+            mask='mask[id,billingItem[id,hourlyFlag]]')
         billing_item_id = file_volume['billingItem']['id']
+
+        if utils.lookup(file_volume, 'billingItem', 'hourlyFlag'):
+            immediate = True
 
         return self.client['Billing_Item'].cancelItem(
             immediate,

--- a/SoftLayer/managers/storage_utils.py
+++ b/SoftLayer/managers/storage_utils.py
@@ -581,6 +581,11 @@ def prepare_snapshot_order_object(manager, volume, capacity, tier, upgrade):
         complex_type = 'SoftLayer_Container_Product_Order_'\
                        'Network_Storage_Enterprise_SnapshotSpace'
 
+    # Determine if hourly billing should be used
+    hourly_billing_flag = utils.lookup(volume, 'billingItem', 'hourlyFlag')
+    if hourly_billing_flag is None:
+        hourly_billing_flag = False
+
     # Build and return the order object
     snapshot_space_order = {
         'complexType': complex_type,
@@ -588,15 +593,16 @@ def prepare_snapshot_order_object(manager, volume, capacity, tier, upgrade):
         'prices': prices,
         'quantity': 1,
         'location': volume['billingItem']['location']['id'],
-        'volumeId': volume['id']
+        'volumeId': volume['id'],
+        'useHourlyPricing': hourly_billing_flag
     }
 
     return snapshot_space_order
 
 
 def prepare_volume_order_object(manager, storage_type, location, size,
-                                iops, tier, snapshot_size,
-                                service_offering, volume_type):
+                                iops, tier, snapshot_size, service_offering,
+                                volume_type, hourly_billing_flag=False):
     """Prepare the order object which is submitted to the placeOrder() method
 
     :param manager: The File or Block manager calling this function
@@ -608,6 +614,7 @@ def prepare_volume_order_object(manager, storage_type, location, size,
     :param snapshot_size: The size of snapshot space for the volume (optional)
     :param service_offering: Requested offering package to use for the order
     :param volume_type: The type of the volume to order ('file' or 'block')
+    :param hourly_billing_flag: Billing type, monthly (False) or hourly (True)
     :return: Returns the order object for the
              Product_Order service's placeOrder() method
     """
@@ -689,6 +696,7 @@ def prepare_volume_order_object(manager, storage_type, location, size,
         'prices': prices,
         'quantity': 1,
         'location': location_id,
+        'useHourlyPricing': hourly_billing_flag
     }
 
     if order_type_is_saas:
@@ -847,6 +855,11 @@ def prepare_replicant_order_object(manager, snapshot_schedule, location,
             find_ent_space_price(package, 'replication', volume_size, tier)
         ]
 
+    # Determine if hourly billing should be used
+    hourly_billing_flag = utils.lookup(volume, 'billingItem', 'hourlyFlag')
+    if hourly_billing_flag is None:
+        hourly_billing_flag = False
+
     # Build and return the order object
     replicant_order = {
         'complexType': complex_type,
@@ -856,6 +869,7 @@ def prepare_replicant_order_object(manager, snapshot_schedule, location,
         'location': location_id,
         'originVolumeId': volume['id'],
         'originVolumeScheduleId': snapshot_schedule_id,
+        'useHourlyPricing': hourly_billing_flag
     }
 
     if order_type_is_saas:
@@ -867,8 +881,8 @@ def prepare_replicant_order_object(manager, snapshot_schedule, location,
 
 
 def prepare_duplicate_order_object(manager, origin_volume, iops, tier,
-                                   duplicate_size,
-                                   duplicate_snapshot_size, volume_type):
+                                   duplicate_size, duplicate_snapshot_size,
+                                   volume_type, hourly_billing_flag=False):
     """Prepare the duplicate order to submit to SoftLayer_Product::placeOrder()
 
     :param manager: The File or Block manager calling this function
@@ -878,6 +892,7 @@ def prepare_duplicate_order_object(manager, origin_volume, iops, tier,
     :param duplicate_size: The requested size for the duplicate volume
     :param duplicate_snapshot_size: The size for the duplicate snapshot space
     :param volume_type: The type of the origin volume ('file' or 'block')
+    :param hourly_billing_flag: Billing type, monthly (False) or hourly (True)
     :return: Returns the order object to be passed to the
              placeOrder() method of the Product_Order service
     """
@@ -979,6 +994,7 @@ def prepare_duplicate_order_object(manager, origin_volume, iops, tier,
         'quantity': 1,
         'location': location_id,
         'duplicateOriginVolumeId': origin_volume['id'],
+        'useHourlyPricing': hourly_billing_flag
     }
 
     if volume_is_performance:

--- a/tests/CLI/modules/block_tests.py
+++ b/tests/CLI/modules/block_tests.py
@@ -228,6 +228,41 @@ class BlockTests(testing.TestCase):
                          'Order could not be placed! Please verify '
                          'your options and try again.\n')
 
+    def test_volume_order_hourly_billing_not_available(self):
+        result = self.run_command(['block', 'volume-order',
+                                   '--storage-type=endurance', '--size=20',
+                                   '--tier=0.25', '--os-type=linux',
+                                   '--location=dal10', '--billing=hourly',
+                                   '--service-offering=enterprise'])
+
+        self.assertEqual(2, result.exit_code)
+
+    @mock.patch('SoftLayer.BlockStorageManager.order_block_volume')
+    def test_volume_order_hourly_billing(self, order_mock):
+        order_mock.return_value = {
+            'placedOrder': {
+                'id': 10983647,
+                'items': [
+                    {'description': 'Storage as a Service'},
+                    {'description': 'Block Storage'},
+                    {'description': '20 GB Storage Space'},
+                    {'description': '200 IOPS'}]
+                }
+        }
+
+        result = self.run_command(['block', 'volume-order',
+                                   '--storage-type=endurance', '--size=20',
+                                   '--tier=0.25', '--os-type=linux',
+                                   '--location=dal10', '--billing=hourly',
+                                   '--service-offering=storage_as_a_service'])
+        self.assert_no_fail(result)
+        self.assertEqual(result.output,
+                         'Order #10983647 placed successfully!\n'
+                         ' > Storage as a Service\n'
+                         ' > Block Storage\n'
+                         ' > 20 GB Storage Space\n'
+                         ' > 200 IOPS\n')
+
     @mock.patch('SoftLayer.BlockStorageManager.order_block_volume')
     def test_volume_order_performance_manager_error(self, order_mock):
         order_mock.side_effect = ValueError('failure!')
@@ -539,68 +574,31 @@ class BlockTests(testing.TestCase):
                          'Order #24601 placed successfully!\n'
                          ' > Storage as a Service\n')
 
-    def test_set_password(self):
-        result = self.run_command(['block', 'access-password', '1234', '--password=AAAAA'])
-        self.assert_no_fail(result)
-
-    def test_block_volume_order_performance_hourly_billing_not_available(self):
-        result = self.run_command(['block', 'volume-order',
-                                   '--storage-type=performance', '--size=20',
-                                   '--os-type=LINUX'
-                                   '--location=dal10',
-                                   '--service-offering=performance',
-                                   '--billing=hourly',
-                                   '--iops=200'])
-
-        self.assertEqual(2, result.exit_code)
-
-    @mock.patch('SoftLayer.BlockStorageManager.order_block_volume')
-    def test_volume_order_performance_hourly(self, order_mock):
-        order_mock.return_value = {
-            'placedOrder': {
-                'id': 478,
-                'items': [
-                    {'description': 'Storage as a Service'},
-                    {'description': 'Block Storage'},
-                    {'description': '0.25 IOPS per GB'},
-                    {'description': '20 GB Storage Space'},
-                    {'description': '10 GB Storage Space (Snapshot Space)'}]
-            }
-        }
-
-        result = self.run_command(['block', 'volume-order',
-                                   '--storage-type=performance',
-                                   '--size=20',
-                                   '--iops=100',
-                                   '--os-type=LINUX',
-                                   '--location=dal10',
-                                   '--snapshot-size=10',
-                                   '--billing=hourly'])
-
-        self.assert_no_fail(result)
-        self.assertEqual(result.output,
-                         'Order #478 placed successfully!\n'
-                         ' > Storage as a Service\n > Block Storage\n'
-                         ' > 0.25 IOPS per GB\n > 20 GB Storage Space\n'
-                         ' > 10 GB Storage Space (Snapshot Space)\n')
-
     @mock.patch('SoftLayer.BlockStorageManager.order_duplicate_volume')
-    def test_duplicate_order_hourly(self, order_mock):
+    def test_duplicate_order_hourly_billing(self, order_mock):
         order_mock.return_value = {
             'placedOrder': {
-                'id': 24601,
+                'id': 24602,
                 'items': [{'description': 'Storage as a Service'}]
             }
         }
 
-        result = self.run_command(['block', 'volume-duplicate', '102',
+        result = self.run_command(['block', 'volume-duplicate', '100',
                                    '--origin-snapshot-id=470',
                                    '--duplicate-size=250',
-                                   '--duplicate-tier=2',
-                                   '--duplicate-snapshot-size=20',
-                                   '--billing=hourly'])
+                                   '--duplicate-tier=2', '--billing=hourly',
+                                   '--duplicate-snapshot-size=20'])
 
+        order_mock.assert_called_with('100', origin_snapshot_id=470,
+                                      duplicate_size=250, duplicate_iops=None,
+                                      duplicate_tier_level=2,
+                                      duplicate_snapshot_size=20,
+                                      hourly_billing_flag=True)
         self.assert_no_fail(result)
         self.assertEqual(result.output,
-                         'Order #24601 placed successfully!\n'
+                         'Order #24602 placed successfully!\n'
                          ' > Storage as a Service\n')
+
+    def test_set_password(self):
+        result = self.run_command(['block', 'access-password', '1234', '--password=AAAAA'])
+        self.assert_no_fail(result)

--- a/tests/CLI/modules/file_tests.py
+++ b/tests/CLI/modules/file_tests.py
@@ -514,3 +514,60 @@ class FileTests(testing.TestCase):
         self.assertEqual(result.output,
                          'Order #24602 placed successfully!\n'
                          ' > Storage as a Service\n')
+
+    def test_volume_order_performance_hourly_billing_not_available(self):
+        result = self.run_command(['file', 'volume-order',
+                                   '--storage-type=performance', '--size=20',
+                                   '--location=dal10', '--iops=200',
+                                   '--service-offering=performance',
+                                   '--billing=hourly'])
+
+        self.assertEqual(2, result.exit_code)
+
+    @mock.patch('SoftLayer.FileStorageManager.order_file_volume')
+    def test_volume_order_performance_hourly(self, order_mock):
+        order_mock.return_value = {
+            'placedOrder': {
+                'id': 478,
+                'items': [
+                    {'description': 'Storage as a Service'},
+                    {'description': 'File Storage'},
+                    {'description': '0.25 IOPS per GB'},
+                    {'description': '20 GB Storage Space'},
+                    {'description': '10 GB Storage Space (Snapshot Space)'}]
+            }
+        }
+
+        result = self.run_command(['file', 'volume-order',
+                                   '--storage-type=performance', '--size=20',
+                                   '--iops=100', '--location=dal05',
+                                   '--snapshot-size=10',
+                                   '--billing=hourly'])
+
+        self.assert_no_fail(result)
+        self.assertEqual(result.output,
+                         'Order #478 placed successfully!\n'
+                         ' > Storage as a Service\n > File Storage\n'
+                         ' > 0.25 IOPS per GB\n > 20 GB Storage Space\n'
+                         ' > 10 GB Storage Space (Snapshot Space)\n')
+
+    @mock.patch('SoftLayer.FileStorageManager.order_duplicate_volume')
+    def test_duplicate_order_hourly(self, order_mock):
+        order_mock.return_value = {
+            'placedOrder': {
+                'id': 24602,
+                'items': [{'description': 'Storage as a Service'}]
+            }
+        }
+
+        result = self.run_command(['file', 'volume-duplicate', '100',
+                                   '--origin-snapshot-id=470',
+                                   '--duplicate-size=250',
+                                   '--duplicate-tier=2',
+                                   '--duplicate-snapshot-size=20',
+                                   '--billing=hourly'])
+
+        self.assert_no_fail(result)
+        self.assertEqual(result.output,
+                         'Order #24602 placed successfully!\n'
+                         ' > Storage as a Service\n')

--- a/tests/CLI/modules/file_tests.py
+++ b/tests/CLI/modules/file_tests.py
@@ -229,6 +229,44 @@ class FileTests(testing.TestCase):
                          'Order could not be placed! Please verify '
                          'your options and try again.\n')
 
+    def test_volume_order_hourly_billing_not_available(self):
+        result = self.run_command(['file', 'volume-order',
+                                   '--storage-type=endurance', '--size=20',
+                                   '--tier=0.25', '--location=dal10',
+                                   '--billing=hourly',
+                                   '--service-offering=enterprise'])
+
+        self.assertEqual(2, result.exit_code)
+
+    @mock.patch('SoftLayer.FileStorageManager.order_file_volume')
+    def test_volume_order_hourly_billing(self, order_mock):
+        order_mock.return_value = {
+            'placedOrder': {
+                'id': 479,
+                'items': [
+                    {'description': 'Storage as a Service'},
+                    {'description': 'File Storage'},
+                    {'description': '20 GB Storage Space'},
+                    {'description': '0.25 IOPS per GB'},
+                    {'description': '10 GB Storage Space (Snapshot Space)'}]
+            }
+        }
+
+        result = self.run_command(['file', 'volume-order',
+                                   '--storage-type=endurance', '--size=20',
+                                   '--tier=0.25', '--location=dal05',
+                                   '--service-offering=storage_as_a_service',
+                                   '--billing=hourly', '--snapshot-size=10'])
+
+        self.assert_no_fail(result)
+        self.assertEqual(result.output,
+                         'Order #479 placed successfully!\n'
+                         ' > Storage as a Service\n'
+                         ' > File Storage\n'
+                         ' > 20 GB Storage Space\n'
+                         ' > 0.25 IOPS per GB\n'
+                         ' > 10 GB Storage Space (Snapshot Space)\n')
+
     @mock.patch('SoftLayer.FileStorageManager.order_file_volume')
     def test_volume_order_performance_manager_error(self, order_mock):
         order_mock.side_effect = ValueError('failure!')
@@ -515,44 +553,8 @@ class FileTests(testing.TestCase):
                          'Order #24602 placed successfully!\n'
                          ' > Storage as a Service\n')
 
-    def test_volume_order_performance_hourly_billing_not_available(self):
-        result = self.run_command(['file', 'volume-order',
-                                   '--storage-type=performance', '--size=20',
-                                   '--location=dal10', '--iops=200',
-                                   '--service-offering=performance',
-                                   '--billing=hourly'])
-
-        self.assertEqual(2, result.exit_code)
-
-    @mock.patch('SoftLayer.FileStorageManager.order_file_volume')
-    def test_volume_order_performance_hourly(self, order_mock):
-        order_mock.return_value = {
-            'placedOrder': {
-                'id': 478,
-                'items': [
-                    {'description': 'Storage as a Service'},
-                    {'description': 'File Storage'},
-                    {'description': '0.25 IOPS per GB'},
-                    {'description': '20 GB Storage Space'},
-                    {'description': '10 GB Storage Space (Snapshot Space)'}]
-            }
-        }
-
-        result = self.run_command(['file', 'volume-order',
-                                   '--storage-type=performance', '--size=20',
-                                   '--iops=100', '--location=dal05',
-                                   '--snapshot-size=10',
-                                   '--billing=hourly'])
-
-        self.assert_no_fail(result)
-        self.assertEqual(result.output,
-                         'Order #478 placed successfully!\n'
-                         ' > Storage as a Service\n > File Storage\n'
-                         ' > 0.25 IOPS per GB\n > 20 GB Storage Space\n'
-                         ' > 10 GB Storage Space (Snapshot Space)\n')
-
     @mock.patch('SoftLayer.FileStorageManager.order_duplicate_volume')
-    def test_duplicate_order_hourly(self, order_mock):
+    def test_duplicate_order_hourly_billing(self, order_mock):
         order_mock.return_value = {
             'placedOrder': {
                 'id': 24602,
@@ -563,10 +565,14 @@ class FileTests(testing.TestCase):
         result = self.run_command(['file', 'volume-duplicate', '100',
                                    '--origin-snapshot-id=470',
                                    '--duplicate-size=250',
-                                   '--duplicate-tier=2',
-                                   '--duplicate-snapshot-size=20',
-                                   '--billing=hourly'])
+                                   '--duplicate-tier=2', '--billing=hourly',
+                                   '--duplicate-snapshot-size=20'])
 
+        order_mock.assert_called_with('100', origin_snapshot_id=470,
+                                      duplicate_size=250, duplicate_iops=None,
+                                      duplicate_tier_level=2,
+                                      duplicate_snapshot_size=20,
+                                      hourly_billing_flag=True)
         self.assert_no_fail(result)
         self.assertEqual(result.output,
                          'Order #24602 placed successfully!\n'

--- a/tests/managers/block_tests.py
+++ b/tests/managers/block_tests.py
@@ -313,7 +313,8 @@ class BlockTests(testing.TestCase):
                 'quantity': 1,
                 'location': 449494,
                 'iops': 2000,
-                'osFormatType': {'keyName': 'LINUX'}
+                'osFormatType': {'keyName': 'LINUX'},
+                'useHourlyPricing': False,
             },)
         )
 
@@ -357,7 +358,8 @@ class BlockTests(testing.TestCase):
                 'volumeSize': 1000,
                 'quantity': 1,
                 'location': 449494,
-                'osFormatType': {'keyName': 'LINUX'}
+                'osFormatType': {'keyName': 'LINUX'},
+                'useHourlyPricing': False,
             },)
         )
 
@@ -461,7 +463,8 @@ class BlockTests(testing.TestCase):
                 ],
                 'quantity': 1,
                 'location': 449500,
-                'volumeId': 102
+                'volumeId': 102,
+                'useHourlyPricing': False,
             },)
         )
 
@@ -491,7 +494,8 @@ class BlockTests(testing.TestCase):
                 ],
                 'quantity': 1,
                 'location': 449500,
-                'volumeId': 102
+                'volumeId': 102,
+                'useHourlyPricing': False,
             },)
         )
 
@@ -559,7 +563,8 @@ class BlockTests(testing.TestCase):
                 'iops': 1000,
                 'originVolumeId': 102,
                 'originVolumeScheduleId': 978,
-                'osFormatType': {'keyName': 'XEN'}
+                'osFormatType': {'keyName': 'XEN'},
+                'useHourlyPricing': False,
             },)
         )
 
@@ -600,7 +605,8 @@ class BlockTests(testing.TestCase):
                 'location': 449494,
                 'originVolumeId': 102,
                 'originVolumeScheduleId': 978,
-                'osFormatType': {'keyName': 'LINUX'}
+                'osFormatType': {'keyName': 'LINUX'},
+                'useHourlyPricing': False,
             },)
         )
 
@@ -659,7 +665,8 @@ class BlockTests(testing.TestCase):
                 'location': 449500,
                 'duplicateOriginVolumeId': 102,
                 'osFormatType': {'keyName': 'LINUX'},
-                'iops': 1000
+                'iops': 1000,
+                'useHourlyPricing': False,
             },))
 
         mock_volume['storageType']['keyName'] = prev_storage_type_keyname
@@ -705,7 +712,8 @@ class BlockTests(testing.TestCase):
                 'duplicateOriginVolumeId': 102,
                 'osFormatType': {'keyName': 'LINUX'},
                 'duplicateOriginSnapshotId': 470,
-                'iops': 2000
+                'iops': 2000,
+                'useHourlyPricing': False,
             },))
 
         mock_volume['storageType']['keyName'] = prev_storage_type_keyname
@@ -741,7 +749,8 @@ class BlockTests(testing.TestCase):
                 'quantity': 1,
                 'location': 449500,
                 'duplicateOriginVolumeId': 102,
-                'osFormatType': {'keyName': 'LINUX'}
+                'osFormatType': {'keyName': 'LINUX'},
+                'useHourlyPricing': False,
             },))
 
     def test_order_block_duplicate_endurance(self):
@@ -782,7 +791,8 @@ class BlockTests(testing.TestCase):
                 'location': 449500,
                 'duplicateOriginVolumeId': 102,
                 'osFormatType': {'keyName': 'LINUX'},
-                'duplicateOriginSnapshotId': 470
+                'duplicateOriginSnapshotId': 470,
+                'useHourlyPricing': False,
             },))
 
     def test_setCredentialPassword(self):

--- a/tests/managers/block_tests.py
+++ b/tests/managers/block_tests.py
@@ -25,6 +25,21 @@ class BlockTests(testing.TestCase):
             identifier=449,
         )
 
+    def test_cancel_block_volume_immediately_hourly_billing(self):
+        mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
+        mock.return_value = {
+            'billingItem': {'hourlyFlag': True, 'id': 449},
+        }
+
+        self.block.cancel_block_volume(123, immediate=False)
+
+        self.assert_called_with(
+            'SoftLayer_Billing_Item',
+            'cancelItem',
+            args=(True, True, 'No longer needed'),
+            identifier=449,
+        )
+
     def test_get_block_volume_details(self):
         result = self.block.get_block_volume_details(100)
 
@@ -181,6 +196,48 @@ class BlockTests(testing.TestCase):
             identifier=123,
         )
 
+    def test_cancel_snapshot_hourly_billing_immediate_true(self):
+        mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
+        mock.return_value = {
+            'billingItem': {
+                'activeChildren': [
+                    {'categoryCode': 'storage_snapshot_space', 'id': 417}
+                ],
+                'hourlyFlag': True,
+                'id': 449
+            },
+        }
+
+        self.block.cancel_snapshot_space(1234, immediate=True)
+
+        self.assert_called_with(
+            'SoftLayer_Billing_Item',
+            'cancelItem',
+            args=(True, True, 'No longer needed'),
+            identifier=417,
+        )
+
+    def test_cancel_snapshot_hourly_billing_immediate_false(self):
+        mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
+        mock.return_value = {
+            'billingItem': {
+                'activeChildren': [
+                    {'categoryCode': 'storage_snapshot_space', 'id': 417}
+                ],
+                'hourlyFlag': True,
+                'id': 449
+            },
+        }
+
+        self.block.cancel_snapshot_space(1234, immediate=False)
+
+        self.assert_called_with(
+            'SoftLayer_Billing_Item',
+            'cancelItem',
+            args=(True, True, 'No longer needed'),
+            identifier=417,
+        )
+
     def test_cancel_snapshot_exception_no_billing_item_active_children(self):
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = {
@@ -313,8 +370,8 @@ class BlockTests(testing.TestCase):
                 'quantity': 1,
                 'location': 449494,
                 'iops': 2000,
-                'osFormatType': {'keyName': 'LINUX'},
                 'useHourlyPricing': False,
+                'osFormatType': {'keyName': 'LINUX'}
             },)
         )
 
@@ -358,8 +415,8 @@ class BlockTests(testing.TestCase):
                 'volumeSize': 1000,
                 'quantity': 1,
                 'location': 449494,
-                'osFormatType': {'keyName': 'LINUX'},
                 'useHourlyPricing': False,
+                'osFormatType': {'keyName': 'LINUX'}
             },)
         )
 
@@ -464,7 +521,7 @@ class BlockTests(testing.TestCase):
                 'quantity': 1,
                 'location': 449500,
                 'volumeId': 102,
-                'useHourlyPricing': False,
+                'useHourlyPricing': False
             },)
         )
 
@@ -495,7 +552,7 @@ class BlockTests(testing.TestCase):
                 'quantity': 1,
                 'location': 449500,
                 'volumeId': 102,
-                'useHourlyPricing': False,
+                'useHourlyPricing': False
             },)
         )
 
@@ -563,8 +620,8 @@ class BlockTests(testing.TestCase):
                 'iops': 1000,
                 'originVolumeId': 102,
                 'originVolumeScheduleId': 978,
-                'osFormatType': {'keyName': 'XEN'},
                 'useHourlyPricing': False,
+                'osFormatType': {'keyName': 'XEN'}
             },)
         )
 
@@ -605,8 +662,8 @@ class BlockTests(testing.TestCase):
                 'location': 449494,
                 'originVolumeId': 102,
                 'originVolumeScheduleId': 978,
-                'osFormatType': {'keyName': 'LINUX'},
                 'useHourlyPricing': False,
+                'osFormatType': {'keyName': 'LINUX'}
             },)
         )
 
@@ -666,7 +723,7 @@ class BlockTests(testing.TestCase):
                 'duplicateOriginVolumeId': 102,
                 'osFormatType': {'keyName': 'LINUX'},
                 'iops': 1000,
-                'useHourlyPricing': False,
+                'useHourlyPricing': False
             },))
 
         mock_volume['storageType']['keyName'] = prev_storage_type_keyname
@@ -713,7 +770,7 @@ class BlockTests(testing.TestCase):
                 'osFormatType': {'keyName': 'LINUX'},
                 'duplicateOriginSnapshotId': 470,
                 'iops': 2000,
-                'useHourlyPricing': False,
+                'useHourlyPricing': False
             },))
 
         mock_volume['storageType']['keyName'] = prev_storage_type_keyname
@@ -750,7 +807,7 @@ class BlockTests(testing.TestCase):
                 'location': 449500,
                 'duplicateOriginVolumeId': 102,
                 'osFormatType': {'keyName': 'LINUX'},
-                'useHourlyPricing': False,
+                'useHourlyPricing': False
             },))
 
     def test_order_block_duplicate_endurance(self):
@@ -792,7 +849,7 @@ class BlockTests(testing.TestCase):
                 'duplicateOriginVolumeId': 102,
                 'osFormatType': {'keyName': 'LINUX'},
                 'duplicateOriginSnapshotId': 470,
-                'useHourlyPricing': False,
+                'useHourlyPricing': False
             },))
 
     def test_setCredentialPassword(self):

--- a/tests/managers/file_tests.py
+++ b/tests/managers/file_tests.py
@@ -385,7 +385,8 @@ class FileTests(testing.TestCase):
                 'volumeSize': 1000,
                 'quantity': 1,
                 'location': 449494,
-                'iops': 2000
+                'iops': 2000,
+                'useHourlyPricing': False,
             },)
         )
 
@@ -429,7 +430,8 @@ class FileTests(testing.TestCase):
                 ],
                 'volumeSize': 1000,
                 'quantity': 1,
-                'location': 449494
+                'location': 449494,
+                'useHourlyPricing': False,
             },)
         )
 
@@ -461,7 +463,8 @@ class FileTests(testing.TestCase):
                 ],
                 'quantity': 1,
                 'location': 449500,
-                'volumeId': 102
+                'volumeId': 102,
+                'useHourlyPricing': False
             },)
         )
 
@@ -493,7 +496,8 @@ class FileTests(testing.TestCase):
                 ],
                 'quantity': 1,
                 'location': 449500,
-                'volumeId': 102
+                'volumeId': 102,
+                'useHourlyPricing': False
             },)
         )
 
@@ -536,7 +540,8 @@ class FileTests(testing.TestCase):
                 'location': 449494,
                 'iops': 1000,
                 'originVolumeId': 102,
-                'originVolumeScheduleId': 978
+                'originVolumeScheduleId': 978,
+                'useHourlyPricing': False
             },)
         )
 
@@ -578,7 +583,8 @@ class FileTests(testing.TestCase):
                 'quantity': 1,
                 'location': 449494,
                 'originVolumeId': 102,
-                'originVolumeScheduleId': 978
+                'originVolumeScheduleId': 978,
+                'useHourlyPricing': False
             },)
         )
 
@@ -617,7 +623,8 @@ class FileTests(testing.TestCase):
                 'quantity': 1,
                 'location': 449500,
                 'duplicateOriginVolumeId': 102,
-                'iops': 1000
+                'iops': 1000,
+                'useHourlyPricing': False
             },))
 
         mock_volume['storageType']['keyName'] = prev_storage_type_keyname
@@ -662,7 +669,8 @@ class FileTests(testing.TestCase):
                 'location': 449500,
                 'duplicateOriginVolumeId': 102,
                 'duplicateOriginSnapshotId': 470,
-                'iops': 2000
+                'iops': 2000,
+                'useHourlyPricing': False,
             },))
 
         mock_volume['storageType']['keyName'] = prev_storage_type_keyname
@@ -699,7 +707,8 @@ class FileTests(testing.TestCase):
                 'volumeSize': 500,
                 'quantity': 1,
                 'location': 449500,
-                'duplicateOriginVolumeId': 102
+                'duplicateOriginVolumeId': 102,
+                'useHourlyPricing': False,
             },))
 
         mock_volume['storageType']['keyName'] = prev_storage_type_keyname
@@ -743,7 +752,8 @@ class FileTests(testing.TestCase):
                 'quantity': 1,
                 'location': 449500,
                 'duplicateOriginVolumeId': 102,
-                'duplicateOriginSnapshotId': 470
+                'duplicateOriginSnapshotId': 470,
+                'useHourlyPricing': False,
             },))
 
         mock_volume['storageType']['keyName'] = prev_storage_type_keyname

--- a/tests/managers/file_tests.py
+++ b/tests/managers/file_tests.py
@@ -25,6 +25,21 @@ class FileTests(testing.TestCase):
             identifier=449,
         )
 
+    def test_cancel_file_volume_immediately_hourly_billing(self):
+        mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
+        mock.return_value = {
+            'billingItem': {'hourlyFlag': True, 'id': 449},
+        }
+
+        self.file.cancel_file_volume(123, immediate=False)
+
+        self.assert_called_with(
+            'SoftLayer_Billing_Item',
+            'cancelItem',
+            args=(True, True, 'No longer needed'),
+            identifier=449,
+        )
+
     def test_authorize_host_to_volume(self):
         result = self.file.authorize_host_to_volume(
             50,
@@ -164,6 +179,48 @@ class FileTests(testing.TestCase):
             'cancelItem',
             args=(True, True, 'No longer needed'),
             identifier=123,
+        )
+
+    def test_cancel_snapshot_hourly_billing_immediate_true(self):
+        mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
+        mock.return_value = {
+            'billingItem': {
+                'activeChildren': [
+                    {'categoryCode': 'storage_snapshot_space', 'id': 417}
+                ],
+                'hourlyFlag': True,
+                'id': 449
+            },
+        }
+
+        self.file.cancel_snapshot_space(1234, immediate=True)
+
+        self.assert_called_with(
+            'SoftLayer_Billing_Item',
+            'cancelItem',
+            args=(True, True, 'No longer needed'),
+            identifier=417,
+        )
+
+    def test_cancel_snapshot_hourly_billing_immediate_false(self):
+        mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
+        mock.return_value = {
+            'billingItem': {
+                'activeChildren': [
+                    {'categoryCode': 'storage_snapshot_space', 'id': 417}
+                ],
+                'hourlyFlag': True,
+                'id': 449
+            },
+        }
+
+        self.file.cancel_snapshot_space(1234, immediate=False)
+
+        self.assert_called_with(
+            'SoftLayer_Billing_Item',
+            'cancelItem',
+            args=(True, True, 'No longer needed'),
+            identifier=417,
         )
 
     def test_cancel_snapshot_exception_no_billing_item_active_children(self):
@@ -386,7 +443,7 @@ class FileTests(testing.TestCase):
                 'quantity': 1,
                 'location': 449494,
                 'iops': 2000,
-                'useHourlyPricing': False,
+                'useHourlyPricing': False
             },)
         )
 
@@ -431,7 +488,7 @@ class FileTests(testing.TestCase):
                 'volumeSize': 1000,
                 'quantity': 1,
                 'location': 449494,
-                'useHourlyPricing': False,
+                'useHourlyPricing': False
             },)
         )
 
@@ -670,7 +727,7 @@ class FileTests(testing.TestCase):
                 'duplicateOriginVolumeId': 102,
                 'duplicateOriginSnapshotId': 470,
                 'iops': 2000,
-                'useHourlyPricing': False,
+                'useHourlyPricing': False
             },))
 
         mock_volume['storageType']['keyName'] = prev_storage_type_keyname
@@ -708,7 +765,7 @@ class FileTests(testing.TestCase):
                 'quantity': 1,
                 'location': 449500,
                 'duplicateOriginVolumeId': 102,
-                'useHourlyPricing': False,
+                'useHourlyPricing': False
             },))
 
         mock_volume['storageType']['keyName'] = prev_storage_type_keyname
@@ -753,7 +810,7 @@ class FileTests(testing.TestCase):
                 'location': 449500,
                 'duplicateOriginVolumeId': 102,
                 'duplicateOriginSnapshotId': 470,
-                'useHourlyPricing': False,
+                'useHourlyPricing': False
             },))
 
         mock_volume['storageType']['keyName'] = prev_storage_type_keyname

--- a/tests/managers/storage_utils_tests.py
+++ b/tests/managers/storage_utils_tests.py
@@ -2722,7 +2722,7 @@ class StorageUtilsTests(testing.TestCase):
             'quantity': 1,
             'location': 449500,
             'volumeId': 102,
-            'useHourlyPricing': False,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_snapshot_order_object(
@@ -2741,15 +2741,15 @@ class StorageUtilsTests(testing.TestCase):
             'complexType': 'SoftLayer_Container_Product_Order_'
                            'Network_Storage_Enterprise_SnapshotSpace_Upgrade',
             'packageId': 759,
-            'prices': [{'id': 193613}],
+            'prices': [{'id': 193853}],
             'quantity': 1,
             'location': 449500,
             'volumeId': 102,
-            'useHourlyPricing': False,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_snapshot_order_object(
-            self.block, mock_volume, 10, 2, True
+            self.block, mock_volume, 20, None, True
         )
 
         self.assertEqual(expected_object, result)
@@ -2845,7 +2845,7 @@ class StorageUtilsTests(testing.TestCase):
             'quantity': 1,
             'location': 449500,
             'volumeId': 100,
-            'useHourlyPricing': False,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_snapshot_order_object(
@@ -2870,7 +2870,7 @@ class StorageUtilsTests(testing.TestCase):
             'quantity': 1,
             'location': 449500,
             'volumeId': 100,
-            'useHourlyPricing': False,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_snapshot_order_object(
@@ -2914,7 +2914,7 @@ class StorageUtilsTests(testing.TestCase):
             exceptions.SoftLayerError,
             storage_utils.prepare_volume_order_object,
             self.block, 'saxophone_cat', 'dal09', 1000,
-            None, 4, None, 'enterprise', 'block', False
+            None, 4, None, 'enterprise', 'block'
         )
 
         self.assertEqual(
@@ -2930,7 +2930,7 @@ class StorageUtilsTests(testing.TestCase):
             exceptions.SoftLayerError,
             storage_utils.prepare_volume_order_object,
             self.block, 'endurance', 'hoth01', 1000,
-            None, 4, None, 'enterprise', 'block', False
+            None, 4, None, 'enterprise', 'block'
         )
 
         self.assertEqual(
@@ -2947,7 +2947,7 @@ class StorageUtilsTests(testing.TestCase):
             exceptions.SoftLayerError,
             storage_utils.prepare_volume_order_object,
             self.block, 'performance', 'dal09', 1000,
-            None, 4, None, 'enterprise', 'block', False
+            None, 4, None, 'enterprise', 'block'
         )
 
         self.assertEqual(
@@ -2964,7 +2964,7 @@ class StorageUtilsTests(testing.TestCase):
             exceptions.SoftLayerError,
             storage_utils.prepare_volume_order_object,
             self.block, 'endurance', 'dal09', 1000,
-            800, None, None, 'performance', 'block', False
+            800, None, None, 'performance', 'block'
         )
 
         self.assertEqual(
@@ -3069,8 +3069,8 @@ class StorageUtilsTests(testing.TestCase):
             ],
             'quantity': 1,
             'location': 29,
-            'useHourlyPricing': False,
-            'volumeSize': 1000
+            'volumeSize': 1000,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_volume_order_object(
@@ -3099,8 +3099,8 @@ class StorageUtilsTests(testing.TestCase):
             ],
             'quantity': 1,
             'location': 29,
-            'useHourlyPricing': False,
-            'volumeSize': 1000
+            'volumeSize': 1000,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_volume_order_object(
@@ -3376,11 +3376,11 @@ class StorageUtilsTests(testing.TestCase):
             'originVolumeId': 102,
             'originVolumeScheduleId': 978,
             'volumeSize': 500,
-            'useHourlyPricing': False,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_replicant_order_object(
-            self.block, 'WEEKLY', 'wdc04', 2, mock_volume, 'block'
+            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block'
         )
 
         self.assertEqual(expected_object, result)
@@ -3410,7 +3410,7 @@ class StorageUtilsTests(testing.TestCase):
             'originVolumeId': 102,
             'originVolumeScheduleId': 978,
             'volumeSize': 500,
-            'useHourlyPricing': False,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_replicant_order_object(
@@ -3474,7 +3474,7 @@ class StorageUtilsTests(testing.TestCase):
             'originVolumeScheduleId': 978,
             'volumeSize': 500,
             'iops': 1000,
-            'useHourlyPricing': False,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_replicant_order_object(
@@ -3579,6 +3579,44 @@ class StorageUtilsTests(testing.TestCase):
         )
 
         self.assertEqual(expected_object, result)
+
+    def test_prep_replicant_order_hourly_billing(self):
+        mock = self.set_mock('SoftLayer_Location_Datacenter', 'getDatacenters')
+        mock.return_value = [{'id': 51, 'name': 'wdc04'}]
+        mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
+        mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
+
+        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
+        prev_hourly_flag = mock_volume['billingItem']['hourlyFlag']
+        mock_volume['billingItem']['hourlyFlag'] = True
+
+        expected_object = {
+            'complexType': 'SoftLayer_Container_Product_Order_'
+                           'Network_Storage_AsAService',
+            'packageId': 759,
+            'prices': [
+                {'id': 189433},
+                {'id': 189443},
+                {'id': 193433},
+                {'id': 193373},
+                {'id': 193613},
+                {'id': 194693}
+            ],
+            'quantity': 1,
+            'location': 51,
+            'originVolumeId': 102,
+            'originVolumeScheduleId': 978,
+            'volumeSize': 500,
+            'useHourlyPricing': True
+        }
+
+        result = storage_utils.prepare_replicant_order_object(
+            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block'
+        )
+
+        self.assertEqual(expected_object, result)
+
+        mock_volume['billingItem']['hourlyFlag'] = prev_hourly_flag
 
     # ---------------------------------------------------------------------
     # Tests for prepare_duplicate_order_object()
@@ -3702,8 +3740,8 @@ class StorageUtilsTests(testing.TestCase):
             'volumeSize': 500,
             'quantity': 1,
             'location': 449500,
-            'useHourlyPricing': False,
-            'duplicateOriginVolumeId': 102}
+            'duplicateOriginVolumeId': 102,
+            'useHourlyPricing': False}
 
         result = storage_utils.prepare_duplicate_order_object(
             self.block, mock_volume, None, None, None, None, 'block')
@@ -3843,8 +3881,8 @@ class StorageUtilsTests(testing.TestCase):
             'quantity': 1,
             'location': 449500,
             'duplicateOriginVolumeId': 102,
-            'useHourlyPricing': False,
-            'iops': 1000}
+            'iops': 1000,
+            'useHourlyPricing': False}
 
         result = storage_utils.prepare_duplicate_order_object(
             self.file, mock_volume, None, None, None, None, 'file')
@@ -3876,8 +3914,8 @@ class StorageUtilsTests(testing.TestCase):
             'quantity': 1,
             'location': 449500,
             'duplicateOriginVolumeId': 102,
-            'useHourlyPricing': False,
-            'iops': 2000}
+            'iops': 2000,
+            'useHourlyPricing': False}
 
         result = storage_utils.prepare_duplicate_order_object(
             self.block, mock_volume, 2000, None, 1000, 10, 'block')
@@ -3909,8 +3947,8 @@ class StorageUtilsTests(testing.TestCase):
             'quantity': 1,
             'location': 449500,
             'duplicateOriginVolumeId': 102,
-            'useHourlyPricing': False,
-            'iops': 2000}
+            'iops': 2000,
+            'useHourlyPricing': False}
 
         result = storage_utils.prepare_duplicate_order_object(
             self.file, mock_volume, 2000, None, 1000, 10, 'file')
@@ -4003,8 +4041,8 @@ class StorageUtilsTests(testing.TestCase):
             'volumeSize': 500,
             'quantity': 1,
             'location': 449500,
-            'useHourlyPricing': False,
-            'duplicateOriginVolumeId': 102}
+            'duplicateOriginVolumeId': 102,
+            'useHourlyPricing': False}
 
         result = storage_utils.prepare_duplicate_order_object(
             self.file, mock_volume, None, None, None, None, 'file')
@@ -4033,8 +4071,8 @@ class StorageUtilsTests(testing.TestCase):
             'volumeSize': 1000,
             'quantity': 1,
             'location': 449500,
-            'useHourlyPricing': False,
-            'duplicateOriginVolumeId': 102}
+            'duplicateOriginVolumeId': 102,
+            'useHourlyPricing': False}
 
         result = storage_utils.prepare_duplicate_order_object(
             self.block, mock_volume, None, 4.0, 1000, 10, 'block')
@@ -4063,8 +4101,8 @@ class StorageUtilsTests(testing.TestCase):
             'volumeSize': 1000,
             'quantity': 1,
             'location': 449500,
-            'useHourlyPricing': False,
-            'duplicateOriginVolumeId': 102}
+            'duplicateOriginVolumeId': 102,
+            'useHourlyPricing': False}
 
         result = storage_utils.prepare_duplicate_order_object(
             self.file, mock_volume, None, 4.0, 1000, 10, 'file')

--- a/tests/managers/storage_utils_tests.py
+++ b/tests/managers/storage_utils_tests.py
@@ -2721,7 +2721,8 @@ class StorageUtilsTests(testing.TestCase):
             'prices': [{'id': 193613}],
             'quantity': 1,
             'location': 449500,
-            'volumeId': 102
+            'volumeId': 102,
+            'useHourlyPricing': False,
         }
 
         result = storage_utils.prepare_snapshot_order_object(
@@ -2740,14 +2741,15 @@ class StorageUtilsTests(testing.TestCase):
             'complexType': 'SoftLayer_Container_Product_Order_'
                            'Network_Storage_Enterprise_SnapshotSpace_Upgrade',
             'packageId': 759,
-            'prices': [{'id': 193853}],
+            'prices': [{'id': 193613}],
             'quantity': 1,
             'location': 449500,
-            'volumeId': 102
+            'volumeId': 102,
+            'useHourlyPricing': False,
         }
 
         result = storage_utils.prepare_snapshot_order_object(
-            self.block, mock_volume, 20, None, True
+            self.block, mock_volume, 10, 2, True
         )
 
         self.assertEqual(expected_object, result)
@@ -2792,7 +2794,8 @@ class StorageUtilsTests(testing.TestCase):
             'prices': [{'id': 191193}],
             'quantity': 1,
             'location': 449500,
-            'volumeId': 102
+            'volumeId': 102,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_snapshot_order_object(
@@ -2841,7 +2844,8 @@ class StorageUtilsTests(testing.TestCase):
             'prices': [{'id': 46160}],
             'quantity': 1,
             'location': 449500,
-            'volumeId': 100
+            'volumeId': 100,
+            'useHourlyPricing': False,
         }
 
         result = storage_utils.prepare_snapshot_order_object(
@@ -2865,7 +2869,8 @@ class StorageUtilsTests(testing.TestCase):
             'prices': [{'id': 45860}],
             'quantity': 1,
             'location': 449500,
-            'volumeId': 100
+            'volumeId': 100,
+            'useHourlyPricing': False,
         }
 
         result = storage_utils.prepare_snapshot_order_object(
@@ -2873,6 +2878,33 @@ class StorageUtilsTests(testing.TestCase):
         )
 
         self.assertEqual(expected_object, result)
+
+    def test_prep_snapshot_order_hourly_billing(self):
+        mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
+        mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
+
+        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
+        prev_hourly_flag = mock_volume['billingItem']['hourlyFlag']
+        mock_volume['billingItem']['hourlyFlag'] = True
+
+        expected_object = {
+            'complexType': 'SoftLayer_Container_Product_Order_'
+                           'Network_Storage_Enterprise_SnapshotSpace',
+            'packageId': 759,
+            'prices': [{'id': 193853}],
+            'quantity': 1,
+            'location': 449500,
+            'volumeId': 102,
+            'useHourlyPricing': True
+        }
+
+        result = storage_utils.prepare_snapshot_order_object(
+            self.block, mock_volume, 20, None, False
+        )
+
+        self.assertEqual(expected_object, result)
+
+        mock_volume['billingItem']['hourlyFlag'] = prev_hourly_flag
 
     # ---------------------------------------------------------------------
     # Tests for prepare_volume_order_object()
@@ -2882,7 +2914,7 @@ class StorageUtilsTests(testing.TestCase):
             exceptions.SoftLayerError,
             storage_utils.prepare_volume_order_object,
             self.block, 'saxophone_cat', 'dal09', 1000,
-            None, 4, None, 'enterprise', 'block'
+            None, 4, None, 'enterprise', 'block', False
         )
 
         self.assertEqual(
@@ -2898,7 +2930,7 @@ class StorageUtilsTests(testing.TestCase):
             exceptions.SoftLayerError,
             storage_utils.prepare_volume_order_object,
             self.block, 'endurance', 'hoth01', 1000,
-            None, 4, None, 'enterprise', 'block'
+            None, 4, None, 'enterprise', 'block', False
         )
 
         self.assertEqual(
@@ -2915,7 +2947,7 @@ class StorageUtilsTests(testing.TestCase):
             exceptions.SoftLayerError,
             storage_utils.prepare_volume_order_object,
             self.block, 'performance', 'dal09', 1000,
-            None, 4, None, 'enterprise', 'block'
+            None, 4, None, 'enterprise', 'block', False
         )
 
         self.assertEqual(
@@ -2932,7 +2964,7 @@ class StorageUtilsTests(testing.TestCase):
             exceptions.SoftLayerError,
             storage_utils.prepare_volume_order_object,
             self.block, 'endurance', 'dal09', 1000,
-            800, None, None, 'performance', 'block'
+            800, None, None, 'performance', 'block', False
         )
 
         self.assertEqual(
@@ -2977,7 +3009,8 @@ class StorageUtilsTests(testing.TestCase):
             'quantity': 1,
             'location': 29,
             'volumeSize': 1000,
-            'iops': 800
+            'iops': 800,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_volume_order_object(
@@ -3007,7 +3040,8 @@ class StorageUtilsTests(testing.TestCase):
             'quantity': 1,
             'location': 29,
             'volumeSize': 1000,
-            'iops': 800
+            'iops': 800,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_volume_order_object(
@@ -3035,6 +3069,7 @@ class StorageUtilsTests(testing.TestCase):
             ],
             'quantity': 1,
             'location': 29,
+            'useHourlyPricing': False,
             'volumeSize': 1000
         }
 
@@ -3064,6 +3099,7 @@ class StorageUtilsTests(testing.TestCase):
             ],
             'quantity': 1,
             'location': 29,
+            'useHourlyPricing': False,
             'volumeSize': 1000
         }
 
@@ -3092,7 +3128,8 @@ class StorageUtilsTests(testing.TestCase):
                 {'id': 41562}
             ],
             'quantity': 1,
-            'location': 29
+            'location': 29,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_volume_order_object(
@@ -3120,7 +3157,8 @@ class StorageUtilsTests(testing.TestCase):
                 {'id': 41562}
             ],
             'quantity': 1,
-            'location': 29
+            'location': 29,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_volume_order_object(
@@ -3149,7 +3187,8 @@ class StorageUtilsTests(testing.TestCase):
                 {'id': 45088}
             ],
             'quantity': 1,
-            'location': 29
+            'location': 29,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_volume_order_object(
@@ -3179,7 +3218,8 @@ class StorageUtilsTests(testing.TestCase):
                 {'id': 46170}
             ],
             'quantity': 1,
-            'location': 29
+            'location': 29,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_volume_order_object(
@@ -3335,11 +3375,12 @@ class StorageUtilsTests(testing.TestCase):
             'location': 51,
             'originVolumeId': 102,
             'originVolumeScheduleId': 978,
-            'volumeSize': 500
+            'volumeSize': 500,
+            'useHourlyPricing': False,
         }
 
         result = storage_utils.prepare_replicant_order_object(
-            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block'
+            self.block, 'WEEKLY', 'wdc04', 2, mock_volume, 'block'
         )
 
         self.assertEqual(expected_object, result)
@@ -3368,7 +3409,8 @@ class StorageUtilsTests(testing.TestCase):
             'location': 51,
             'originVolumeId': 102,
             'originVolumeScheduleId': 978,
-            'volumeSize': 500
+            'volumeSize': 500,
+            'useHourlyPricing': False,
         }
 
         result = storage_utils.prepare_replicant_order_object(
@@ -3431,7 +3473,8 @@ class StorageUtilsTests(testing.TestCase):
             'originVolumeId': 102,
             'originVolumeScheduleId': 978,
             'volumeSize': 500,
-            'iops': 1000
+            'iops': 1000,
+            'useHourlyPricing': False,
         }
 
         result = storage_utils.prepare_replicant_order_object(
@@ -3492,7 +3535,8 @@ class StorageUtilsTests(testing.TestCase):
             'quantity': 1,
             'location': 51,
             'originVolumeId': 100,
-            'originVolumeScheduleId': 978
+            'originVolumeScheduleId': 978,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_replicant_order_object(
@@ -3526,7 +3570,8 @@ class StorageUtilsTests(testing.TestCase):
             'quantity': 1,
             'location': 51,
             'originVolumeId': 100,
-            'originVolumeScheduleId': 978
+            'originVolumeScheduleId': 978,
+            'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_replicant_order_object(
@@ -3657,6 +3702,7 @@ class StorageUtilsTests(testing.TestCase):
             'volumeSize': 500,
             'quantity': 1,
             'location': 449500,
+            'useHourlyPricing': False,
             'duplicateOriginVolumeId': 102}
 
         result = storage_utils.prepare_duplicate_order_object(
@@ -3797,6 +3843,7 @@ class StorageUtilsTests(testing.TestCase):
             'quantity': 1,
             'location': 449500,
             'duplicateOriginVolumeId': 102,
+            'useHourlyPricing': False,
             'iops': 1000}
 
         result = storage_utils.prepare_duplicate_order_object(
@@ -3829,6 +3876,7 @@ class StorageUtilsTests(testing.TestCase):
             'quantity': 1,
             'location': 449500,
             'duplicateOriginVolumeId': 102,
+            'useHourlyPricing': False,
             'iops': 2000}
 
         result = storage_utils.prepare_duplicate_order_object(
@@ -3861,6 +3909,7 @@ class StorageUtilsTests(testing.TestCase):
             'quantity': 1,
             'location': 449500,
             'duplicateOriginVolumeId': 102,
+            'useHourlyPricing': False,
             'iops': 2000}
 
         result = storage_utils.prepare_duplicate_order_object(
@@ -3954,6 +4003,7 @@ class StorageUtilsTests(testing.TestCase):
             'volumeSize': 500,
             'quantity': 1,
             'location': 449500,
+            'useHourlyPricing': False,
             'duplicateOriginVolumeId': 102}
 
         result = storage_utils.prepare_duplicate_order_object(
@@ -3983,6 +4033,7 @@ class StorageUtilsTests(testing.TestCase):
             'volumeSize': 1000,
             'quantity': 1,
             'location': 449500,
+            'useHourlyPricing': False,
             'duplicateOriginVolumeId': 102}
 
         result = storage_utils.prepare_duplicate_order_object(
@@ -4012,6 +4063,7 @@ class StorageUtilsTests(testing.TestCase):
             'volumeSize': 1000,
             'quantity': 1,
             'location': 449500,
+            'useHourlyPricing': False,
             'duplicateOriginVolumeId': 102}
 
         result = storage_utils.prepare_duplicate_order_object(


### PR DESCRIPTION
Add the '--billing' flag to volume-order and volume-duplicate commands, and add logic within snapshot space and replication orders to use hourly billing if the original volume used hourly billing.