### PR TITLE
remove deprecated arguments to prompt()

### DIFF
--- a/SoftLayer/shell/core.py
+++ b/SoftLayer/shell/core.py
@@ -51,22 +51,6 @@ def cli(ctx, env):
     complete = completer.ShellCompleter(core.cli)
 
     while True:
-        def get_prompt_tokens(_):
-            """Returns tokens for the command prompt"""
-            tokens = []
-            try:
-                tokens.append((token.Token.Username, env.client.auth.username))
-                tokens.append((token.Token.At, "@"))
-            except AttributeError:
-                pass
-
-            tokens.append((token.Token.Host, "slcli-shell"))
-            if env.vars['last_exit_code']:
-                tokens.append((token.Token.ErrorPrompt, '> '))
-            else:
-                tokens.append((token.Token.Prompt, '> '))
-
-            return tokens
         try:
             line = p_shortcuts.prompt(
                 completer=complete,

--- a/SoftLayer/shell/core.py
+++ b/SoftLayer/shell/core.py
@@ -15,7 +15,6 @@ import traceback
 import click
 from prompt_toolkit import auto_suggest as p_auto_suggest
 from prompt_toolkit import shortcuts as p_shortcuts
-from pygments import token
 
 from SoftLayer.CLI import core
 from SoftLayer.CLI import environment

--- a/SoftLayer/shell/core.py
+++ b/SoftLayer/shell/core.py
@@ -49,7 +49,6 @@ def cli(ctx, env):
     app_path = click.get_app_dir('softlayer_shell')
     if not os.path.exists(app_path):
         os.makedirs(app_path)
-    history = p_history.FileHistory(os.path.join(app_path, 'history'))
     complete = completer.ShellCompleter(core.cli)
 
     while True:

--- a/SoftLayer/shell/core.py
+++ b/SoftLayer/shell/core.py
@@ -14,7 +14,6 @@ import traceback
 
 import click
 from prompt_toolkit import auto_suggest as p_auto_suggest
-from prompt_toolkit import history as p_history
 from prompt_toolkit import shortcuts as p_shortcuts
 from pygments import token
 

--- a/SoftLayer/shell/core.py
+++ b/SoftLayer/shell/core.py
@@ -69,14 +69,13 @@ def cli(ctx, env):
                 tokens.append((token.Token.Prompt, '> '))
 
             return tokens
-
         try:
             line = p_shortcuts.prompt(
                 completer=complete,
-                history=history,
+                complete_while_typing=True,
                 auto_suggest=p_auto_suggest.AutoSuggestFromHistory(),
-                get_prompt_tokens=get_prompt_tokens,
             )
+
 
             # Parse arguments
             try:

--- a/SoftLayer/shell/core.py
+++ b/SoftLayer/shell/core.py
@@ -76,7 +76,6 @@ def cli(ctx, env):
                 auto_suggest=p_auto_suggest.AutoSuggestFromHistory(),
             )
 
-
             # Parse arguments
             try:
                 args = shlex.split(line)


### PR DESCRIPTION
prompt-toolkit has been updated many times since slcli-shell was created. p_shortcuts.prompt() passed arguments that are long deprecated causing the shell to fail.
