### PR TITLE
Fix issue 966 - order NETWORK_GATEWAY_APPLINCE with slcli but meet error Price does not have an id

### DIFF
--- a/SoftLayer/CLI/order/place.py
+++ b/SoftLayer/CLI/order/place.py
@@ -88,7 +88,7 @@ def cli(env, package_keyname, location, preset, verify, billing, complex_type,
     if verify:
         table = formatting.Table(COLUMNS)
         order_to_place = manager.verify_order(*args, **kwargs)
-        for price in order_to_place['prices']:
+        for price in order_to_place['orderContainers'][0]['prices']:
             cost_key = 'hourlyRecurringFee' if billing == 'hourly' else 'recurringFee'
             table.add_row([
                 price['item']['keyName'],

--- a/SoftLayer/managers/ordering.py
+++ b/SoftLayer/managers/ordering.py
@@ -445,6 +445,7 @@ class OrderingManager(object):
         :param int quantity: The number of resources to order
 
         """
+        container = {}
         order = {}
         extras = extras or {}
 
@@ -470,7 +471,10 @@ class OrderingManager(object):
 
         price_ids = self.get_price_id_list(package_keyname, item_keynames)
         order['prices'] = [{'id': price_id} for price_id in price_ids]
-        return order
+
+        container['orderContainers'] = [order]
+
+        return container
 
     def package_locations(self, package_keyname):
         """List datacenter locations for a package keyname

--- a/tests/CLI/modules/order_tests.py
+++ b/tests/CLI/modules/order_tests.py
@@ -133,7 +133,7 @@ class OrderTests(testing.TestCase):
         self.assert_called_with('SoftLayer_Product_Order', 'verifyOrder')
         expected_results = []
 
-        for price in order['prices']:
+        for price in order['orderContainers'][0]['prices']:
             expected_results.append({'keyName': price['item']['keyName'],
                                      'description': price['item']['description'],
                                      'cost': price['hourlyRecurringFee']})
@@ -160,7 +160,7 @@ class OrderTests(testing.TestCase):
         self.assert_called_with('SoftLayer_Product_Order', 'verifyOrder')
         expected_results = []
 
-        for price in order['prices']:
+        for price in order['orderContainers'][0]['prices']:
             expected_results.append({'keyName': price['item']['keyName'],
                                      'description': price['item']['description'],
                                      'cost': price['recurringFee']})
@@ -222,4 +222,4 @@ class OrderTests(testing.TestCase):
                   'recurringFee': '120'}
         price2 = {'item': item2, 'hourlyRecurringFee': '0.05',
                   'recurringFee': '150'}
-        return {'prices': [price1, price2]}
+        return {'orderContainers': [{'prices': [price1, price2]}]}

--- a/tests/managers/ordering_tests.py
+++ b/tests/managers/ordering_tests.py
@@ -321,13 +321,15 @@ class OrderingTests(testing.TestCase):
         complex_type = 'SoftLayer_Container_Foo'
         items = ['ITEM1', 'ITEM2']
         preset = 'PRESET_KEYNAME'
-        expected_order = {'complexType': 'SoftLayer_Container_Foo',
-                          'location': 1854895,
-                          'packageId': 1234,
-                          'presetId': 5678,
-                          'prices': [{'id': 1111}, {'id': 2222}],
-                          'quantity': 1,
-                          'useHourlyPricing': True}
+        expected_order = {'orderContainers': [
+                            {'complexType': 'SoftLayer_Container_Foo',
+                             'location': 1854895,
+                             'packageId': 1234,
+                             'presetId': 5678,
+                             'prices': [{'id': 1111}, {'id': 2222}],
+                             'quantity': 1,
+                             'useHourlyPricing': True}
+                         ]}
 
         mock_pkg, mock_preset, mock_get_ids = self._patch_for_generate()
 
@@ -342,12 +344,14 @@ class OrderingTests(testing.TestCase):
         pkg = 'PACKAGE_KEYNAME'
         items = ['ITEM1', 'ITEM2']
         complex_type = 'My_Type'
-        expected_order = {'complexType': 'My_Type',
-                          'location': 1854895,
-                          'packageId': 1234,
-                          'prices': [{'id': 1111}, {'id': 2222}],
-                          'quantity': 1,
-                          'useHourlyPricing': True}
+        expected_order = {'orderContainers': [
+                            {'complexType': 'My_Type',
+                             'location': 1854895,
+                             'packageId': 1234,
+                             'prices': [{'id': 1111}, {'id': 2222}],
+                             'quantity': 1,
+                             'useHourlyPricing': True}
+                         ]}
 
         mock_pkg, mock_preset, mock_get_ids = self._patch_for_generate()
 


### PR DESCRIPTION
Fix for #966 

It was tested on a QA environment for NETWORK_GATEWAY_APPLIANCE, 2U_NETWORK_GATEWAY_APPLIANCE_1O_GBPS, BARE_METAL_SERVER with preset D2620V4_64GB_2X1TB_SATA_RAID_1, CLOUD_SERVER, PORTABLE_STORAGE, DUAL_E52600_V4_12_DRIVES

Below examples for gateways:

**NETWORK_GATEWAY_APPLIANCE**

`$ slcli order place --verify --billing monthly NETWORK_GATEWAY_APPLIANCE DALLAS06 INTEL_SINGLE_XEON_1270_3_50 RAM_8_GB_DDR3_1333_ECC_NON_REG OS_VYATTA_5600_5_X_UP_TO_1GBPS_SUBSCRIPTION_EDITION_64_BIT DISK_CONTROLLER_NONRAID HARD_DRIVE_500GB_SATA_II BANDWIDTH_20000_GB 100_MBPS_PUBLIC_PRIVATE_NETWORK_UPLINKS 1_IPV6_ADDRESS MONITORING_HOST_PING AUTOMATED_NOTIFICATION UNLIMITED_SSL_VPN_USERS_1_PPTP_VPN_USER_PER_ACCOUNT NESSUS_VULNERABILITY_ASSESSMENT_REPORTING 1_IP_ADDRESS NOTIFICATION_EMAIL_AND_TICKET REBOOT_KVM_OVER_IP --complex-type SoftLayer_Container_Product_Order_Hardware_Server_Gateway_Appliance --extras '{"hardware": [{"hostname" : "ajcbGateway01", "domain": "acamacho.com"}], "sshKeys" : [87634], "tags": "acamacho, test"}'`

```
:............................................................:..........................................................................:......:
:                          keyName                           :                               description                                : cost :
:............................................................:..........................................................................:......:
:                INTEL_SINGLE_XEON_1270_3_50                 :             Single Intel Xeon E3-1270 v3 (4 Cores, 3.50 GHz)             : 209  :
:               RAM_8_GB_DDR3_1333_ECC_NON_REG               :                              8 GB DDR3 1333                              :  48  :
: OS_VYATTA_5600_5_X_UP_TO_1GBPS_SUBSCRIPTION_EDITION_64_BIT : Virtual Router Appliance 5.x (up to 1Gbps) Subscription Edition (64 Bit) : 219  :
:                  DISK_CONTROLLER_NONRAID                   :                                 Non-RAID                                 :  0   :
:                  HARD_DRIVE_500GB_SATA_II                  :                               500 GB SATA                                :  0   :
:                     BANDWIDTH_20000_GB                     :                       20000 GB Bandwidth Allotment                       :  0   :
:          100_MBPS_PUBLIC_PRIVATE_NETWORK_UPLINKS           :                100 Mbps Public & Private Network Uplinks                 :  0   :
:                       1_IPV6_ADDRESS                       :                              1 IPv6 Address                              :  0   :
:                    MONITORING_HOST_PING                    :                                Host Ping                                 :  0   :
:                   AUTOMATED_NOTIFICATION                   :                          Automated Notification                          :  0   :
:    UNLIMITED_SSL_VPN_USERS_1_PPTP_VPN_USER_PER_ACCOUNT     :          Unlimited SSL VPN Users & 1 PPTP VPN User per account           :  0   :
:         NESSUS_VULNERABILITY_ASSESSMENT_REPORTING          :               Nessus Vulnerability Assessment & Reporting                :  0   :
:                        1_IP_ADDRESS                        :                               1 IP Address                               :  0   :
:               NOTIFICATION_EMAIL_AND_TICKET                :                             Email and Ticket                             :  0   :
:                     REBOOT_KVM_OVER_IP                     :                           Reboot / KVM over IP                           :  0   :
:............................................................:..........................................................................:......:
```

**2U_NETWORK_GATEWAY_APPLIANCE_1O_GBPS**

`$ slcli order place --billing monthly 2U_NETWORK_GATEWAY_APPLIANCE_1O_GBPS DALLAS06 INTEL_XEON_2620_2_40 OS_VYATTA_5600_5_X_UP_TO_20GBPS_SUBSCRIPTION_EDITION_64_BIT RAM_64_GB_DDR3_1333_REG_2 DISK_CONTROLLER_RAID HARD_DRIVE_1_00TB_SATA_II BANDWIDTH_UNLIMITED_100_MBPS_UPLINK 100_MBPS_PUBLIC_PRIVATE_NETWORK_UPLINKS REBOOT_KVM_OVER_IP 1_IP_ADDRESS REDUNDANT_POWER_SUPPLY MONITORING_HOST_PING  NOTIFICATION_EMAIL_AND_TICKET AUTOMATED_NOTIFICATION UNLIMITED_SSL_VPN_USERS_1_PPTP_VPN_USER_PER_ACCOUNT NESSUS_VULNERABILITY_ASSESSMENT_REPORTING --complex-type SoftLayer_Container_Product_Order_Hardware_Server_Gateway_Appliance --extras '{"hardware": [{"hostname" : "ajcbGateway01", "domain": "acamacho.com"}], "sshKeys" : [87634], "tags": "acamacho, test"}'`
```
This action will incur charges on your account. Continue? [y/N]: y
:.........:...........................:
:    name : value                     :
:.........:...........................:
:      id : 22299768                  :
: created : 2018-06-22T16:29:00-04:00 :
:  status : PENDING_AUTO_APPROVAL     :
:.........:...........................:
```