### PR TITLE
#959 added warning message when ordering legacy storage offerings

### DIFF
--- a/SoftLayer/CLI/block/order.py
+++ b/SoftLayer/CLI/block/order.py
@@ -60,9 +60,9 @@ CONTEXT_SETTINGS = {'token_normalize_func': lambda x: x.upper()}
 @environment.pass_env
 def cli(env, storage_type, size, iops, tier, os_type,
         location, snapshot_size, service_offering, billing):
-    """Order a block storage volume. 
+    """Order a block storage volume.
 
-    Valid size and iops options can be found here: 
+    Valid size and iops options can be found here:
     https://console.bluemix.net/docs/infrastructure/BlockStorage/index.html#provisioning
     """
     block_manager = SoftLayer.BlockStorageManager(env.client)

--- a/SoftLayer/CLI/block/order.py
+++ b/SoftLayer/CLI/block/order.py
@@ -60,7 +60,11 @@ CONTEXT_SETTINGS = {'token_normalize_func': lambda x: x.upper()}
 @environment.pass_env
 def cli(env, storage_type, size, iops, tier, os_type,
         location, snapshot_size, service_offering, billing):
-    """Order a block storage volume."""
+    """Order a block storage volume. 
+
+    Valid size and iops options can be found here: 
+    https://console.bluemix.net/docs/infrastructure/BlockStorage/index.html#provisioning
+    """
     block_manager = SoftLayer.BlockStorageManager(env.client)
     storage_type = storage_type.lower()
 

--- a/SoftLayer/CLI/block/order.py
+++ b/SoftLayer/CLI/block/order.py
@@ -17,17 +17,14 @@ CONTEXT_SETTINGS = {'token_normalize_func': lambda x: x.upper()}
               required=True)
 @click.option('--size',
               type=int,
-              help='Size of block storage volume in GB. Permitted Sizes:\n'
-                   '20, 40, 80, 100, 250, 500, 1000, 2000, 4000, 8000, 12000',
+              help='Size of block storage volume in GB.',
               required=True)
 @click.option('--iops',
               type=int,
-              help='Performance Storage IOPs,'
-              ' between 100 and 6000 in multiples of 100'
-              '  [required for storage-type performance]')
+              help="""Performance Storage IOPs. Options vary based on storage size.
+[required for storage-type performance]""")
 @click.option('--tier',
-              help='Endurance Storage Tier (IOP per GB)'
-              '  [required for storage-type endurance]',
+              help='Endurance Storage Tier (IOP per GB) [required for storage-type endurance]',
               type=click.Choice(['0.25', '2', '4', '10']))
 @click.option('--os-type',
               help='Operating System',
@@ -49,8 +46,8 @@ CONTEXT_SETTINGS = {'token_normalize_func': lambda x: x.upper()}
               'space along with endurance block storage; specifies '
               'the size (in GB) of snapshot space to order')
 @click.option('--service-offering',
-              help='The service offering package to use for placing '
-              'the order [optional, default is \'storage_as_a_service\']',
+              help="""The service offering package to use for placing the order.
+[optional, default is \'storage_as_a_service\']. enterprise and performance are depreciated""",
               default='storage_as_a_service',
               type=click.Choice([
                   'storage_as_a_service',
@@ -71,26 +68,21 @@ def cli(env, storage_type, size, iops, tier, os_type,
     if billing.lower() == "hourly":
         hourly_billing_flag = True
 
-    if hourly_billing_flag and service_offering != 'storage_as_a_service':
-        raise exceptions.CLIAbort(
-            'Hourly billing is only available for the storage_as_a_service '
-            'service offering'
-        )
+    if service_offering != 'storage_as_a_service':
+        click.secho('{} is a legacy storage offering'.format(service_offering), fg='red')
+        if hourly_billing_flag:
+            raise exceptions.CLIAbort(
+                'Hourly billing is only available for the storage_as_a_service service offering'
+            )
 
     if storage_type == 'performance':
         if iops is None:
-            raise exceptions.CLIAbort(
-                'Option --iops required with Performance')
-
-        if iops % 100 != 0:
-            raise exceptions.CLIAbort(
-                'Option --iops must be a multiple of 100'
-            )
+            raise exceptions.CLIAbort('Option --iops required with Performance')
 
         if service_offering == 'performance' and snapshot_size is not None:
             raise exceptions.CLIAbort(
-                '--snapshot-size is not available for performance volumes '
-                'ordered with the \'performance\' service offering option'
+                '--snapshot-size is not available for performance service offerings. '
+                'Use --service-offering storage_as_a_service'
             )
 
         try:
@@ -110,8 +102,7 @@ def cli(env, storage_type, size, iops, tier, os_type,
     if storage_type == 'endurance':
         if tier is None:
             raise exceptions.CLIAbort(
-                'Option --tier required with Endurance in IOPS/GB '
-                '[0.25,2,4,10]'
+                'Option --tier required with Endurance in IOPS/GB [0.25,2,4,10]'
             )
 
         try:
@@ -134,5 +125,4 @@ def cli(env, storage_type, size, iops, tier, os_type,
         for item in order['placedOrder']['items']:
             click.echo(" > %s" % item['description'])
     else:
-        click.echo("Order could not be placed! Please verify your options " +
-                   "and try again.")
+        click.echo("Order could not be placed! Please verify your options and try again.")

--- a/SoftLayer/CLI/core.py
+++ b/SoftLayer/CLI/core.py
@@ -75,7 +75,8 @@ username and api_key need to be configured. The easiest way to do that is to
 use: 'slcli setup'""",
              cls=CommandLoader,
              context_settings={'help_option_names': ['-h', '--help'],
-                               'auto_envvar_prefix': 'SLCLI'})
+                               'auto_envvar_prefix': 'SLCLI',
+                               'max_content_width': 999})
 @click.option('--format',
               default=DEFAULT_FORMAT,
               show_default=True,

--- a/SoftLayer/CLI/file/order.py
+++ b/SoftLayer/CLI/file/order.py
@@ -50,8 +50,8 @@ CONTEXT_SETTINGS = {'token_normalize_func': lambda x: x.upper()}
 def cli(env, storage_type, size, iops, tier,
         location, snapshot_size, service_offering, billing):
     """Order a file storage volume.
-    
-    Valid size and iops options can be found here: 
+
+    Valid size and iops options can be found here:
     https://console.bluemix.net/docs/infrastructure/FileStorage/index.html#provisioning
     """
     file_manager = SoftLayer.FileStorageManager(env.client)

--- a/SoftLayer/CLI/file/order.py
+++ b/SoftLayer/CLI/file/order.py
@@ -49,7 +49,11 @@ CONTEXT_SETTINGS = {'token_normalize_func': lambda x: x.upper()}
 @environment.pass_env
 def cli(env, storage_type, size, iops, tier,
         location, snapshot_size, service_offering, billing):
-    """Order a file storage volume."""
+    """Order a file storage volume.
+    
+    Valid size and iops options can be found here: 
+    https://console.bluemix.net/docs/infrastructure/FileStorage/index.html#provisioning
+    """
     file_manager = SoftLayer.FileStorageManager(env.client)
     storage_type = storage_type.lower()
 

--- a/SoftLayer/CLI/file/order.py
+++ b/SoftLayer/CLI/file/order.py
@@ -35,8 +35,8 @@ CONTEXT_SETTINGS = {'token_normalize_func': lambda x: x.upper()}
               'space along with endurance file storage; specifies '
               'the size (in GB) of snapshot space to order')
 @click.option('--service-offering',
-              help='The service offering package to use for placing '
-              'the order [optional, default is \'storage_as_a_service\']',
+              help="""The service offering package to use for placing the order.
+[optional, default is \'storage_as_a_service\']. enterprise and performance are depreciated""",
               default='storage_as_a_service',
               type=click.Choice([
                   'storage_as_a_service',
@@ -70,13 +70,12 @@ def cli(env, storage_type, size, iops, tier,
 
     if storage_type == 'performance':
         if iops is None:
-            raise exceptions.CLIAbort(
-                'Option --iops required with Performance')
+            raise exceptions.CLIAbort('Option --iops required with Performance')
 
         if service_offering == 'performance' and snapshot_size is not None:
             raise exceptions.CLIAbort(
-                '--snapshot-size is not available for performance volumes '
-                'ordered with the \'performance\' service offering option'
+                '--snapshot-size is not available for performance service offerings. '
+                'Use --service-offering storage_as_a_service'
             )
 
         try:

--- a/SoftLayer/CLI/file/order.py
+++ b/SoftLayer/CLI/file/order.py
@@ -21,12 +21,10 @@ CONTEXT_SETTINGS = {'token_normalize_func': lambda x: x.upper()}
               required=True)
 @click.option('--iops',
               type=int,
-              help='Performance Storage IOPs,'
-              ' between 100 and 6000 in multiples of 100'
-              '  [required for storage-type performance]')
+              help="""Performance Storage IOPs. Options vary based on storage size.
+[required for storage-type performance]""")
 @click.option('--tier',
-              help='Endurance Storage Tier (IOP per GB)'
-              '  [required for storage-type endurance]',
+              help='Endurance Storage Tier (IOP per GB) [required for storage-type endurance]',
               type=click.Choice(['0.25', '2', '4', '10']))
 @click.option('--location',
               help='Datacenter short name (e.g.: dal09)',
@@ -59,21 +57,17 @@ def cli(env, storage_type, size, iops, tier,
     if billing.lower() == "hourly":
         hourly_billing_flag = True
 
-    if hourly_billing_flag and service_offering != 'storage_as_a_service':
-        raise exceptions.CLIAbort(
-            'Hourly billing is only available for the storage_as_a_service '
-            'service offering'
-        )
+    if service_offering != 'storage_as_a_service':
+        click.secho('{} is a legacy storage offering'.format(service_offering), fg='red')
+        if hourly_billing_flag:
+            raise exceptions.CLIAbort(
+                'Hourly billing is only available for the storage_as_a_service service offering'
+            )
 
     if storage_type == 'performance':
         if iops is None:
             raise exceptions.CLIAbort(
                 'Option --iops required with Performance')
-
-        if iops % 100 != 0:
-            raise exceptions.CLIAbort(
-                'Option --iops must be a multiple of 100'
-            )
 
         if service_offering == 'performance' and snapshot_size is not None:
             raise exceptions.CLIAbort(
@@ -97,8 +91,7 @@ def cli(env, storage_type, size, iops, tier,
     if storage_type == 'endurance':
         if tier is None:
             raise exceptions.CLIAbort(
-                'Option --tier required with Endurance in IOPS/GB '
-                '[0.25,2,4,10]'
+                'Option --tier required with Endurance in IOPS/GB [0.25,2,4,10]'
             )
 
         try:
@@ -120,5 +113,4 @@ def cli(env, storage_type, size, iops, tier,
         for item in order['placedOrder']['items']:
             click.echo(" > %s" % item['description'])
     else:
-        click.echo("Order could not be placed! Please verify your options " +
-                   "and try again.")
+        click.echo("Order could not be placed! Please verify your options and try again.")

--- a/tests/CLI/modules/block_tests.py
+++ b/tests/CLI/modules/block_tests.py
@@ -141,14 +141,6 @@ class BlockTests(testing.TestCase):
 
         self.assertEqual(2, result.exit_code)
 
-    def test_volume_order_performance_iops_not_multiple_of_100(self):
-        result = self.run_command(['block', 'volume-order',
-                                   '--storage-type=performance', '--size=20',
-                                   '--iops=122', '--os-type=linux',
-                                   '--location=dal05'])
-
-        self.assertEqual(2, result.exit_code)
-
     def test_volume_order_performance_snapshot_error(self):
         result = self.run_command(['block', 'volume-order',
                                    '--storage-type=performance', '--size=20',

--- a/tests/CLI/modules/file_tests.py
+++ b/tests/CLI/modules/file_tests.py
@@ -144,13 +144,6 @@ class FileTests(testing.TestCase):
 
         self.assertEqual(2, result.exit_code)
 
-    def test_volume_order_performance_iops_not_multiple_of_100(self):
-        result = self.run_command(['file', 'volume-order',
-                                   '--storage-type=performance', '--size=20',
-                                   '--iops=122', '--location=dal05'])
-
-        self.assertEqual(2, result.exit_code)
-
     def test_volume_order_performance_snapshot_error(self):
         result = self.run_command(['file', 'volume-order',
                                    '--storage-type=performance', '--size=20',


### PR DESCRIPTION
added warning message when ordering legacy storage offerings from the cli, removed restriction on IOPS being multiples of 100 for performance volumes