### PR TITLE
Fix for issues 984 and 985

### DIFF
--- a/SoftLayer/managers/ordering.py
+++ b/SoftLayer/managers/ordering.py
@@ -334,10 +334,11 @@ class OrderingManager(object):
                   keynames in the given package
 
         """
-        mask = 'id, keyName, prices'
+        mask = 'id, itemCategory, keyName, prices[categories]'
         items = self.list_items(package_keyname, mask=mask)
 
         prices = []
+        gpu_number = -1
         for item_keyname in item_keynames:
             try:
                 # Need to find the item in the package that has a matching
@@ -353,8 +354,17 @@ class OrderingManager(object):
             # because that is the most generic price. verifyOrder/placeOrder
             # can take that ID and create the proper price for us in the location
             # in which the order is made
-            price_id = [p['id'] for p in matching_item['prices']
-                        if not p['locationGroupId']][0]
+            if matching_item['itemCategory']['categoryCode'] != "gpu0":
+                price_id = [p['id'] for p in matching_item['prices']
+                            if not p['locationGroupId']][0]
+            else:
+                # GPU items has two generic prices and they are added to the list
+                # according to the number of gpu items added in the order.
+                gpu_number += 1
+                price_id = [p['id'] for p in matching_item['prices']
+                            if not p['locationGroupId']
+                            and p['categories'][0]['categoryCode'] == "gpu" + str(gpu_number)][0]
+
             prices.append(price_id)
 
         return prices

--- a/tests/CLI/modules/order_tests.py
+++ b/tests/CLI/modules/order_tests.py
@@ -210,9 +210,13 @@ class OrderTests(testing.TestCase):
 
     def _get_order_items(self):
         item1 = {'keyName': 'ITEM1', 'description': 'description1',
-                 'prices': [{'id': 1111, 'locationGroupId': None}]}
+                 'itemCategory': {'categoryCode': 'cat1'},
+                 'prices': [{'id': 1111, 'locationGroupId': None,
+                             'categories': [{'categoryCode': 'cat1'}]}]}
         item2 = {'keyName': 'ITEM2', 'description': 'description2',
-                 'prices': [{'id': 2222, 'locationGroupId': None}]}
+                 'itemCategory': {'categoryCode': 'cat2'},
+                 'prices': [{'id': 2222, 'locationGroupId': None,
+                             'categories': [{'categoryCode': 'cat2'}]}]}
 
         return [item1, item2]
 

--- a/tests/managers/ordering_tests.py
+++ b/tests/managers/ordering_tests.py
@@ -283,22 +283,25 @@ class OrderingTests(testing.TestCase):
         self.assertEqual('Preset {} does not exist in package {}'.format(keyname, 'PACKAGE_KEYNAME'), str(exc))
 
     def test_get_price_id_list(self):
-        price1 = {'id': 1234, 'locationGroupId': None}
-        item1 = {'id': 1111, 'keyName': 'ITEM1', 'prices': [price1]}
-        price2 = {'id': 5678, 'locationGroupId': None}
-        item2 = {'id': 2222, 'keyName': 'ITEM2', 'prices': [price2]}
+        category1 = {'categoryCode': 'cat1'}
+        price1 = {'id': 1234, 'locationGroupId': None, 'itemCategory': [category1]}
+        item1 = {'id': 1111, 'keyName': 'ITEM1', 'itemCategory': category1, 'prices': [price1]}
+        category2 = {'categoryCode': 'cat2'}
+        price2 = {'id': 5678, 'locationGroupId': None, 'categories': [category2]}
+        item2 = {'id': 2222, 'keyName': 'ITEM2', 'itemCategory': category2, 'prices': [price2]}
 
         with mock.patch.object(self.ordering, 'list_items') as list_mock:
             list_mock.return_value = [item1, item2]
 
             prices = self.ordering.get_price_id_list('PACKAGE_KEYNAME', ['ITEM1', 'ITEM2'])
 
-        list_mock.assert_called_once_with('PACKAGE_KEYNAME', mask='id, keyName, prices')
+        list_mock.assert_called_once_with('PACKAGE_KEYNAME', mask='id, itemCategory, keyName, prices[categories]')
         self.assertEqual([price1['id'], price2['id']], prices)
 
     def test_get_price_id_list_item_not_found(self):
-        price1 = {'id': 1234, 'locationGroupId': ''}
-        item1 = {'id': 1111, 'keyName': 'ITEM1', 'prices': [price1]}
+        category1 = {'categoryCode': 'cat1'}
+        price1 = {'id': 1234, 'locationGroupId': '', 'categories': [category1]}
+        item1 = {'id': 1111, 'keyName': 'ITEM1', 'itemCategory': category1, 'prices': [price1]}
 
         with mock.patch.object(self.ordering, 'list_items') as list_mock:
             list_mock.return_value = [item1]
@@ -306,7 +309,7 @@ class OrderingTests(testing.TestCase):
             exc = self.assertRaises(exceptions.SoftLayerError,
                                     self.ordering.get_price_id_list,
                                     'PACKAGE_KEYNAME', ['ITEM2'])
-        list_mock.assert_called_once_with('PACKAGE_KEYNAME', mask='id, keyName, prices')
+        list_mock.assert_called_once_with('PACKAGE_KEYNAME', mask='id, itemCategory, keyName, prices[categories]')
         self.assertEqual("Item ITEM2 does not exist for package PACKAGE_KEYNAME", str(exc))
 
     def test_generate_no_complex_type(self):
@@ -460,30 +463,34 @@ class OrderingTests(testing.TestCase):
 
     def test_location_group_id_none(self):
         # RestTransport uses None for empty locationGroupId
-        price1 = {'id': 1234, 'locationGroupId': None}
-        item1 = {'id': 1111, 'keyName': 'ITEM1', 'prices': [price1]}
-        price2 = {'id': 5678, 'locationGroupId': None}
-        item2 = {'id': 2222, 'keyName': 'ITEM2', 'prices': [price2]}
+        category1 = {'categoryCode': 'cat1'}
+        price1 = {'id': 1234, 'locationGroupId': None, 'categories': [category1]}
+        item1 = {'id': 1111, 'keyName': 'ITEM1', 'itemCategory': category1, 'prices': [price1]}
+        category2 = {'categoryCode': 'cat2'}
+        price2 = {'id': 5678, 'locationGroupId': None, 'categories': [category2]}
+        item2 = {'id': 2222, 'keyName': 'ITEM2', 'itemCategory': category2, 'prices': [price2]}
 
         with mock.patch.object(self.ordering, 'list_items') as list_mock:
             list_mock.return_value = [item1, item2]
 
             prices = self.ordering.get_price_id_list('PACKAGE_KEYNAME', ['ITEM1', 'ITEM2'])
 
-        list_mock.assert_called_once_with('PACKAGE_KEYNAME', mask='id, keyName, prices')
+        list_mock.assert_called_once_with('PACKAGE_KEYNAME', mask='id, itemCategory, keyName, prices[categories]')
         self.assertEqual([price1['id'], price2['id']], prices)
 
     def test_location_groud_id_empty(self):
         # XMLRPCtransport uses '' for empty locationGroupId
-        price1 = {'id': 1234, 'locationGroupId': ''}
-        item1 = {'id': 1111, 'keyName': 'ITEM1', 'prices': [price1]}
-        price2 = {'id': 5678, 'locationGroupId': ""}
-        item2 = {'id': 2222, 'keyName': 'ITEM2', 'prices': [price2]}
+        category1 = {'categoryCode': 'cat1'}
+        price1 = {'id': 1234, 'locationGroupId': '', 'categories': [category1]}
+        item1 = {'id': 1111, 'keyName': 'ITEM1', 'itemCategory': category1, 'prices': [price1]}
+        category2 = {'categoryCode': 'cat2'}
+        price2 = {'id': 5678, 'locationGroupId': "", 'categories': [category2]}
+        item2 = {'id': 2222, 'keyName': 'ITEM2', 'itemCategory': category2, 'prices': [price2]}
 
         with mock.patch.object(self.ordering, 'list_items') as list_mock:
             list_mock.return_value = [item1, item2]
 
             prices = self.ordering.get_price_id_list('PACKAGE_KEYNAME', ['ITEM1', 'ITEM2'])
 
-        list_mock.assert_called_once_with('PACKAGE_KEYNAME', mask='id, keyName, prices')
+        list_mock.assert_called_once_with('PACKAGE_KEYNAME', mask='id, itemCategory, keyName, prices[categories]')
         self.assertEqual([price1['id'], price2['id']], prices)

--- a/tests/managers/ordering_tests.py
+++ b/tests/managers/ordering_tests.py
@@ -312,6 +312,20 @@ class OrderingTests(testing.TestCase):
         list_mock.assert_called_once_with('PACKAGE_KEYNAME', mask='id, itemCategory, keyName, prices[categories]')
         self.assertEqual("Item ITEM2 does not exist for package PACKAGE_KEYNAME", str(exc))
 
+    def test_get_price_id_list_gpu_items_with_two_categories(self):
+        # Specific for GPU prices which are differentiated by their category (gpu0, gpu1)
+        price1 = {'id': 1234, 'locationGroupId': None, 'categories': [{'categoryCode': 'gpu1'}]}
+        price2 = {'id': 5678, 'locationGroupId': None, 'categories': [{'categoryCode': 'gpu0'}]}
+        item1 = {'id': 1111, 'keyName': 'ITEM1', 'itemCategory': {'categoryCode': 'gpu0'}, 'prices': [price1, price2]}
+
+        with mock.patch.object(self.ordering, 'list_items') as list_mock:
+            list_mock.return_value = [item1, item1]
+
+            prices = self.ordering.get_price_id_list('PACKAGE_KEYNAME', ['ITEM1', 'ITEM1'])
+
+            list_mock.assert_called_once_with('PACKAGE_KEYNAME', mask='id, itemCategory, keyName, prices[categories]')
+            self.assertEqual([price2['id'], price1['id']], prices)
+
     def test_generate_no_complex_type(self):
         pkg = 'PACKAGE_KEYNAME'
         items = ['ITEM1', 'ITEM2']


### PR DESCRIPTION
- By default, the gpu0 price id is added to the list first, this fixes the issue #984.
- The gpu0 and gpu1 are added to the list if the GPU KeyName is added twice in the order. Fix for #985 
- If customer requires 2 GPU items they must to add the keyName twice, an expected API exception is raised when the GPU keyNames are different.

Try with following command:

`slcli order place --verify  --billing monthly --complex-type SoftLayer_Container_Product_Order_Hardware_Server DUAL_E52600_V4_12_DRIVES DALLAS12 REBOOT_KVM_OVER_IP UNLIMITED_SSL_VPN_USERS_1_PPTP_VPN_USER_PER_ACCOUNT NESSUS_VULNERABILITY_ASSESSMENT_REPORTING NOTIFICATION_EMAIL_AND_TICKET 1_IP_ADDRESS AUTOMATED_NOTIFICATION MONITORING_HOST_PING BANDWIDTH_500_GB REDUNDANT_POWER_SUPPLY INTEL_TXT_TRUSTED_EXECUTION_TECHNOLOGY OS_UBUNTU_16_04_LTS_XENIAL_XERUS_MINIMAL_64_BIT INTEL_INTEL_XEON_E52620_V4_2_10 RAM_128_GB_DDR4_2133_ECC_REG 10_GBPS_REDUNDANT_PUBLIC_PRIVATE_NETWORK_UPLINKS DISK_CONTROLLER_NONRAID HARD_DRIVE_1_9TB_SSD_SED_5DWPD HARD_DRIVE_2_00_TB_SATA_2  HARD_DRIVE_3_8TB_SSD_SED_3DWPD GPU_NVIDIA_TESLA_K80 GPU_NVIDIA_TESLA_K80`

