### PR TITLE
WIP: Add support for specifying a subnet on a private VLAN

### DIFF
--- a/SoftLayer/CLI/virt/create.py
+++ b/SoftLayer/CLI/virt/create.py
@@ -132,6 +132,9 @@ def _parse_create_args(client, args):
     if args.get('vlan_private'):
         data['private_vlan'] = args['vlan_private']
 
+    if args.get('vlan_private_subnet'):
+        data['private_vlan_subnet'] = args['vlan_private_subnet']
+
     if args.get('public_security_group'):
         pub_groups = args.get('public_security_group')
         data['public_security_groups'] = [group for group in pub_groups]
@@ -225,6 +228,10 @@ def _parse_create_args(client, args):
               type=click.INT)
 @click.option('--vlan-private',
               help="The ID of the private VLAN on which you want the virtual "
+                   "server placed",
+              type=click.INT)
+@click.option('--vlan-private-subnet',
+              help="The ID of the private VLAN subnet on which you want the virtual "
                    "server placed",
               type=click.INT)
 @helpers.multi_option('--public-security-group',

--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -309,7 +309,7 @@ class VSManager(utils.IdentifierMixin, object):
             dedicated=False, public_vlan=None, private_vlan=None,
             userdata=None, nic_speed=None, disks=None, post_uri=None,
             private=False, ssh_keys=None, public_security_groups=None,
-            private_security_groups=None, **kwargs):
+            private_security_groups=None, private_vlan_subnet=None, **kwargs):
         """Returns a dict appropriate to pass into Virtual_Guest::createObject
 
             See :func:`create_instance` for a list of available options.
@@ -368,10 +368,25 @@ class VSManager(utils.IdentifierMixin, object):
             data.update({
                 'primaryNetworkComponent': {
                     "networkVlan": {"id": int(public_vlan)}}})
+
         if private_vlan:
-            data.update({
-                "primaryBackendNetworkComponent": {
-                    "networkVlan": {"id": int(private_vlan)}}})
+            # As per https://stackoverflow.com/questions/37592080/create-a-softlayer-virtual-guest-on-a-specific-subnet
+            # we can specify a subnet under the VLAN
+            if private_vlan_subnet:
+                data.update({
+                    "primaryBackendNetworkComponent": {
+                        "networkVlanId": int(private_vlan),
+                        "networkVlan": {
+                            "primarySubnet": {
+                                "id": int(private_vlan_subnet)
+                            }
+                        }
+                    }
+                })
+            else:
+                data.update({
+                    "primaryBackendNetworkComponent": {
+                        "networkVlan": {"id": int(private_vlan)}}})
 
         if public_security_groups:
             secgroups = [{'securityGroup': {'id': int(sg)}}
@@ -565,6 +580,7 @@ class VSManager(utils.IdentifierMixin, object):
         :param list public_security_groups: The list of security group IDs to apply to the public interface
         :param list private_security_groups: The list of security group IDs to apply to the private interface
         :param int private_vlan: The ID of the private VLAN on which you want  this VS placed.
+        :param int private_vlan_subnet: The ID of the private VLAN subnet on which you want  this VS placed.
         :param list disks: A list of disk capacities for this server.
         :param string post_uri: The URI of the post-install script to run  after reload
         :param bool private: If true, the VS will be provisioned only with access to the private network.


### PR DESCRIPTION
  - For https://github.com/softlayer/softlayer-python/issues/921
  - When a private subnet id is given in addition to a private
    VLAN id this extra information will be passed to the create
    request to further specify the location of the VM
  - TODO: Support specifying subnet on the public network interface
  - TODO: Pass lint checks