### PR TITLE
NETWORK-8987 - added createDate and modifyDate parameters to sg rule-list

### DIFF
--- a/SoftLayer/CLI/securitygroup/rule.py
+++ b/SoftLayer/CLI/securitygroup/rule.py
@@ -15,7 +15,9 @@ COLUMNS = ['id',
            'ethertype',
            'portRangeMin',
            'portRangeMax',
-           'protocol']
+           'protocol',
+           'createDate',
+           'modifyDate']
 
 
 @click.command()
@@ -49,7 +51,9 @@ def rule_list(env, securitygroup_id, sortby):
             rule.get('ethertype') or formatting.blank(),
             port_min,
             port_max,
-            rule.get('protocol') or formatting.blank()
+            rule.get('protocol') or formatting.blank(),
+            rule.get('createDate') or formatting.blank(),
+            rule.get('modifyDate') or formatting.blank()
         ])
 
     env.fout(table)

--- a/SoftLayer/managers/network.py
+++ b/SoftLayer/managers/network.py
@@ -372,7 +372,7 @@ class NetworkManager(object):
                 'description,'
                 '''rules[id, remoteIp, remoteGroupId,
                          direction, ethertype, portRangeMin,
-                         portRangeMax, protocol],'''
+                         portRangeMax, protocol, createDate, modifyDate],'''
                 '''networkComponentBindings[
                     networkComponent[
                         id,

--- a/tests/CLI/modules/securitygroup_tests.py
+++ b/tests/CLI/modules/securitygroup_tests.py
@@ -121,7 +121,7 @@ class SecurityGroupTests(testing.TestCase):
                            'portRangeMax': None,
                            'createDate': None,
                            'modifyDate': None}],
-                        json.loads(result.output))
+                          json.loads(result.output))
 
     def test_securitygroup_rule_add(self):
         result = self.run_command(['sg', 'rule-add', '100',

--- a/tests/CLI/modules/securitygroup_tests.py
+++ b/tests/CLI/modules/securitygroup_tests.py
@@ -118,8 +118,10 @@ class SecurityGroupTests(testing.TestCase):
                            'remoteGroupId': None,
                            'protocol': None,
                            'portRangeMin': None,
-                           'portRangeMax': None}],
-                         json.loads(result.output))
+                           'portRangeMax': None,
+                           'createDate': None,
+                           'modifyDate': None}],
+                        json.loads(result.output))
 
     def test_securitygroup_rule_add(self):
         result = self.run_command(['sg', 'rule-add', '100',


### PR DESCRIPTION
This adds the createDate and modifyDate parameters to the sg rule-list table under rule.py and to the mask under the get_securitygroup command under network.py.