### PR TITLE
Broken unit tests

### DIFF
--- a/tests/managers/vs_tests.py
+++ b/tests/managers/vs_tests.py
@@ -5,7 +5,6 @@
     :license: MIT, see LICENSE for more details.
 
 """
-import logging
 import mock
 
 import SoftLayer
@@ -873,7 +872,6 @@ class VSWaitReadyGoTests(testing.TestCase):
             mock.call(id=1, mask=mock.ANY),
             mock.call(id=1, mask=mock.ANY),
         ])
-
 
     @mock.patch('time.time')
     @mock.patch('time.sleep')

--- a/tests/managers/vs_tests.py
+++ b/tests/managers/vs_tests.py
@@ -5,6 +5,7 @@
     :license: MIT, see LICENSE for more details.
 
 """
+import logging
 import mock
 
 import SoftLayer
@@ -863,7 +864,8 @@ class VSWaitReadyGoTests(testing.TestCase):
             {'activeTransaction': {'id': 1}},
             {'provisionDate': 'aaa'}
         ]
-        _time.side_effect = [0, 1, 2]
+        # logging calls time.time as of pytest3.3, not sure if there is a better way of getting around that.
+        _time.side_effect = [0, 0, 1, 1, 2, 2, 2]
         value = self.vs.wait_for_ready(1, 2, delay=1)
         self.assertFalse(value)
         _sleep.assert_called_once_with(1)
@@ -872,12 +874,14 @@ class VSWaitReadyGoTests(testing.TestCase):
             mock.call(id=1, mask=mock.ANY),
         ])
 
+
     @mock.patch('time.time')
     @mock.patch('time.sleep')
     def test_iter_20_incomplete(self, _sleep, _time):
         """Wait for up to 20 seconds (sleeping for 10 seconds) for a server."""
         self.guestObject.return_value = {'activeTransaction': {'id': 1}}
-        _time.side_effect = [0, 10, 20]
+        # logging calls time.time as of pytest3.3, not sure if there is a better way of getting around that.
+        _time.side_effect = [0, 0, 10, 10, 20, 20, 50, 60]
         value = self.vs.wait_for_ready(1, 20, delay=10)
         self.assertFalse(value)
         self.guestObject.assert_has_calls([mock.call(id=1, mask=mock.ANY)])
@@ -888,11 +892,12 @@ class VSWaitReadyGoTests(testing.TestCase):
     @mock.patch('random.randint')
     @mock.patch('time.time')
     @mock.patch('time.sleep')
-    def test_exception_from_api(self, _sleep, _time, _random, vs):
+    def test_exception_from_api(self, _sleep, _time, _random, _vs):
         """Tests escalating scale back when an excaption is thrown"""
         self.guestObject.return_value = {'activeTransaction': {'id': 1}}
-        vs.side_effect = exceptions.TransportError(104, "Its broken")
-        _time.side_effect = [0, 0, 2, 6, 14, 20, 100]
+        _vs.side_effect = exceptions.TransportError(104, "Its broken")
+        # logging calls time.time as of pytest3.3, not sure if there is a better way of getting around that.
+        _time.side_effect = [0, 0, 0, 0, 2, 2, 2, 6, 6, 6, 14, 14, 14, 20, 20, 20, 100, 100, 100]
         _random.side_effect = [0, 0, 0, 0, 0]
         value = self.vs.wait_for_ready(1, 20, delay=1)
         _sleep.assert_has_calls([

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34,py35,py36,pypy,analysis,coverage
+envlist = py27,py35,py36,pypy,analysis,coverage
 
 [flake8]
 max-line-length=120 


### PR DESCRIPTION
pytest 3.3 did some weird things with logging, which threw off any unit tests mocking time.time

Also pytest doesn't support python 3.3 anymore, so removed that from tox