### PR TITLE
Usage of requests.Session

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -29,3 +29,4 @@ Swapnil Khanapurkar <swapnil_khanapurkar@persistent.co.in>
 The SoftLayer Developer Network <sldn@softlayer.com>
 Tim Ariyeh <tim.ariyeh@gmail.com>
 Wissam Elriachy <wissam.elriachy@gmail.com>
+Anthony Monthe (ZuluPro) <anthony.monthe@gmail.com>

--- a/SoftLayer/transports.py
+++ b/SoftLayer/transports.py
@@ -40,6 +40,18 @@ REST_SPECIAL_METHODS = {
 }
 
 
+def get_session(user_agent):
+    client = requests.Session()
+    client.headers.update({
+        'Content-Type': 'application/json',
+        'User-Agent': user_agent,
+    })
+    retry = Retry(connect=3, backoff_factor=3)
+    adapter = HTTPAdapter(max_retries=retry)
+    client.mount('https://', adapter)
+    return client
+
+
 class Request(object):
     """Transport request object."""
 
@@ -113,14 +125,7 @@ class XmlRpcTransport(object):
     @property
     def client(self):
         if not hasattr(self, '_client'):
-            self._client = requests.Session()
-            self._client.headers.update({
-                'Content-Type': 'application/json',
-                'User-Agent': self.user_agent,
-            })
-            retry = Retry(connect=3, backoff_factor=3)
-            adapter = HTTPAdapter(max_retries=retry)
-            self._client.mount('https://', adapter)
+            self._client = get_session(self.user_agent)
         return self._client
 
     def __call__(self, request):
@@ -227,14 +232,7 @@ class RestTransport(object):
     @property
     def client(self):
         if not hasattr(self, '_client'):
-            self._client = requests.Session()
-            self._client.headers.update({
-                'Content-Type': 'application/json',
-                'User-Agent': self.user_agent,
-            })
-            retry = Retry(connect=3, backoff_factor=3)
-            adapter = HTTPAdapter(max_retries=retry)
-            self._client.mount('https://', adapter)
+            self._client = get_session(self.user_agent)
         return self._client
 
     def __call__(self, request):

--- a/tests/transport_tests.py
+++ b/tests/transport_tests.py
@@ -44,7 +44,7 @@ class TestXmlRpcAPICall(testing.TestCase):
         )
         self.response = get_xmlrpc_response()
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_call(self, request):
         request.return_value = self.response
 
@@ -95,7 +95,7 @@ class TestXmlRpcAPICall(testing.TestCase):
             warnings.warn("Incorrect Exception raised. Expected a "
                           "SoftLayer.TransportError error")
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_valid_proxy(self, request):
         request.return_value = self.response
         self.transport.proxy = 'http://localhost:3128'
@@ -116,7 +116,7 @@ class TestXmlRpcAPICall(testing.TestCase):
             cert=None,
             verify=True)
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_identifier(self, request):
         request.return_value = self.response
 
@@ -134,7 +134,7 @@ class TestXmlRpcAPICall(testing.TestCase):
 <value><int>1234</int></value>
 </member>""", kwargs['data'])
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_filter(self, request):
         request.return_value = self.response
 
@@ -152,7 +152,7 @@ class TestXmlRpcAPICall(testing.TestCase):
 <value><string>^= prefix</string></value>
 </member>""", kwargs['data'])
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_limit_offset(self, request):
         request.return_value = self.response
 
@@ -172,7 +172,7 @@ class TestXmlRpcAPICall(testing.TestCase):
 <value><int>10</int></value>
 </member>""", kwargs['data'])
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_old_mask(self, request):
         request.return_value = self.response
 
@@ -194,7 +194,7 @@ class TestXmlRpcAPICall(testing.TestCase):
 </struct></value>
 </member>""", kwargs['data'])
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_mask_call_no_mask_prefix(self, request):
         request.return_value = self.response
 
@@ -210,7 +210,7 @@ class TestXmlRpcAPICall(testing.TestCase):
             "<value><string>mask[something.nested]</string></value>",
             kwargs['data'])
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_mask_call_v2(self, request):
         request.return_value = self.response
 
@@ -226,7 +226,7 @@ class TestXmlRpcAPICall(testing.TestCase):
             "<value><string>mask[something[nested]]</string></value>",
             kwargs['data'])
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_mask_call_v2_dot(self, request):
         request.return_value = self.response
 
@@ -241,7 +241,7 @@ class TestXmlRpcAPICall(testing.TestCase):
         self.assertIn("<value><string>mask.something.nested</string></value>",
                       kwargs['data'])
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_request_exception(self, request):
         # Test Text Error
         e = requests.HTTPError('error')
@@ -257,7 +257,7 @@ class TestXmlRpcAPICall(testing.TestCase):
         self.assertRaises(SoftLayer.TransportError, self.transport, req)
 
 
-@mock.patch('requests.request')
+@mock.patch('SoftLayer.transports.requests.Session.request')
 @pytest.mark.parametrize(
     "transport_verify,request_verify,expected",
     [
@@ -313,7 +313,7 @@ class TestRestAPICall(testing.TestCase):
             endpoint_url='http://something.com',
         )
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_basic(self, request):
         request().content = '[]'
         request().text = '[]'
@@ -340,7 +340,7 @@ class TestRestAPICall(testing.TestCase):
             proxies=None,
             timeout=None)
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_error(self, request):
         # Test JSON Error
         e = requests.HTTPError('error')
@@ -369,7 +369,7 @@ class TestRestAPICall(testing.TestCase):
             warnings.warn("AssertionError raised instead of a "
                           "SoftLayer.TransportError error")
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_valid_proxy(self, request):
         request().text = '{}'
         self.transport.proxy = 'http://localhost:3128'
@@ -392,7 +392,7 @@ class TestRestAPICall(testing.TestCase):
             timeout=mock.ANY,
             headers=mock.ANY)
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_with_id(self, request):
         request().text = '{}'
 
@@ -416,7 +416,7 @@ class TestRestAPICall(testing.TestCase):
             proxies=None,
             timeout=None)
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_with_args(self, request):
         request().text = '{}'
 
@@ -440,7 +440,7 @@ class TestRestAPICall(testing.TestCase):
             proxies=None,
             timeout=None)
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_with_filter(self, request):
         request().text = '{}'
 
@@ -465,7 +465,7 @@ class TestRestAPICall(testing.TestCase):
             proxies=None,
             timeout=None)
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_with_mask(self, request):
         request().text = '{}'
 
@@ -510,7 +510,7 @@ class TestRestAPICall(testing.TestCase):
             proxies=None,
             timeout=None)
 
-    @mock.patch('requests.request')
+    @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_unknown_error(self, request):
         e = requests.RequestException('error')
         e.response = mock.MagicMock()


### PR DESCRIPTION
I just experienced the following error:

```
File "/usr/local/lib/python2.7/dist-packages/SoftLayer/API.py", line 360, in call
    return self.client.call(self.name, name, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/SoftLayer/API.py", line 263, in call
    return self.transport(request)
  File "/usr/local/lib/python2.7/dist-packages/SoftLayer/transports.py", line 199, in __call__
    raise exceptions.TransportError(0, str(ex))
SoftLayer.exceptions.TransportError: TransportError(0): ('Connection broken: error("(104, \'ECONNRESET\')",)', error("(104, 'ECONNRESET')",))
```

So I though about the change the transport implementation to allow retries in case connection error.

This also create memoized session.