### PR TITLE
Improve error handling when adding SSH keys

### DIFF
--- a/SoftLayer/CLI/sshkey/add.py
+++ b/SoftLayer/CLI/sshkey/add.py
@@ -6,6 +6,7 @@ import click
 
 import SoftLayer
 from SoftLayer.CLI import environment
+from SoftLayer.CLI import exceptions
 
 
 @click.command()
@@ -18,6 +19,16 @@ from SoftLayer.CLI import environment
 @environment.pass_env
 def cli(env, label, in_file, key, note):
     """Add a new SSH key."""
+
+    if in_file is None and key is None:
+        raise exceptions.ArgumentError(
+            'Either [-f | --in-file] or [-k | --key] arguments are required to add a key'
+        )
+
+    if in_file and key:
+        raise exceptions.ArgumentError(
+            '[-f | --in-file] is not allowed with [-k | --key]'
+        )
 
     if key:
         key_text = key

--- a/SoftLayer/managers/sshkey.py
+++ b/SoftLayer/managers/sshkey.py
@@ -28,6 +28,7 @@ class SshKeyManager(utils.IdentifierMixin, object):
 
         :param string key: The SSH key to add
         :param string label: The label for the key
+        :param string notes: Additional notes for the key
         :returns: A dictionary of the new key's information.
         """
         order = {

--- a/tests/CLI/modules/sshkey_tests.py
+++ b/tests/CLI/modules/sshkey_tests.py
@@ -12,9 +12,24 @@ import tempfile
 import mock
 
 from SoftLayer import testing
+from SoftLayer.CLI import exceptions
 
 
 class SshKeyTests(testing.TestCase):
+    def test_add_without_key_errors(self):
+        result = self.run_command(['sshkey', 'add', 'key1'])
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertIsInstance(result.exception, exceptions.ArgumentError)
+
+    def test_add_with_key_file_and_key_argument_errors(self):
+        path = os.path.join(testing.FIXTURE_PATH, 'id_rsa.pub')
+        result = self.run_command(['sshkey', 'add', 'key1',
+                                   '--key=some_key',
+                                   '--in-file=%s' % path])
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertIsInstance(result.exception, exceptions.ArgumentError)
 
     def test_add_by_option(self):
         service = self.client['Security_Ssh_Key']

--- a/tests/CLI/modules/sshkey_tests.py
+++ b/tests/CLI/modules/sshkey_tests.py
@@ -11,8 +11,8 @@ import tempfile
 
 import mock
 
-from SoftLayer import testing
 from SoftLayer.CLI import exceptions
+from SoftLayer import testing
 
 
 class SshKeyTests(testing.TestCase):


### PR DESCRIPTION
Fixes the messaging confusion shown in #925 when a new SSH key is added from the CLI.