### PR TITLE
Fix compatibility with Python 3.7

### DIFF
--- a/SoftLayer/API.py
+++ b/SoftLayer/API.py
@@ -298,7 +298,7 @@ class BaseClient(object):
                     results = transports.SoftLayerListResult(results, len(results))
                 else:
                     yield results
-                    raise StopIteration
+                    return
 
             for item in results:
                 yield item
@@ -312,8 +312,6 @@ class BaseClient(object):
                 keep_looping = False
 
             offset += limit
-
-        raise StopIteration
 
     def __repr__(self):
         return "Client(transport=%r, auth=%r)" % (self.transport, self.auth)


### PR DESCRIPTION
Simply replace the raise statement with return. All tests pass with
Python 3.7.0 here with the change.

This fixes #1016