### PR TITLE
virtual detail: show dedicated host info, if applicable

### DIFF
--- a/SoftLayer/CLI/virt/detail.py
+++ b/SoftLayer/CLI/virt/detail.py
@@ -45,6 +45,7 @@ def cli(env, identifier, passwords=False, price=False):
     table.add_row(['active_transaction', formatting.active_txn(result)])
     table.add_row(['datacenter',
                    result['datacenter']['name'] or formatting.blank()])
+    _cli_helper_dedicated_host(env, result, table)
     operating_system = utils.lookup(result,
                                     'operatingSystem',
                                     'softwareLicense',
@@ -138,3 +139,19 @@ def cli(env, identifier, passwords=False, price=False):
         pass
 
     env.fout(table)
+
+
+def _cli_helper_dedicated_host(env, result, table):
+    """Get details on dedicated host for a virtual server."""
+
+    dedicated_host_id = utils.lookup(result, 'dedicatedHost', 'id')
+    if dedicated_host_id:
+        table.add_row(['dedicated_host_id', dedicated_host_id])
+        # Try to find name of dedicated host
+        try:
+            dedicated_host = env.client.call('Virtual_DedicatedHost', 'getObject',
+                                             id=dedicated_host_id)
+        except SoftLayer.SoftLayerAPIError:
+            dedicated_host = {}
+        table.add_row(['dedicated_host',
+                       dedicated_host.get('name') or formatting.blank()])

--- a/SoftLayer/CLI/virt/detail.py
+++ b/SoftLayer/CLI/virt/detail.py
@@ -1,6 +1,8 @@
 """Get details for a virtual server."""
 # :license: MIT, see LICENSE for more details.
 
+import logging
+
 import click
 
 import SoftLayer
@@ -8,6 +10,8 @@ from SoftLayer.CLI import environment
 from SoftLayer.CLI import formatting
 from SoftLayer.CLI import helpers
 from SoftLayer import utils
+
+LOGGER = logging.getLogger(__name__)
 
 
 @click.command()
@@ -152,6 +156,7 @@ def _cli_helper_dedicated_host(env, result, table):
             dedicated_host = env.client.call('Virtual_DedicatedHost', 'getObject',
                                              id=dedicated_host_id)
         except SoftLayer.SoftLayerAPIError:
+            LOGGER.error('Unable to get dedicated host id %s', dedicated_host_id)
             dedicated_host = {}
         table.add_row(['dedicated_host',
                        dedicated_host.get('name') or formatting.blank()])

--- a/SoftLayer/fixtures/SoftLayer_Virtual_DedicatedHost.py
+++ b/SoftLayer/fixtures/SoftLayer_Virtual_DedicatedHost.py
@@ -1,0 +1,10 @@
+getObject = {
+    'id': 37401,
+    'memoryCapacity': 242,
+    'modifyDate': '',
+    'name': 'test-dedicated',
+    'diskCapacity': 1200,
+    'createDate': '2017-10-16T12:50:23-05:00',
+    'cpuCount': 56,
+    'accountId': 1199911
+}

--- a/SoftLayer/fixtures/SoftLayer_Virtual_Guest.py
+++ b/SoftLayer/fixtures/SoftLayer_Virtual_Guest.py
@@ -44,6 +44,7 @@ getObject = {
     'networkVlans': [{'networkSpace': 'PUBLIC',
                       'vlanNumber': 23,
                       'id': 1}],
+    'dedicatedHost': {'id': 37401},
     'operatingSystem': {
         'passwords': [{'username': 'user', 'password': 'pass'}],
         'softwareLicense': {

--- a/tests/CLI/modules/vs_tests.py
+++ b/tests/CLI/modules/vs_tests.py
@@ -9,6 +9,7 @@ import json
 import mock
 
 from SoftLayer.CLI import exceptions
+from SoftLayer import SoftLayerAPIError
 from SoftLayer import testing
 
 
@@ -42,6 +43,8 @@ class VirtTests(testing.TestCase):
                           'cores': 2,
                           'created': '2013-08-01 15:23:45',
                           'datacenter': 'TEST00',
+                          'dedicated_host': 'test-dedicated',
+                          'dedicated_host_id': 37401,
                           'hostname': 'vs-test1',
                           'domain': 'test.sftlyr.ws',
                           'fqdn': 'vs-test1.test.sftlyr.ws',
@@ -87,6 +90,24 @@ class VirtTests(testing.TestCase):
             json.loads(result.output)['tags'],
             ['example-tag'],
         )
+
+    def test_detail_vs_dedicated_host_not_found(self):
+        ex = SoftLayerAPIError('SoftLayer_Exception', 'Not found')
+        mock = self.set_mock('SoftLayer_Virtual_DedicatedHost', 'getObject')
+        mock.side_effect = ex
+        result = self.run_command(['vs', 'detail', '100'])
+        self.assert_no_fail(result)
+        self.assertEqual(json.loads(result.output)['dedicated_host_id'], 37401)
+        self.assertIsNone(json.loads(result.output)['dedicated_host'])
+
+    def test_detail_vs_no_dedicated_host_hostname(self):
+        mock = self.set_mock('SoftLayer_Virtual_DedicatedHost', 'getObject')
+        mock.return_value = {'this_is_a_fudged_Virtual_DedicatedHost': True,
+                             'name_is_not_provided': ''}
+        result = self.run_command(['vs', 'detail', '100'])
+        self.assert_no_fail(result)
+        self.assertEqual(json.loads(result.output)['dedicated_host_id'], 37401)
+        self.assertIsNone(json.loads(result.output)['dedicated_host'])
 
     def test_create_options(self):
         result = self.run_command(['vs', 'create-options'])


### PR DESCRIPTION
This is only applicable for VSIs that were created to be in a
dedicated host.

Provide id and name of the dedicated host where VSI is running.