### PR TITLE
Remove redundant validation from duplicate ordering (covered by API)

### DIFF
--- a/SoftLayer/managers/storage_utils.py
+++ b/SoftLayer/managers/storage_utils.py
@@ -945,9 +945,8 @@ def prepare_duplicate_order_object(manager, origin_volume, iops, tier,
     if 'PERFORMANCE' in origin_storage_type:
         volume_is_performance = True
         if iops is None:
-            if isinstance(utils.lookup(origin_volume, 'provisionedIops'), str):
-                iops = int(origin_volume['provisionedIops'])
-            else:
+            iops = int(origin_volume.get('provisionedIops', 0))
+            if iops <= 0:
                 raise exceptions.SoftLayerError(
                     "Cannot find origin volume's provisioned IOPS")
         # Set up the price array for the order

--- a/tests/managers/block_tests.py
+++ b/tests/managers/block_tests.py
@@ -5,6 +5,7 @@
     :license: MIT, see LICENSE for more details.
 """
 
+import copy
 import SoftLayer
 from SoftLayer import exceptions
 from SoftLayer import fixtures
@@ -336,8 +337,7 @@ class BlockTests(testing.TestCase):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'PERFORMANCE_BLOCK_STORAGE'
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -374,8 +374,6 @@ class BlockTests(testing.TestCase):
                 'osFormatType': {'keyName': 'LINUX'}
             },)
         )
-
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
 
     def test_order_block_volume_endurance(self):
         mock = self.set_mock('SoftLayer_Location_Datacenter', 'getDatacenters')
@@ -498,8 +496,7 @@ class BlockTests(testing.TestCase):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'ENDURANCE_BLOCK_STORAGE'
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -524,8 +521,6 @@ class BlockTests(testing.TestCase):
                 'useHourlyPricing': False
             },)
         )
-
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
 
     def test_order_block_snapshot_space(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
@@ -557,8 +552,7 @@ class BlockTests(testing.TestCase):
         )
 
     def test_order_block_replicant_os_type_not_found(self):
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_os_type = mock_volume['osType']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         del mock_volume['osType']
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -575,8 +569,6 @@ class BlockTests(testing.TestCase):
             str(exception)
         )
 
-        mock_volume['osType'] = prev_os_type
-
     def test_order_block_replicant_performance_os_type_given(self):
         mock = self.set_mock('SoftLayer_Location_Datacenter', 'getDatacenters')
         mock.return_value = [{'id': 449494, 'name': 'dal09'}]
@@ -584,8 +576,7 @@ class BlockTests(testing.TestCase):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'PERFORMANCE_BLOCK_STORAGE'
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -624,8 +615,6 @@ class BlockTests(testing.TestCase):
                 'osFormatType': {'keyName': 'XEN'}
             },)
         )
-
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
 
     def test_order_block_replicant_endurance(self):
         mock = self.set_mock('SoftLayer_Location_Datacenter', 'getDatacenters')
@@ -671,8 +660,7 @@ class BlockTests(testing.TestCase):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_os_type = mock_volume['osType']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         del mock_volume['osType']
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -686,14 +674,11 @@ class BlockTests(testing.TestCase):
         self.assertEqual(str(exception),
                          "Cannot find origin volume's os-type")
 
-        mock_volume['osType'] = prev_os_type
-
     def test_order_block_duplicate_performance_no_duplicate_snapshot(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'PERFORMANCE_BLOCK_STORAGE'
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -726,14 +711,11 @@ class BlockTests(testing.TestCase):
                 'useHourlyPricing': False
             },))
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
     def test_order_block_duplicate_performance(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'PERFORMANCE_BLOCK_STORAGE'
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -772,8 +754,6 @@ class BlockTests(testing.TestCase):
                 'iops': 2000,
                 'useHourlyPricing': False
             },))
-
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
 
     def test_order_block_duplicate_endurance_no_duplicate_snapshot(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')

--- a/tests/managers/file_tests.py
+++ b/tests/managers/file_tests.py
@@ -5,6 +5,7 @@
     :license: MIT, see LICENSE for more details.
 """
 
+import copy
 import SoftLayer
 from SoftLayer import exceptions
 from SoftLayer import fixtures
@@ -410,8 +411,7 @@ class FileTests(testing.TestCase):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'PERFORMANCE_FILE_STORAGE'
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -447,8 +447,6 @@ class FileTests(testing.TestCase):
             },)
         )
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
     def test_order_file_volume_endurance(self):
         mock = self.set_mock('SoftLayer_Location_Datacenter', 'getDatacenters')
         mock.return_value = [{'id': 449494, 'name': 'dal09'}]
@@ -456,8 +454,7 @@ class FileTests(testing.TestCase):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'ENDURANCE_FILE_STORAGE'
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -492,14 +489,11 @@ class FileTests(testing.TestCase):
             },)
         )
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
     def test_order_file_snapshot_space_upgrade(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'ENDURANCE_FILE_STORAGE'
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -525,14 +519,11 @@ class FileTests(testing.TestCase):
             },)
         )
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
     def test_order_file_snapshot_space(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'ENDURANCE_FILE_STORAGE'
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -558,8 +549,6 @@ class FileTests(testing.TestCase):
             },)
         )
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
     def test_order_file_replicant_performance(self):
         mock = self.set_mock('SoftLayer_Location_Datacenter', 'getDatacenters')
         mock.return_value = [{'id': 449494, 'name': 'dal09'}]
@@ -567,8 +556,7 @@ class FileTests(testing.TestCase):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'PERFORMANCE_FILE_STORAGE'
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -602,8 +590,6 @@ class FileTests(testing.TestCase):
             },)
         )
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
     def test_order_file_replicant_endurance(self):
         mock = self.set_mock('SoftLayer_Location_Datacenter', 'getDatacenters')
         mock.return_value = [{'id': 449494, 'name': 'dal09'}]
@@ -611,8 +597,7 @@ class FileTests(testing.TestCase):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'ENDURANCE_FILE_STORAGE'
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -645,14 +630,11 @@ class FileTests(testing.TestCase):
             },)
         )
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
     def test_order_file_duplicate_performance_no_duplicate_snapshot(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'PERFORMANCE_FILE_STORAGE'
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -684,14 +666,11 @@ class FileTests(testing.TestCase):
                 'useHourlyPricing': False
             },))
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
     def test_order_file_duplicate_performance(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'PERFORMANCE_FILE_STORAGE'
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -730,14 +709,11 @@ class FileTests(testing.TestCase):
                 'useHourlyPricing': False
             },))
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
     def test_order_file_duplicate_endurance_no_duplicate_snapshot(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'ENDURANCE_FILE_STORAGE'
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -768,14 +744,11 @@ class FileTests(testing.TestCase):
                 'useHourlyPricing': False
             },))
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
     def test_order_file_duplicate_endurance(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'ENDURANCE_FILE_STORAGE'
         mock = self.set_mock('SoftLayer_Network_Storage', 'getObject')
         mock.return_value = mock_volume
@@ -812,5 +785,3 @@ class FileTests(testing.TestCase):
                 'duplicateOriginSnapshotId': 470,
                 'useHourlyPricing': False
             },))
-
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname

--- a/tests/managers/storage_utils_tests.py
+++ b/tests/managers/storage_utils_tests.py
@@ -5,6 +5,7 @@
     :license: MIT, see LICENSE for more details.
 """
 
+import copy
 import SoftLayer
 from SoftLayer import exceptions
 from SoftLayer import fixtures
@@ -2672,8 +2673,7 @@ class StorageUtilsTests(testing.TestCase):
     # Tests for prepare_snapshot_order_object()
     # ---------------------------------------------------------------------
     def test_prep_snapshot_order_billing_item_cancelled(self):
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_billing_item = mock_volume['billingItem']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         del mock_volume['billingItem']
 
         exception = self.assertRaises(
@@ -2687,11 +2687,8 @@ class StorageUtilsTests(testing.TestCase):
             str(exception)
         )
 
-        mock_volume['billingItem'] = prev_billing_item
-
     def test_prep_snapshot_order_invalid_billing_item_category_code(self):
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_billing_item_category = mock_volume['billingItem']['categoryCode']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['billingItem']['categoryCode'] = 'invalid_type_ninja_cat'
 
         exception = self.assertRaises(
@@ -2705,8 +2702,6 @@ class StorageUtilsTests(testing.TestCase):
             "billing item category code of 'invalid_type_ninja_cat'",
             str(exception)
         )
-
-        mock_volume['billingItem']['categoryCode'] = prev_billing_item_category
 
     def test_prep_snapshot_order_saas_endurance_tier_is_not_none(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
@@ -2758,9 +2753,7 @@ class StorageUtilsTests(testing.TestCase):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
-        prev_staas_version = mock_volume['staasVersion']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'PERFORMANCE_BLOCK_STORAGE'
         mock_volume['staasVersion'] = '1'
 
@@ -2776,15 +2769,11 @@ class StorageUtilsTests(testing.TestCase):
             str(exception)
         )
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-        mock_volume['staasVersion'] = prev_staas_version
-
     def test_prep_snapshot_order_saas_performance(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'PERFORMANCE_BLOCK_STORAGE'
 
         expected_object = {
@@ -2804,14 +2793,11 @@ class StorageUtilsTests(testing.TestCase):
 
         self.assertEqual(expected_object, result)
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
     def test_prep_snapshot_order_saas_invalid_storage_type(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'TASTY_PASTA_STORAGE'
 
         exception = self.assertRaises(
@@ -2826,8 +2812,6 @@ class StorageUtilsTests(testing.TestCase):
             "volume is a PERFORMANCE or an ENDURANCE volume)",
             str(exception)
         )
-
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
 
     def test_prep_snapshot_order_enterprise_tier_is_not_none(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
@@ -2883,8 +2867,7 @@ class StorageUtilsTests(testing.TestCase):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_hourly_flag = mock_volume['billingItem']['hourlyFlag']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['billingItem']['hourlyFlag'] = True
 
         expected_object = {
@@ -2903,8 +2886,6 @@ class StorageUtilsTests(testing.TestCase):
         )
 
         self.assertEqual(expected_object, result)
-
-        mock_volume['billingItem']['hourlyFlag'] = prev_hourly_flag
 
     # ---------------------------------------------------------------------
     # Tests for prepare_volume_order_object()
@@ -3233,8 +3214,7 @@ class StorageUtilsTests(testing.TestCase):
     # Tests for prepare_replicant_order_object()
     # ---------------------------------------------------------------------
     def test_prep_replicant_order_volume_cancelled(self):
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_billing_item = mock_volume['billingItem']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         del mock_volume['billingItem']
 
         exception = self.assertRaises(
@@ -3249,11 +3229,8 @@ class StorageUtilsTests(testing.TestCase):
             str(exception)
         )
 
-        mock_volume['billingItem'] = prev_billing_item
-
     def test_prep_replicant_order_volume_cancellation_date_set(self):
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_cancellation_date = mock_volume['billingItem']['cancellationDate']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['billingItem']['cancellationDate'] = 'y2k, oh nooooo'
 
         exception = self.assertRaises(
@@ -3268,12 +3245,9 @@ class StorageUtilsTests(testing.TestCase):
             str(exception)
         )
 
-        mock_volume['billingItem']['cancellationDate'] = prev_cancellation_date
-
     def test_prep_replicant_order_snapshot_space_cancelled(self):
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         snapshot_billing_item = mock_volume['billingItem']['activeChildren'][0]
-        prev_cancellation_date = snapshot_billing_item['cancellationDate']
         snapshot_billing_item['cancellationDate'] = 'daylight saving time, no!'
 
         exception = self.assertRaises(
@@ -3287,8 +3261,6 @@ class StorageUtilsTests(testing.TestCase):
             'cancellation; unable to order replicant volume',
             str(exception)
         )
-
-        snapshot_billing_item['cancellationDate'] = prev_cancellation_date
 
     def test_prep_replicant_order_invalid_location(self):
         mock = self.set_mock('SoftLayer_Location_Datacenter', 'getDatacenters')
@@ -3312,8 +3284,7 @@ class StorageUtilsTests(testing.TestCase):
         mock = self.set_mock('SoftLayer_Location_Datacenter', 'getDatacenters')
         mock.return_value = [{'id': 51, 'name': 'wdc04'}]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_billing_item_category = mock_volume['billingItem']['categoryCode']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['billingItem']['categoryCode'] = 'invalid_type_ninja_cat'
 
         exception = self.assertRaises(
@@ -3328,14 +3299,11 @@ class StorageUtilsTests(testing.TestCase):
             str(exception)
         )
 
-        mock_volume['billingItem']['categoryCode'] = prev_billing_item_category
-
     def test_prep_replicant_order_snapshot_capacity_not_found(self):
         mock = self.set_mock('SoftLayer_Location_Datacenter', 'getDatacenters')
         mock.return_value = [{'id': 51, 'name': 'wdc04'}]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_snapshot_capacity = mock_volume['snapshotCapacityGb']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         del mock_volume['snapshotCapacityGb']
 
         exception = self.assertRaises(
@@ -3348,8 +3316,6 @@ class StorageUtilsTests(testing.TestCase):
             "Snapshot capacity not found for the given primary volume",
             str(exception)
         )
-
-        mock_volume['snapshotCapacityGb'] = prev_snapshot_capacity
 
     def test_prep_replicant_order_saas_endurance(self):
         mock = self.set_mock('SoftLayer_Location_Datacenter', 'getDatacenters')
@@ -3425,9 +3391,7 @@ class StorageUtilsTests(testing.TestCase):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type = mock_volume['storageType']['keyName']
-        prev_has_encryption_at_rest_flag = mock_volume['hasEncryptionAtRest']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'PERFORMANCE_BLOCK_STORAGE'
         mock_volume['hasEncryptionAtRest'] = 0
 
@@ -3443,17 +3407,13 @@ class StorageUtilsTests(testing.TestCase):
             str(exception)
         )
 
-        mock_volume['storageType']['keyName'] = prev_storage_type
-        mock_volume['hasEncryptionAtRest'] = prev_has_encryption_at_rest_flag
-
     def test_prep_replicant_order_saas_performance(self):
         mock = self.set_mock('SoftLayer_Location_Datacenter', 'getDatacenters')
         mock.return_value = [{'id': 51, 'name': 'wdc04'}]
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'PERFORMANCE_BLOCK_STORAGE'
 
         expected_object = {
@@ -3483,16 +3443,13 @@ class StorageUtilsTests(testing.TestCase):
 
         self.assertEqual(expected_object, result)
 
-        mock_volume['storageType']['keyName'] = prev_storage_type
-
     def test_prep_replicant_order_saas_invalid_storage_type(self):
         mock = self.set_mock('SoftLayer_Location_Datacenter', 'getDatacenters')
         mock.return_value = [{'id': 51, 'name': 'wdc04'}]
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'CATS_LIKE_PIANO_MUSIC'
 
         exception = self.assertRaises(
@@ -3507,8 +3464,6 @@ class StorageUtilsTests(testing.TestCase):
             "volume is a PERFORMANCE or an ENDURANCE volume)",
             str(exception)
         )
-
-        mock_volume['storageType']['keyName'] = prev_storage_type
 
     def test_prep_replicant_order_ent_endurance(self):
         mock = self.set_mock('SoftLayer_Location_Datacenter', 'getDatacenters')
@@ -3586,8 +3541,7 @@ class StorageUtilsTests(testing.TestCase):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_hourly_flag = mock_volume['billingItem']['hourlyFlag']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['billingItem']['hourlyFlag'] = True
 
         expected_object = {
@@ -3616,8 +3570,6 @@ class StorageUtilsTests(testing.TestCase):
 
         self.assertEqual(expected_object, result)
 
-        mock_volume['billingItem']['hourlyFlag'] = prev_hourly_flag
-
     # ---------------------------------------------------------------------
     # Tests for prepare_duplicate_order_object()
     # ---------------------------------------------------------------------
@@ -3625,8 +3577,7 @@ class StorageUtilsTests(testing.TestCase):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_billing_item = mock_volume['billingItem']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         del mock_volume['billingItem']
 
         exception = self.assertRaises(
@@ -3639,14 +3590,11 @@ class StorageUtilsTests(testing.TestCase):
                          "The origin volume has been cancelled; "
                          "unable to order duplicate volume")
 
-        mock_volume['billingItem'] = prev_billing_item
-
     def test_prep_duplicate_order_origin_snapshot_capacity_not_found(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_snapshot_capacity_gb = mock_volume['snapshotCapacityGb']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         del mock_volume['snapshotCapacityGb']
 
         exception = self.assertRaises(
@@ -3659,14 +3607,11 @@ class StorageUtilsTests(testing.TestCase):
                          "Snapshot space not found for the origin volume. "
                          "Origin snapshot space is needed for duplication.")
 
-        mock_volume['snapshotCapacityGb'] = prev_snapshot_capacity_gb
-
     def test_prep_duplicate_order_origin_volume_location_not_found(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_location = mock_volume['billingItem']['location']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         del mock_volume['billingItem']['location']
 
         exception = self.assertRaises(
@@ -3678,14 +3623,11 @@ class StorageUtilsTests(testing.TestCase):
         self.assertEqual(str(exception),
                          "Cannot find origin volume's location")
 
-        mock_volume['billingItem']['location'] = prev_location
-
     def test_prep_duplicate_order_origin_volume_staas_version_below_v2(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_staas_version = mock_volume['staasVersion']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['staasVersion'] = 1
 
         exception = self.assertRaises(
@@ -3698,104 +3640,11 @@ class StorageUtilsTests(testing.TestCase):
                          "does not support Encryption at Rest.",
                          str(exception))
 
-        mock_volume['staasVersion'] = prev_staas_version
-
-    def test_prep_duplicate_order_origin_volume_capacity_not_found(self):
-        mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
-        mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
-
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_capacity_gb = mock_volume['capacityGb']
-        mock_volume['capacityGb'] = None
-
-        exception = self.assertRaises(
-            exceptions.SoftLayerError,
-            storage_utils.prepare_duplicate_order_object,
-            self.block, mock_volume, None, None, None, None, 'block'
-        )
-
-        self.assertEqual(str(exception), "Cannot find origin volume's size.")
-
-        mock_volume['capacityGb'] = prev_capacity_gb
-
-    def test_prep_duplicate_order_origin_originalVolumeSize_empty_block(self):
-        mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
-        mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
-
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_original_volume_size = mock_volume['originalVolumeSize']
-        del mock_volume['originalVolumeSize']
-
-        expected_object = {
-            'complexType': 'SoftLayer_Container_Product_Order_'
-                           'Network_Storage_AsAService',
-            'packageId': 759,
-            'prices': [
-                {'id': 189433},
-                {'id': 189443},
-                {'id': 193433},
-                {'id': 193373},
-                {'id': 193613}
-            ],
-            'volumeSize': 500,
-            'quantity': 1,
-            'location': 449500,
-            'duplicateOriginVolumeId': 102,
-            'useHourlyPricing': False}
-
-        result = storage_utils.prepare_duplicate_order_object(
-            self.block, mock_volume, None, None, None, None, 'block')
-
-        self.assertEqual(expected_object, result)
-
-        mock_volume['originalVolumeSize'] = prev_original_volume_size
-
-    def test_prep_duplicate_order_size_too_small(self):
-        mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
-        mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
-
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-
-        exception = self.assertRaises(
-            exceptions.SoftLayerError,
-            storage_utils.prepare_duplicate_order_object,
-            self.block, mock_volume, None, None, 250, None, 'block'
-        )
-
-        self.assertEqual(str(exception),
-                         "The requested duplicate volume size is too small. "
-                         "Duplicate volumes must be at least as large as "
-                         "their origin volumes.")
-
-    def test_prep_duplicate_order_size_too_large_block(self):
-        mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
-        mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
-
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-
-        exception = self.assertRaises(
-            exceptions.SoftLayerError,
-            storage_utils.prepare_duplicate_order_object,
-            self.block, mock_volume, None, None, 8000, None, 'block'
-        )
-
-        self.assertEqual(str(exception),
-                         "The requested duplicate volume size is too large. "
-                         "The maximum size for duplicate block volumes is 10 "
-                         "times the size of the origin volume or, if the "
-                         "origin volume was also a duplicate, 10 times the "
-                         "size of the initial origin volume (i.e. the origin "
-                         "volume from which the first duplicate was created "
-                         "in the chain of duplicates). "
-                         "Requested: 8000 GB. Base origin size: 500 GB.")
-
     def test_prep_duplicate_order_performance_origin_iops_not_found(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
-        prev_provisioned_iops = mock_volume['provisionedIops']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'PERFORMANCE_BLOCK_'\
                                                 'STORAGE_REPLICANT'
         mock_volume['provisionedIops'] = None
@@ -3809,62 +3658,12 @@ class StorageUtilsTests(testing.TestCase):
         self.assertEqual(str(exception),
                          "Cannot find origin volume's provisioned IOPS")
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-        mock_volume['provisionedIops'] = prev_provisioned_iops
-
-    def test_prep_duplicate_order_performance_iops_above_limit(self):
-        mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
-        mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
-
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
-        prev_provisioned_iops = mock_volume['provisionedIops']
-        mock_volume['storageType']['keyName'] = 'PERFORMANCE_BLOCK_STORAGE'
-        mock_volume['provisionedIops'] = '100'
-
-        exception = self.assertRaises(
-            exceptions.SoftLayerError,
-            storage_utils.prepare_duplicate_order_object,
-            self.block, mock_volume, 1000, None, 500, None, 'block'
-        )
-
-        self.assertEqual(str(exception),
-                         "Origin volume performance is < 0.3 IOPS/GB, "
-                         "duplicate volume performance must also be < 0.3 "
-                         "IOPS/GB. 2.0 IOPS/GB (1000/500) requested.")
-
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-        mock_volume['provisionedIops'] = prev_provisioned_iops
-
-    def test_prep_duplicate_order_performance_iops_below_limit(self):
-        mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
-        mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
-
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
-        mock_volume['storageType']['keyName'] = 'PERFORMANCE_BLOCK_STORAGE'
-
-        exception = self.assertRaises(
-            exceptions.SoftLayerError,
-            storage_utils.prepare_duplicate_order_object,
-            self.block, mock_volume, 200, None, 1000, None, 'block'
-        )
-
-        self.assertEqual(str(exception),
-                         "Origin volume performance is >= 0.3 IOPS/GB, "
-                         "duplicate volume performance must also be >= 0.3 "
-                         "IOPS/GB. 0.2 IOPS/GB (200/1000) requested.")
-
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
     def test_prep_duplicate_order_performance_use_default_origin_values(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
-        mock_volume['storageType']['keyName'] = 'PERFORMANCE_FILE_'\
-                                                'STORAGE_REPLICANT'
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
+        mock_volume['storageType']['keyName'] = 'PERFORMANCE_FILE_STORAGE_REPLICANT'
 
         expected_object = {
             'complexType': 'SoftLayer_Container_Product_Order_'
@@ -3889,14 +3688,11 @@ class StorageUtilsTests(testing.TestCase):
 
         self.assertEqual(expected_object, result)
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
     def test_prep_duplicate_order_performance_block(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'PERFORMANCE_BLOCK_STORAGE'
 
         expected_object = {
@@ -3922,14 +3718,11 @@ class StorageUtilsTests(testing.TestCase):
 
         self.assertEqual(expected_object, result)
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
     def test_prep_duplicate_order_performance_file(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'PERFORMANCE_FILE_STORAGE'
 
         expected_object = {
@@ -3955,75 +3748,11 @@ class StorageUtilsTests(testing.TestCase):
 
         self.assertEqual(expected_object, result)
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
-    def test_prep_duplicate_order_endurance_origin_tier_not_found(self):
-        mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
-        mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
-
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_tier_level = mock_volume['storageTierLevel']
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
-        mock_volume['storageTierLevel'] = 'NINJA_PENGUINS'
-        mock_volume['storageType']['keyName'] = 'ENDURANCE_BLOCK_'\
-                                                'STORAGE_REPLICANT'
-
-        exception = self.assertRaises(
-            exceptions.SoftLayerError,
-            storage_utils.prepare_duplicate_order_object,
-            self.block, mock_volume, None, None, None, None, 'block'
-        )
-
-        self.assertEqual(str(exception),
-                         "Cannot find origin volume's tier level")
-
-        mock_volume['storageTierLevel'] = prev_tier_level
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
-    def test_prep_duplicate_order_endurance_tier_above_limit(self):
-        mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
-        mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
-
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_tier_level = mock_volume['storageTierLevel']
-        mock_volume['storageTierLevel'] = 'LOW_INTENSITY_TIER'
-
-        exception = self.assertRaises(
-            exceptions.SoftLayerError,
-            storage_utils.prepare_duplicate_order_object,
-            self.block, mock_volume, None, 2, None, None, 'block'
-        )
-
-        self.assertEqual(str(exception),
-                         "Origin volume performance tier is 0.25 IOPS/GB, "
-                         "duplicate volume performance tier must also be 0.25 "
-                         "IOPS/GB. 2 IOPS/GB requested.")
-
-        mock_volume['storageTierLevel'] = prev_tier_level
-
-    def test_prep_duplicate_order_endurance_tier_below_limit(self):
-        mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
-        mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
-
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-
-        exception = self.assertRaises(
-            exceptions.SoftLayerError,
-            storage_utils.prepare_duplicate_order_object,
-            self.block, mock_volume, None, 0.25, None, None, 'block'
-        )
-
-        self.assertEqual(str(exception),
-                         "Origin volume performance tier is above 0.25 "
-                         "IOPS/GB, duplicate volume performance tier must "
-                         "also be above 0.25 IOPS/GB. 0.25 IOPS/GB requested.")
-
     def test_prep_duplicate_order_endurance_use_default_origin_values(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'ENDURANCE_FILE_'\
                                                 'STORAGE_REPLICANT'
 
@@ -4048,8 +3777,6 @@ class StorageUtilsTests(testing.TestCase):
             self.file, mock_volume, None, None, None, None, 'file')
 
         self.assertEqual(expected_object, result)
-
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
 
     def test_prep_duplicate_order_endurance_block(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
@@ -4083,8 +3810,7 @@ class StorageUtilsTests(testing.TestCase):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'ENDURANCE_FILE_STORAGE'
 
         expected_object = {
@@ -4109,14 +3835,11 @@ class StorageUtilsTests(testing.TestCase):
 
         self.assertEqual(expected_object, result)
 
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname
-
     def test_prep_duplicate_order_invalid_origin_storage_type(self):
         mock = self.set_mock('SoftLayer_Product_Package', 'getAllObjects')
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
-        mock_volume = fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME
-        prev_storage_type_keyname = mock_volume['storageType']['keyName']
+        mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
         mock_volume['storageType']['keyName'] = 'NINJA_CATS'
 
         exception = self.assertRaises(
@@ -4129,5 +3852,3 @@ class StorageUtilsTests(testing.TestCase):
                          "Origin volume does not have a valid storage type "
                          "(with an appropriate keyName to indicate the "
                          "volume is a PERFORMANCE or an ENDURANCE volume)")
-
-        mock_volume['storageType']['keyName'] = prev_storage_type_keyname

--- a/tests/managers/storage_utils_tests.py
+++ b/tests/managers/storage_utils_tests.py
@@ -3645,9 +3645,8 @@ class StorageUtilsTests(testing.TestCase):
         mock.return_value = [fixtures.SoftLayer_Product_Package.SAAS_PACKAGE]
 
         mock_volume = copy.deepcopy(fixtures.SoftLayer_Network_Storage.STAAS_TEST_VOLUME)
-        mock_volume['storageType']['keyName'] = 'PERFORMANCE_BLOCK_'\
-                                                'STORAGE_REPLICANT'
-        mock_volume['provisionedIops'] = None
+        mock_volume['storageType']['keyName'] = 'PERFORMANCE_BLOCK_STORAGE_REPLICANT'
+        del mock_volume['provisionedIops']
 
         exception = self.assertRaises(
             exceptions.SoftLayerError,


### PR DESCRIPTION
With the upcoming introduction of volume modification, some of the existing size-validation logic for ordering duplicate volumes is no longer valid in all cases. In this branch, I have removed most of the size and performance validation logic for ordering duplicate volumes, since this validation is done within the API anyway. While increased reliance on the API does limit how specific we can be with the SLCLI error messages, it does seem like reducing redundant validation logic in the SLCLI will help increase the SLCLI's maintainability overall. Please let me know if I have removed too much, and I will be happy to add logic back in if needed.

This branch also cleans up some unit tests by using deepcopy for copying test fixtures. This will prevent an undesirable "cascading test failure" effect that came with my previous implementation of some unit tests.