### PR TITLE
Add fix for unsetting of values in edit SG rules

### DIFF
--- a/SoftLayer/managers/network.py
+++ b/SoftLayer/managers/network.py
@@ -318,19 +318,19 @@ class NetworkManager(object):
         """
         successful = False
         obj = {}
-        if remote_ip:
+        if remote_ip is not None:
             obj['remoteIp'] = remote_ip
-        if remote_group:
+        if remote_group is not None:
             obj['remoteGroupId'] = remote_group
-        if direction:
+        if direction is not None:
             obj['direction'] = direction
-        if ethertype:
+        if ethertype is not None:
             obj['ethertype'] = ethertype
-        if port_max:
+        if port_max is not None:
             obj['portRangeMax'] = port_max
-        if port_min:
+        if port_min is not None:
             obj['portRangeMin'] = port_min
-        if protocol:
+        if protocol is not None:
             obj['protocol'] = protocol
 
         if obj:

--- a/tests/managers/network_tests.py
+++ b/tests/managers/network_tests.py
@@ -244,6 +244,23 @@ class NetworkTests(testing.TestCase):
                                 args=([{'id': 500,
                                         'direction': 'ingress'}],))
 
+    def test_edit_securitygroup_rule_unset(self):
+        # Test calling edit rule with falsy values, which are used
+        # to unset those values in the API
+        result = self.network.edit_securitygroup_rule(100, 500,
+                                                      protocol='',
+                                                      port_min=-1,
+                                                      port_max=-1,
+                                                      ethertype='',
+                                                      remote_ip='')
+
+        self.assertTrue(result)
+        self.assert_called_with('SoftLayer_Network_SecurityGroup',
+                                'editRules', identifier=100,
+                                args=([{'id': 500, 'protocol': '',
+                                        'portRangeMin': -1, 'portRangeMax': -1,
+                                        'ethertype': '', 'remoteIp': ''}],))
+
     def test_get_rwhois(self):
         result = self.network.get_rwhois()
 


### PR DESCRIPTION
The SL API for editing security group rules allows you to unset string
values by passing in an empty string (''). The edit_securitygroup_rule()
function skipped over any values that were falsy (because if they
weren't set in the arguments, we don't want to change them).
Unfortunately, this caused values that were an empty string to also get
skipped over and not get unset in the API. So edit needs to check
explicitly for None (don't change) in order to get skipped over in
passing to the API.