### PR TITLE
5.6.3 - Updated release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Change Log
 
-## [5.6.1] - 2018-11-07
+## [5.6.3] - 2018-11-07
 
-- Changes: https://github.com/softlayer/softlayer-python/compare/v5.6.0...v5.6.1
+- Changes: https://github.com/softlayer/softlayer-python/compare/v5.6.0...v5.6.3
 
 + #1065 Updated urllib3 and requests libraries due to CVE-2018-18074
 + #1070 Fixed an ordering bug
++ Updated release process and fab-file
 
 ## [5.6.0] - 2018-10-16
 - Changes: https://github.com/softlayer/softlayer-python/compare/v5.5.3...v5.6.0

--- a/SoftLayer/consts.py
+++ b/SoftLayer/consts.py
@@ -5,7 +5,7 @@
 
     :license: MIT, see LICENSE for more details.
 """
-VERSION = 'v5.6.1'
+VERSION = 'v5.6.3'
 API_PUBLIC_ENDPOINT = 'https://api.softlayer.com/xmlrpc/v3.1/'
 API_PRIVATE_ENDPOINT = 'https://api.service.softlayer.com/xmlrpc/v3.1/'
 API_PUBLIC_ENDPOINT_REST = 'https://api.softlayer.com/rest/v3.1/'

--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -503,15 +503,16 @@ class VSManager(utils.IdentifierMixin, object):
                 'domain': u'test01.labs.sftlyr.ws',
                 'hostname': u'minion05',
                 'datacenter': u'hkg02',
+                'flavor': 'BL1_1X2X100'
                 'dedicated': False,
                 'private': False,
-                'cpus': 1,
                 'os_code' : u'UBUNTU_LATEST',
                 'hourly': True,
                 'ssh_keys': [1234],
                 'disks': ('100','25'),
                 'local_disk': True,
-                'memory': 1024
+                'tags': 'test, pleaseCancel',
+                'public_security_groups': [12, 15]
             }
 
             vsi = mgr.verify_create_instance(**new_vsi)
@@ -536,15 +537,14 @@ class VSManager(utils.IdentifierMixin, object):
                 'domain': u'test01.labs.sftlyr.ws',
                 'hostname': u'minion05',
                 'datacenter': u'hkg02',
+                'flavor': 'BL1_1X2X100'
                 'dedicated': False,
                 'private': False,
-                'cpus': 1,
                 'os_code' : u'UBUNTU_LATEST',
                 'hourly': True,
                 'ssh_keys': [1234],
                 'disks': ('100','25'),
                 'local_disk': True,
-                'memory': 1024,
                 'tags': 'test, pleaseCancel',
                 'public_security_groups': [12, 15]
             }
@@ -607,17 +607,16 @@ class VSManager(utils.IdentifierMixin, object):
             # Define the instance we want to create.
             new_vsi = {
                 'domain': u'test01.labs.sftlyr.ws',
-                'hostname': u'multi-test',
+                'hostname': u'minion05',
                 'datacenter': u'hkg02',
+                'flavor': 'BL1_1X2X100'
                 'dedicated': False,
                 'private': False,
-                'cpus': 1,
                 'os_code' : u'UBUNTU_LATEST',
                 'hourly': True,
-                'ssh_keys': [87634],
+                'ssh_keys': [1234],
                 'disks': ('100','25'),
                 'local_disk': True,
-                'memory': 1024,
                 'tags': 'test, pleaseCancel',
                 'public_security_groups': [12, 15]
             }

--- a/fabfile.py
+++ b/fabfile.py
@@ -12,8 +12,8 @@ def make_html():
 
 def upload():
     "Upload distribution to PyPi"
-    local('python setup.py sdist upload')
-    local('python setup.py bdist_wheel upload')
+    local('python setup.py sdist bdist_wheel')
+    local('twine upload dist/*')
 
 
 def clean():

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ else:
 
 setup(
     name='SoftLayer',
-    version='5.6.1',
+    version='5.6.3',
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     author='SoftLayer Technologies, Inc.',

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: slcli # check to see if it's available
-version: '5.6.1+git' # check versioning
+version: '5.6.3+git' # check versioning
 summary: Python based SoftLayer API Tool. # 79 char long summary
 description: |
     A command-line interface is also included and can be used to manage various SoftLayer products and services.


### PR DESCRIPTION
changed fab to use `twine` instead of `setup upload` since that is depreciated 