### PR TITLE
vs manager wait_for_ready exception handling

### DIFF
--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -8,6 +8,7 @@
 import datetime
 import itertools
 import logging
+import random
 import socket
 import time
 import warnings
@@ -406,8 +407,7 @@ class VSManager(utils.IdentifierMixin, object):
         :param int delay: The number of seconds to sleep before checks. Defaults to 10.
         """
 
-        return self.wait_for_ready(instance_id, limit, delay=delay,
-                                   pending=True)
+        return self.wait_for_ready(instance_id, limit, delay=delay, pending=True)
 
     def wait_for_ready(self, instance_id, limit, delay=10, pending=False):
         """Determine if a VS is ready and available.
@@ -457,14 +457,15 @@ class VSManager(utils.IdentifierMixin, object):
                         not reloading,
                         not outstanding]):
                     return True
+                LOGGER.info("%s not ready.", str(instance_id))
             except exceptions.SoftLayerAPIError as exception:
-                delay = delay * 2
+                delay = (delay * 2) + random.randint(0, 9)
                 LOGGER.info('Exception: %s', str(exception))
-                LOGGER.info('Auto retry in %s seconds', str(delay))
 
             now = time.time()
             if now >= until:
                 return False
+            LOGGER.info('Auto retry in %s seconds', str(min(delay, until - now)))
             time.sleep(min(delay, until - now))
 
     def verify_create_instance(self, **kwargs):

--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -398,7 +398,7 @@ class VSManager(utils.IdentifierMixin, object):
     def wait_for_transaction(self, instance_id, limit, delay=10):
         """Waits on a VS transaction for the specified amount of time.
 
-        This is really just a wrapper for wait_for_ready(pending=True). 
+        This is really just a wrapper for wait_for_ready(pending=True).
         Provided for backwards compatibility.
 
         :param int instance_id: The instance ID with the pending transaction

--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -398,14 +398,12 @@ class VSManager(utils.IdentifierMixin, object):
     def wait_for_transaction(self, instance_id, limit, delay=10):
         """Waits on a VS transaction for the specified amount of time.
 
-        This is really just a wrapper for wait_for_ready(pending=True).
+        This is really just a wrapper for wait_for_ready(pending=True). 
         Provided for backwards compatibility.
-
 
         :param int instance_id: The instance ID with the pending transaction
         :param int limit: The maximum amount of time to wait.
-        :param int delay: The number of seconds to sleep before checks.
-                          Defaults to 1.
+        :param int delay: The number of seconds to sleep before checks. Defaults to 10.
         """
 
         return self.wait_for_ready(instance_id, limit, delay=delay,
@@ -423,8 +421,7 @@ class VSManager(utils.IdentifierMixin, object):
 
         :param int instance_id: The instance ID with the pending transaction
         :param int limit: The maximum amount of time to wait.
-        :param int delay: The number of seconds to sleep before checks.
-                          Defaults to 1.
+        :param int delay: The number of seconds to sleep before checks. Defaults to 10.
         :param bool pending: Wait for pending transactions not related to
                              provisioning or reloads such as monitoring.
 

--- a/tests/managers/vs_tests.py
+++ b/tests/managers/vs_tests.py
@@ -8,9 +8,10 @@
 import mock
 
 import SoftLayer
+from SoftLayer import exceptions
 from SoftLayer import fixtures
 from SoftLayer import testing
-from SoftLayer import exceptions
+
 
 class VSTests(testing.TestCase):
 
@@ -883,7 +884,6 @@ class VSWaitReadyGoTests(testing.TestCase):
 
         _sleep.assert_has_calls([mock.call(10)])
 
-
     @mock.patch('SoftLayer.managers.vs.VSManager.get_instance')
     @mock.patch('time.time')
     @mock.patch('time.sleep')
@@ -891,7 +891,7 @@ class VSWaitReadyGoTests(testing.TestCase):
         """Tests escalating scale back when an excaption is thrown"""
         self.guestObject.return_value = {'activeTransaction': {'id': 1}}
         vs.side_effect = exceptions.TransportError(104, "Its broken")
-        _time.side_effect = [0,0,2,6,14,20,100]
+        _time.side_effect = [0, 0, 2, 6, 14, 20, 100]
         value = self.vs.wait_for_ready(1, 20, delay=1)
         _sleep.assert_has_calls([
             mock.call(2),
@@ -899,3 +899,4 @@ class VSWaitReadyGoTests(testing.TestCase):
             mock.call(8),
             mock.call(6)
         ])
+        self.assertFalse(value)

--- a/tests/managers/vs_tests.py
+++ b/tests/managers/vs_tests.py
@@ -885,13 +885,15 @@ class VSWaitReadyGoTests(testing.TestCase):
         _sleep.assert_has_calls([mock.call(10)])
 
     @mock.patch('SoftLayer.managers.vs.VSManager.get_instance')
+    @mock.patch('random.randint')
     @mock.patch('time.time')
     @mock.patch('time.sleep')
-    def test_exception_from_api(self, _sleep, _time, vs):
+    def test_exception_from_api(self, _sleep, _time, _random, vs):
         """Tests escalating scale back when an excaption is thrown"""
         self.guestObject.return_value = {'activeTransaction': {'id': 1}}
         vs.side_effect = exceptions.TransportError(104, "Its broken")
         _time.side_effect = [0, 0, 2, 6, 14, 20, 100]
+        _random.side_effect = [0, 0, 0, 0, 0]
         value = self.vs.wait_for_ready(1, 20, delay=1)
         _sleep.assert_has_calls([
             mock.call(2),


### PR DESCRIPTION
Will allow wait_for_ready to gracefully handle exceptions, and raise the delay for each exception. Raised the default delay from 1s to 10s

```def wait_for_ready(self, instance_id, limit, delay=10, pending=False):```
When an exception is encountered, delay will be multiplied by 2. 
Will still return False if a ready state was not encountered before limit is reached.