### PR TITLE
Change to use singular APIs

### DIFF
--- a/SoftLayer/fixtures/SoftLayer_Network_SecurityGroup.py
+++ b/SoftLayer/fixtures/SoftLayer_Network_SecurityGroup.py
@@ -33,12 +33,12 @@ getObject = {
     'rules': getRules
 }
 
-createObjects = [{'id': 100,
-                  'name': 'secgroup1',
-                  'description': 'Securitygroup1',
-                  'createDate': '2017-05-05T12:44:43-06:00'}]
-editObjects = True
-deleteObjects = True
+createObject = {'id': 100,
+                'name': 'secgroup1',
+                'description': 'Securitygroup1',
+                'createDate': '2017-05-05T12:44:43-06:00'}
+editObject = True
+deleteObject = True
 addRules = True
 editRules = True
 removeRules = True

--- a/SoftLayer/managers/network.py
+++ b/SoftLayer/managers/network.py
@@ -226,15 +226,14 @@ class NetworkManager(object):
         """
 
         create_dict = {'name': name, 'description': description}
-        return self.security_group.createObjects([create_dict])[0]
+        return self.security_group.createObject(create_dict)
 
     def delete_securitygroup(self, group_id):
         """Deletes the specified security group.
 
         :param int group_id: The ID of the security group
         """
-        delete_dict = {'id': group_id}
-        return self.security_group.deleteObjects([delete_dict])
+        return self.security_group.deleteObject(id=group_id)
 
     def detach_securitygroup_component(self, group_id, component_id):
         """Detaches a network component from a security group.
@@ -296,8 +295,7 @@ class NetworkManager(object):
             obj['description'] = description
 
         if obj:
-            obj['id'] = group_id
-            successful = self.security_group.editObjects([obj])
+            successful = self.security_group.editObject(obj, id=group_id)
 
         return successful
 

--- a/tests/CLI/modules/securitygroup_tests.py
+++ b/tests/CLI/modules/securitygroup_tests.py
@@ -60,9 +60,9 @@ class SecurityGroupTests(testing.TestCase):
 
         self.assert_no_fail(result)
         self.assert_called_with('SoftLayer_Network_SecurityGroup',
-                                'createObjects',
-                                args=([{'name': 'secgroup1',
-                                       'description': 'Securitygroup1'}],))
+                                'createObject',
+                                args=({'name': 'secgroup1',
+                                       'description': 'Securitygroup1'},))
         self.assertEqual({'id': 100,
                           'name': 'secgroup1',
                           'description': 'Securitygroup1',
@@ -74,12 +74,13 @@ class SecurityGroupTests(testing.TestCase):
 
         self.assert_no_fail(result)
         self.assert_called_with('SoftLayer_Network_SecurityGroup',
-                                'editObjects',
-                                args=([{'id': '104', 'name': 'foo'}],))
+                                'editObject',
+                                identifier='104',
+                                args=({'name': 'foo'},))
 
     def test_securitygroup_edit_fail(self):
         fixture = self.set_mock('SoftLayer_Network_SecurityGroup',
-                                'editObjects')
+                                'editObject')
         fixture.return_value = False
 
         result = self.run_command(['sg', 'edit', '100',
@@ -92,12 +93,12 @@ class SecurityGroupTests(testing.TestCase):
 
         self.assert_no_fail(result)
         self.assert_called_with('SoftLayer_Network_SecurityGroup',
-                                'deleteObjects',
-                                args=([{'id': '104'}],))
+                                'deleteObject',
+                                identifier='104')
 
     def test_securitygroup_delete_fail(self):
         fixture = self.set_mock('SoftLayer_Network_SecurityGroup',
-                                'deleteObjects')
+                                'deleteObject')
         fixture.return_value = False
 
         result = self.run_command(['sg', 'delete', '100'])

--- a/tests/managers/network_tests.py
+++ b/tests/managers/network_tests.py
@@ -162,15 +162,19 @@ class NetworkTests(testing.TestCase):
                                                    description='bar')
 
         sg_fixture = fixtures.SoftLayer_Network_SecurityGroup
-        self.assertEqual(sg_fixture.createObjects, [result])
+        self.assertEqual(sg_fixture.createObject, result)
+        self.assert_called_with('SoftLayer_Network_SecurityGroup',
+                                'createObject',
+                                args=({'name': 'foo',
+                                       'description': 'bar'},))
 
     def test_delete_securitygroup(self):
         result = self.network.delete_securitygroup(100)
 
         self.assertTrue(result)
         self.assert_called_with('SoftLayer_Network_SecurityGroup',
-                                'deleteObjects',
-                                args=([{'id': 100}],))
+                                'deleteObject',
+                                identifier=100)
 
     def test_detach_securitygroup_component(self):
         result = self.network.detach_securitygroup_component(100, 500)
@@ -227,9 +231,8 @@ class NetworkTests(testing.TestCase):
 
         self.assertTrue(result)
         self.assert_called_with('SoftLayer_Network_SecurityGroup',
-                                'editObjects',
-                                args=([{'id': 100,
-                                        'name': 'foobar'}],))
+                                'editObject', identifier=100,
+                                args=({'name': 'foobar'},))
 
     def test_edit_securitygroup_rule(self):
         result = self.network.edit_securitygroup_rule(100, 500,
@@ -252,6 +255,8 @@ class NetworkTests(testing.TestCase):
 
         sg_fixture = fixtures.SoftLayer_Network_SecurityGroup
         self.assertEqual(sg_fixture.getObject, result)
+        self.assert_called_with('SoftLayer_Network_SecurityGroup',
+                                'getObject', identifier=100)
 
     def test_get_subnet(self):
         result = self.network.get_subnet(9876)


### PR DESCRIPTION
SoftLayer_Network_SecurityGroups now has the singular APIs for
create/edit/delete available, so this changes the manager functions to
use those singular APIs.

The fixtures were also updated to stub out the singular APIs.