### PR TITLE
Icos image support

### DIFF
--- a/SoftLayer/CLI/image/export.py
+++ b/SoftLayer/CLI/image/export.py
@@ -12,7 +12,7 @@ from SoftLayer.CLI import helpers
 @click.command()
 @click.argument('identifier')
 @click.argument('uri')
-@click.option('--ibm_api_key',
+@click.option('--ibm-api-key',
               default="",
               help="The IBM Cloud API Key with access to IBM Cloud Object "
                    "Storage instance.")

--- a/SoftLayer/CLI/image/export.py
+++ b/SoftLayer/CLI/image/export.py
@@ -15,7 +15,9 @@ from SoftLayer.CLI import helpers
 @click.option('--ibm-api-key',
               default="",
               help="The IBM Cloud API Key with access to IBM Cloud Object "
-                   "Storage instance.")
+                   "Storage instance. For help creating this key see "
+                   "https://console.bluemix.net/docs/services/cloud-object-"
+                   "storage/iam/users-serviceids.html#serviceidapikeys")
 @environment.pass_env
 def cli(env, identifier, uri, ibm_api_key):
     """Export an image to object storage.

--- a/SoftLayer/CLI/image/export.py
+++ b/SoftLayer/CLI/image/export.py
@@ -12,17 +12,23 @@ from SoftLayer.CLI import helpers
 @click.command()
 @click.argument('identifier')
 @click.argument('uri')
+@click.option('--ibm_api_key',
+              default="",
+              help="The IBM Cloud API Key with access to IBM Cloud Object "
+                   "Storage instance.")
 @environment.pass_env
-def cli(env, identifier, uri):
+def cli(env, identifier, uri, ibm_api_key):
     """Export an image to object storage.
 
     The URI for an object storage object (.vhd/.iso file) of the format:
     swift://<objectStorageAccount>@<cluster>/<container>/<objectPath>
+    or cos://<clusterName>/<bucketName>/<objectPath> if using IBM Cloud
+    Object Storage
     """
 
     image_mgr = SoftLayer.ImageManager(env.client)
     image_id = helpers.resolve_id(image_mgr.resolve_ids, identifier, 'image')
-    result = image_mgr.export_image_to_uri(image_id, uri)
+    result = image_mgr.export_image_to_uri(image_id, uri, ibm_api_key)
 
     if not result:
         raise exceptions.CLIAbort("Failed to export Image")

--- a/SoftLayer/CLI/image/export.py
+++ b/SoftLayer/CLI/image/export.py
@@ -13,7 +13,7 @@ from SoftLayer.CLI import helpers
 @click.argument('identifier')
 @click.argument('uri')
 @click.option('--ibm-api-key',
-              default="",
+              default=None,
               help="The IBM Cloud API Key with access to IBM Cloud Object "
                    "Storage instance. For help creating this key see "
                    "https://console.bluemix.net/docs/services/cloud-object-"

--- a/SoftLayer/CLI/image/import.py
+++ b/SoftLayer/CLI/image/import.py
@@ -18,13 +18,38 @@ from SoftLayer.CLI import formatting
 @click.option('--os-code',
               default="",
               help="The referenceCode of the operating system software"
-                   " description for the imported VHD")
+                   " description for the imported VHD, ISO, or RAW image")
+@click.option('--ibm-api-key',
+              default="",
+              help="The IBM Cloud API Key with access to IBM Cloud Object "
+                   "Storage instance.")
+@click.option('--root-key-id',
+              default="",
+              help="ID of the root key in Key Protect")
+@click.option('--wrapped-dek',
+              default="",
+              help="Wrapped Decryption Key provided by IBM KeyProtect")
+@click.option('--kp-id',
+              default="",
+              help="ID of the IBM Key Protect Instance")
+@click.option('--cloud-init',
+              default="",
+              help="Specifies if image is cloud init")
+@click.option('--byol',
+              default="",
+              help="Specifies if image is bring your own license")
+@click.option('--is-encrypted',
+              default="",
+              help="Specifies if image is encrypted")
 @environment.pass_env
-def cli(env, name, note, os_code, uri):
+def cli(env, name, note, os_code, uri, ibm_api_key, root_key_id, wrapped_dek,
+        kp_id, cloud_init, byol, is_encrypted):
     """Import an image.
 
     The URI for an object storage object (.vhd/.iso file) of the format:
     swift://<objectStorageAccount>@<cluster>/<container>/<objectPath>
+    or cos://<clusterName>/<bucketName>/<objectPath> if using IBM Cloud
+    Object Storage
     """
 
     image_mgr = SoftLayer.ImageManager(env.client)
@@ -33,6 +58,13 @@ def cli(env, name, note, os_code, uri):
         note=note,
         os_code=os_code,
         uri=uri,
+        ibm_api_key=ibm_api_key,
+        root_key_id=root_key_id,
+        wrapped_dek=wrapped_dek,
+        kp_id=kp_id,
+        cloud_init=cloud_init,
+        byol=byol,
+        is_encrypted=is_encrypted
     )
 
     if not result:

--- a/SoftLayer/CLI/image/import.py
+++ b/SoftLayer/CLI/image/import.py
@@ -16,26 +16,25 @@ from SoftLayer.CLI import formatting
               default="",
               help="The note to be applied to the imported template")
 @click.option('--os-code',
-              default="",
               help="The referenceCode of the operating system software"
                    " description for the imported VHD, ISO, or RAW image")
 @click.option('--ibm-api-key',
-              default="",
+              default=None,
               help="The IBM Cloud API Key with access to IBM Cloud Object "
                    "Storage instance and IBM KeyProtect instance. For help "
                    "creating this key see https://console.bluemix.net/docs/"
                    "services/cloud-object-storage/iam/users-serviceids.html"
                    "#serviceidapikeys")
 @click.option('--root-key-id',
-              default="",
+              default=None,
               help="ID of the root key in Key Protect")
 @click.option('--wrapped-dek',
-              default="",
+              default=None,
               help="Wrapped Data Encryption Key provided by IBM KeyProtect. "
                    "For more info see https://console.bluemix.net/docs/"
                    "services/key-protect/wrap-keys.html#wrap-keys")
 @click.option('--kp-id',
-              default="",
+              default=None,
               help="ID of the IBM Key Protect Instance")
 @click.option('--cloud-init',
               is_flag=True,

--- a/SoftLayer/CLI/image/import.py
+++ b/SoftLayer/CLI/image/import.py
@@ -22,24 +22,28 @@ from SoftLayer.CLI import formatting
 @click.option('--ibm-api-key',
               default="",
               help="The IBM Cloud API Key with access to IBM Cloud Object "
-                   "Storage instance.")
+                   "Storage instance. For help creating this key see "
+                   "https://console.bluemix.net/docs/services/cloud-object-"
+                   "storage/iam/users-serviceids.html#serviceidapikeys")
 @click.option('--root-key-id',
               default="",
               help="ID of the root key in Key Protect")
 @click.option('--wrapped-dek',
               default="",
-              help="Wrapped Decryption Key provided by IBM KeyProtect")
+              help="Wrapped Data Encryption Key provided by IBM KeyProtect. "
+                   "For more info see https://console.bluemix.net/docs/"
+                   "services/key-protect/wrap-keys.html#wrap-keys")
 @click.option('--kp-id',
               default="",
               help="ID of the IBM Key Protect Instance")
 @click.option('--cloud-init',
-              default="",
-              help="Specifies if image is cloud init")
+              is_flag=True,
+              help="Specifies if image is cloud-init")
 @click.option('--byol',
-              default="",
+              is_flag=True,
               help="Specifies if image is bring your own license")
 @click.option('--is-encrypted',
-              default="",
+              is_flag=True,
               help="Specifies if image is encrypted")
 @environment.pass_env
 def cli(env, name, note, os_code, uri, ibm_api_key, root_key_id, wrapped_dek,

--- a/SoftLayer/CLI/image/import.py
+++ b/SoftLayer/CLI/image/import.py
@@ -22,9 +22,10 @@ from SoftLayer.CLI import formatting
 @click.option('--ibm-api-key',
               default="",
               help="The IBM Cloud API Key with access to IBM Cloud Object "
-                   "Storage instance. For help creating this key see "
-                   "https://console.bluemix.net/docs/services/cloud-object-"
-                   "storage/iam/users-serviceids.html#serviceidapikeys")
+                   "Storage instance and IBM KeyProtect instance. For help "
+                   "creating this key see https://console.bluemix.net/docs/"
+                   "services/cloud-object-storage/iam/users-serviceids.html"
+                   "#serviceidapikeys")
 @click.option('--root-key-id',
               default="",
               help="ID of the root key in Key Protect")

--- a/SoftLayer/fixtures/SoftLayer_Virtual_Guest_Block_Device_Template_Group.py
+++ b/SoftLayer/fixtures/SoftLayer_Virtual_Guest_Block_Device_Template_Group.py
@@ -29,5 +29,11 @@ createFromExternalSource = [{
     'id': 100,
     'name': 'test_image',
 }]
-
+createFromIcos = [{
+    'createDate': '2013-12-05T21:53:03-06:00',
+    'globalIdentifier': '0B5DEAF4-643D-46CA-A695-CECBE8832C9D',
+    'id': 100,
+    'name': 'test_image',
+}]
 copyToExternalSource = True
+copyToIcos = True

--- a/SoftLayer/managers/image.py
+++ b/SoftLayer/managers/image.py
@@ -122,8 +122,8 @@ class ImageManager(utils.IdentifierMixin, object):
 
     def import_image_from_uri(self, name, uri, os_code=None, note=None,
                               ibm_api_key=None, root_key_id=None,
-                              wrapped_dek=None, kp_id=None, cloud_init=None,
-                              byol=None, is_encrypted=None):
+                              wrapped_dek=None, kp_id=None, cloud_init=False,
+                              byol=False, is_encrypted=False):
         """Import a new image from object storage.
 
         :param string name: Name of the new image
@@ -138,10 +138,10 @@ class ImageManager(utils.IdentifierMixin, object):
         :param string ibm_api_key: Ibm Api Key needed to communicate with ICOS
         and Key Protect
         :param string root_key_id: ID of the root key in Key Protect
-        :param string wrapped_dek: Wrapped Decryption Key provided by IBM
-         KeyProtect
+        :param string wrapped_dek: Wrapped Data Encryption Key provided by
+        IBM KeyProtect
         :param string kp_id: ID of the IBM Key Protect Instance
-        :param boolean cloud_init: Specifies if image is cloud init
+        :param boolean cloud_init: Specifies if image is cloud-init
         :param boolean byol: Specifies if image is bring your own license
         :param boolean is_encrypted: Specifies if image is encrypted
         """

--- a/SoftLayer/managers/image.py
+++ b/SoftLayer/managers/image.py
@@ -141,9 +141,9 @@ class ImageManager(utils.IdentifierMixin, object):
         :param string wrapped_dek: Wrapped Decryption Key provided by IBM
          KeyProtect
         :param string kp_id: ID of the IBM Key Protect Instance
-        :param bool cloud_init: Specifies if image is cloud init
-        :param bool byol: Specifies if image is bring your own license
-        :param bool is_encrypted: Specifies if image is encrypted
+        :param boolean cloud_init: Specifies if image is cloud init
+        :param boolean byol: Specifies if image is bring your own license
+        :param boolean is_encrypted: Specifies if image is encrypted
         """
         if 'cos://' in uri:
             return self.vgbdtg.createFromIcos({
@@ -152,7 +152,7 @@ class ImageManager(utils.IdentifierMixin, object):
                 'operatingSystemReferenceCode': os_code,
                 'uri': uri,
                 'ibmApiKey': ibm_api_key,
-                'rootKeyid': root_key_id,
+                'rootKeyId': root_key_id,
                 'wrappedDek': wrapped_dek,
                 'keyProtectId': kp_id,
                 'cloudInit': cloud_init,

--- a/tests/managers/image_tests.py
+++ b/tests/managers/image_tests.py
@@ -167,7 +167,7 @@ class ImageTests(testing.TestCase):
                    'operatingSystemReferenceCode': 'UBUNTU_LATEST',
                    'uri': 'cos://some_uri',
                    'ibmApiKey': 'some_ibm_key',
-                   'rootKeyid': 'some_root_key_id',
+                   'rootKeyId': 'some_root_key_id',
                    'wrappedDek': 'some_dek',
                    'keyProtectId': 'some_id',
                    'cloudInit': False,

--- a/tests/managers/image_tests.py
+++ b/tests/managers/image_tests.py
@@ -145,6 +145,36 @@ class ImageTests(testing.TestCase):
                    'uri': 'someuri',
                    'operatingSystemReferenceCode': 'UBUNTU_LATEST'},))
 
+    def test_import_image_cos(self):
+        self.image.import_image_from_uri(name='test_image',
+                                         note='testimage',
+                                         uri='cos://some_uri',
+                                         os_code='UBUNTU_LATEST',
+                                         ibm_api_key='some_ibm_key',
+                                         root_key_id='some_root_key_id',
+                                         wrapped_dek='some_dek',
+                                         kp_id='some_id',
+                                         cloud_init=False,
+                                         byol=False,
+                                         is_encrypted=False
+                                         )
+
+        self.assert_called_with(
+            IMAGE_SERVICE,
+            'createFromIcos',
+            args=({'name': 'test_image',
+                   'note': 'testimage',
+                   'operatingSystemReferenceCode': 'UBUNTU_LATEST',
+                   'uri': 'cos://some_uri',
+                   'ibmApiKey': 'some_ibm_key',
+                   'rootKeyid': 'some_root_key_id',
+                   'wrappedDek': 'some_dek',
+                   'keyProtectId': 'some_id',
+                   'cloudInit': False,
+                   'byol': False,
+                   'isEncrypted': False
+                   },))
+
     def test_export_image(self):
         self.image.export_image_to_uri(1234, 'someuri')
 
@@ -152,4 +182,15 @@ class ImageTests(testing.TestCase):
             IMAGE_SERVICE,
             'copyToExternalSource',
             args=({'uri': 'someuri'},),
+            identifier=1234)
+
+    def test_export_image_cos(self):
+        self.image.export_image_to_uri(1234,
+                                       'cos://someuri',
+                                       ibm_api_key='someApiKey')
+
+        self.assert_called_with(
+            IMAGE_SERVICE,
+            'copyToIcos',
+            args=({'uri': 'cos://someuri', 'ibmApiKey': 'someApiKey'},),
             identifier=1234)


### PR DESCRIPTION
Add export/import capabilities to/from IBM Cloud Object Storage to the image manager as well as the slcli. Unit tests updated to include tests for COS path.