### PR TITLE
5.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Change Log
 
+## [5.6.0] - 2018-10-16
+- Changes: https://github.com/softlayer/softlayer-python/compare/v5.5.3...v5.6.0
+
++ #1026 Support for [Reserved Capacity](https://console.bluemix.net/docs/vsi/vsi_about_reserved.html#about-reserved-virtual-servers)
+  * `slcli vs capacity create`
+  * `slcli vs capacity create-guest`
+  * `slcli vs capacity create-options`
+  * `slcli vs capacity detail`
+  * `slcli vs capacity list`
++ #1050 Fix `post_uri` parameter name on docstring
++ #1039 Fixed suspend cloud server order.
++ #1055 Update to use click 7
++ #1053 Add export/import capabilities to/from IBM Cloud Object Storage to the image manager as well as the slcli. 
+
 
 ## [5.5.3] - 2018-08-31
 - Changes: https://github.com/softlayer/softlayer-python/compare/v5.5.2...v5.5.3

--- a/SoftLayer/consts.py
+++ b/SoftLayer/consts.py
@@ -5,7 +5,7 @@
 
     :license: MIT, see LICENSE for more details.
 """
-VERSION = 'v5.5.3'
+VERSION = 'v5.6.0'
 API_PUBLIC_ENDPOINT = 'https://api.softlayer.com/xmlrpc/v3.1/'
 API_PRIVATE_ENDPOINT = 'https://api.service.softlayer.com/xmlrpc/v3.1/'
 API_PUBLIC_ENDPOINT_REST = 'https://api.softlayer.com/rest/v3.1/'

--- a/setup.py
+++ b/setup.py
@@ -33,10 +33,10 @@ setup(
         'six >= 1.7.0',
         'ptable >= 0.9.2',
         'click >= 7',
-        'requests >= 2.18.4',
+        'requests == 2.19.1',
         'prompt_toolkit >= 0.53',
         'pygments >= 2.0.0',
-        'urllib3 >= 1.22'
+        'urllib3 == 1.22'
     ],
     keywords=['softlayer', 'cloud'],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ else:
 
 setup(
     name='SoftLayer',
-    version='5.5.3',
+    version='5.6.0',
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     author='SoftLayer Technologies, Inc.',

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: slcli # check to see if it's available
-version: '5.5.3+git' # check versioning
+version: '5.6.0+git' # check versioning
 summary: Python based SoftLayer API Tool. # 79 char long summary
 description: |
     A command-line interface is also included and can be used to manage various SoftLayer products and services.

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,6 +1,6 @@
-requests >= 2.18.4
+requests == 2.19.1
 click >= 5, < 7
 prettytable >= 0.7.0
 six >= 1.7.0
 prompt_toolkit
-urllib3
+urllib3 == 1.22

--- a/tools/test-requirements.txt
+++ b/tools/test-requirements.txt
@@ -4,5 +4,5 @@ pytest-cov
 mock
 sphinx
 testtools
-urllib3
-requests >= 2.18.4
+urllib3 == 1.22
+requests == 2.19.1


### PR DESCRIPTION
+ #1026 Support for [Reserved Capacity](https://console.bluemix.net/docs/vsi/vsi_about_reserved.html#about-reserved-virtual-servers)
  * `slcli vs capacity create`
  * `slcli vs capacity create-guest`
  * `slcli vs capacity create-options`
  * `slcli vs capacity detail`
  * `slcli vs capacity list`
+ #1050 Fix `post_uri` parameter name on docstring
+ #1039 Fixed suspend cloud server order.
+ #1055 Update to use click 7
+ #1053 Add export/import capabilities to/from IBM Cloud Object Storage to the image manager as well as the slcli. 