### PR TITLE
dedicatedhost cancel, cancel-guests, and list-guests commands

### DIFF
--- a/SoftLayer/CLI/dedicatedhost/cancel.py
+++ b/SoftLayer/CLI/dedicatedhost/cancel.py
@@ -12,13 +12,9 @@ from SoftLayer.CLI import helpers
 
 @click.command()
 @click.argument('identifier')
-@click.option('--immediate',
-              is_flag=True,
-              default=False,
-              help="Cancels the dedicated host immediately (instead of on the billing anniversary)")
 @environment.pass_env
-def cli(env, identifier, immediate):
-    """Cancel a dedicated host server."""
+def cli(env, identifier):
+    """Cancel a dedicated host server immediately"""
 
     mgr = SoftLayer.DedicatedHostManager(env.client)
 
@@ -27,6 +23,6 @@ def cli(env, identifier, immediate):
     if not (env.skip_confirmations or formatting.no_going_back(host_id)):
         raise exceptions.CLIAbort('Aborted')
 
-    mgr.cancel_host(host_id, immediate)
+    mgr.cancel_host(host_id)
 
-    click.secho('Dedicated Host %s was successfully cancelled' % host_id, fg='green')
+    click.secho('Dedicated Host %s was cancelled' % host_id, fg='green')

--- a/SoftLayer/CLI/dedicatedhost/cancel.py
+++ b/SoftLayer/CLI/dedicatedhost/cancel.py
@@ -1,0 +1,32 @@
+"""Cancel a dedicated host."""
+# :license: MIT, see LICENSE for more details.
+
+import click
+
+import SoftLayer
+from SoftLayer.CLI import environment
+from SoftLayer.CLI import exceptions
+from SoftLayer.CLI import formatting
+from SoftLayer.CLI import helpers
+
+
+@click.command()
+@click.argument('identifier')
+@click.option('--immediate',
+              is_flag=True,
+              default=False,
+              help="Cancels the dedicated host immediately (instead of on the billing anniversary)")
+@environment.pass_env
+def cli(env, identifier, immediate):
+    """Cancel a dedicated host server."""
+
+    mgr = SoftLayer.DedicatedHostManager(env.client)
+
+    host_id = helpers.resolve_id(mgr.resolve_ids, identifier, 'dedicated host')
+
+    if not (env.skip_confirmations or formatting.no_going_back(host_id)):
+        raise exceptions.CLIAbort('Aborted')
+
+    mgr.cancel_host(host_id, immediate)
+
+    click.secho('Dedicated Host %s was successfully cancelled' % host_id, fg='green')

--- a/SoftLayer/CLI/dedicatedhost/cancel_guests.py
+++ b/SoftLayer/CLI/dedicatedhost/cancel_guests.py
@@ -26,9 +26,18 @@ def cli(env, identifier):
     if not (env.skip_confirmations or formatting.no_going_back(host_id)):
         raise exceptions.CLIAbort('Aborted')
 
+    table = formatting.Table(['id', 'server name', 'status'])
+
     result = dh_mgr.cancel_guests(host_id)
 
-    if result is True:
-        click.secho('All guests into the dedicated host %s were cancelled' % host_id, fg='green')
+    if result:
+        for status in result:
+            table.add_row([
+                status['id'],
+                status['fqdn'],
+                status['status']
+            ])
+
+        env.fout(table)
     else:
         click.secho('There is not any guest into the dedicated host %s' % host_id, fg='red')

--- a/SoftLayer/CLI/dedicatedhost/cancel_guests.py
+++ b/SoftLayer/CLI/dedicatedhost/cancel_guests.py
@@ -1,0 +1,39 @@
+"""Cancel a dedicated host."""
+# :license: MIT, see LICENSE for more details.
+
+import click
+
+import SoftLayer
+from SoftLayer.CLI import environment
+from SoftLayer.CLI import exceptions
+from SoftLayer.CLI import formatting
+from SoftLayer.CLI import helpers
+
+
+@click.command()
+@click.argument('identifier')
+@environment.pass_env
+def cli(env, identifier):
+    """Cancel all virtual guests of the dedicated host immediately"""
+
+    dh_mgr = SoftLayer.DedicatedHostManager(env.client)
+    vs_mgr = SoftLayer.VSManager(env.client)
+
+    host_id = helpers.resolve_id(dh_mgr.resolve_ids, identifier, 'dedicated host')
+
+    guests = dh_mgr.list_guests(host_id)
+
+    if guests:
+        msg = '%s guest(s) will be cancelled, ' \
+              'do you want to continue?' % len(guests)
+
+        if not (env.skip_confirmations or formatting.confirm(msg)):
+            raise exceptions.CLIAbort('Aborted')
+
+        for guest in guests:
+            vs_mgr.cancel_instance(guest['id'])
+
+        click.secho('All guests into the dedicated host %s were cancelled' % host_id, fg='green')
+
+    else:
+        click.secho('There is not any guest into the dedicated host %s' % host_id, fg='red')

--- a/SoftLayer/CLI/dedicatedhost/list_guests.py
+++ b/SoftLayer/CLI/dedicatedhost/list_guests.py
@@ -1,4 +1,4 @@
-"""List dedicated servers."""
+"""List guests which are in a dedicated host server."""
 # :license: MIT, see LICENSE for more details.
 
 import click
@@ -55,12 +55,13 @@ DEFAULT_COLUMNS = [
               show_default=True)
 @environment.pass_env
 def cli(env, identifier, sortby, cpu, domain, hostname, memory, tag, columns):
-    """List guests into the dedicated host."""
+    """List guests which are in a dedicated host server."""
+
     mgr = SoftLayer.DedicatedHostManager(env.client)
     guests = mgr.list_guests(host_id=identifier,
                              cpus=cpu,
                              hostname=hostname,
-                             domain= domain,
+                             domain=domain,
                              memory=memory,
                              tags=tag,
                              mask=columns.mask())

--- a/SoftLayer/CLI/dedicatedhost/list_guests.py
+++ b/SoftLayer/CLI/dedicatedhost/list_guests.py
@@ -1,0 +1,75 @@
+"""List dedicated servers."""
+# :license: MIT, see LICENSE for more details.
+
+import click
+
+import SoftLayer
+from SoftLayer.CLI import columns as column_helper
+from SoftLayer.CLI import environment
+from SoftLayer.CLI import formatting
+from SoftLayer.CLI import helpers
+
+COLUMNS = [
+    column_helper.Column('guid', ('globalIdentifier',)),
+    column_helper.Column('cpu', ('maxCpu',)),
+    column_helper.Column('memory', ('maxMemory',)),
+    column_helper.Column('datacenter', ('datacenter', 'name')),
+    column_helper.Column('primary_ip', ('primaryIpAddress',)),
+    column_helper.Column('backend_ip', ('primaryBackendIpAddress',)),
+    column_helper.Column(
+        'created_by',
+        ('billingItem', 'orderItem', 'order', 'userRecord', 'username')),
+    column_helper.Column('power_state', ('powerState', 'name')),
+    column_helper.Column(
+        'tags',
+        lambda server: formatting.tags(server.get('tagReferences')),
+        mask="tagReferences.tag.name"),
+]
+
+DEFAULT_COLUMNS = [
+    'id',
+    'hostname',
+    'domain',
+    'primary_ip',
+    'backend_ip',
+    'power_state'
+]
+
+
+@click.command()
+@click.argument('identifier')
+@click.option('--cpu', '-c', help='Number of CPU cores', type=click.INT)
+@click.option('--domain', '-D', help='Domain portion of the FQDN')
+@click.option('--hostname', '-H', help='Host portion of the FQDN')
+@click.option('--memory', '-m', help='Memory in mebibytes', type=click.INT)
+@helpers.multi_option('--tag', help='Filter by tags')
+@click.option('--sortby',
+              help='Column to sort by',
+              default='hostname',
+              show_default=True)
+@click.option('--columns',
+              callback=column_helper.get_formatter(COLUMNS),
+              help='Columns to display. [options: %s]'
+              % ', '.join(column.name for column in COLUMNS),
+              default=','.join(DEFAULT_COLUMNS),
+              show_default=True)
+@environment.pass_env
+def cli(env, identifier, sortby, cpu, domain, hostname, memory, tag, columns):
+    """List guests into the dedicated host."""
+    mgr = SoftLayer.DedicatedHostManager(env.client)
+    guests = mgr.list_guests(host_id=identifier,
+                             cpus=cpu,
+                             hostname=hostname,
+                             domain= domain,
+                             memory=memory,
+                             tags=tag,
+                             mask=columns.mask())
+
+    table = formatting.Table(columns.columns)
+    table.sortby = sortby
+
+    for guest in guests:
+        table.add_row([value or formatting.blank()
+                       for value in columns.row(guest)])
+
+    env.fout(table)

--- a/SoftLayer/CLI/routes.py
+++ b/SoftLayer/CLI/routes.py
@@ -38,7 +38,7 @@ ALL_ROUTES = [
     ('dedicatedhost:create-options', 'SoftLayer.CLI.dedicatedhost.create_options:cli'),
     ('dedicatedhost:detail', 'SoftLayer.CLI.dedicatedhost.detail:cli'),
     ('dedicatedhost:cancel', 'SoftLayer.CLI.dedicatedhost.cancel:cli'),
-    ('dedicatedhost:cancel-all-guests', 'SoftLayer.CLI.dedicatedhost.cancel_guests:cli'),
+    ('dedicatedhost:cancel-guests', 'SoftLayer.CLI.dedicatedhost.cancel_guests:cli'),
     ('dedicatedhost:list-guests', 'SoftLayer.CLI.dedicatedhost.list_guests:cli'),
 
     ('cdn', 'SoftLayer.CLI.cdn'),

--- a/SoftLayer/CLI/routes.py
+++ b/SoftLayer/CLI/routes.py
@@ -38,6 +38,8 @@ ALL_ROUTES = [
     ('dedicatedhost:create-options', 'SoftLayer.CLI.dedicatedhost.create_options:cli'),
     ('dedicatedhost:detail', 'SoftLayer.CLI.dedicatedhost.detail:cli'),
     ('dedicatedhost:cancel', 'SoftLayer.CLI.dedicatedhost.cancel:cli'),
+    ('dedicatedhost:cancel-all-guests', 'SoftLayer.CLI.dedicatedhost.cancel_guests:cli'),
+    ('dedicatedhost:list-guests', 'SoftLayer.CLI.dedicatedhost.list_guests:cli'),
 
     ('cdn', 'SoftLayer.CLI.cdn'),
     ('cdn:detail', 'SoftLayer.CLI.cdn.detail:cli'),

--- a/SoftLayer/CLI/routes.py
+++ b/SoftLayer/CLI/routes.py
@@ -37,6 +37,7 @@ ALL_ROUTES = [
     ('dedicatedhost:create', 'SoftLayer.CLI.dedicatedhost.create:cli'),
     ('dedicatedhost:create-options', 'SoftLayer.CLI.dedicatedhost.create_options:cli'),
     ('dedicatedhost:detail', 'SoftLayer.CLI.dedicatedhost.detail:cli'),
+    ('dedicatedhost:cancel', 'SoftLayer.CLI.dedicatedhost.cancel:cli'),
 
     ('cdn', 'SoftLayer.CLI.cdn'),
     ('cdn:detail', 'SoftLayer.CLI.cdn.detail:cli'),

--- a/SoftLayer/fixtures/SoftLayer_Virtual_DedicatedHost.py
+++ b/SoftLayer/fixtures/SoftLayer_Virtual_DedicatedHost.py
@@ -80,8 +80,7 @@ getObjectById = {
 deleteObject = True
 
 getGuests = [{
-    'id': 100,
-    'metricTrackingObjectId': 1,
+    'id': 200,
     'hostname': 'vs-test1',
     'domain': 'test.sftlyr.ws',
     'fullyQualifiedDomainName': 'vs-test1.test.sftlyr.ws',
@@ -95,7 +94,6 @@ getGuests = [{
     'globalIdentifier': '1a2b3c-1701',
     'primaryBackendIpAddress': '10.45.19.37',
     'hourlyBillingFlag': False,
-
     'billingItem': {
         'id': 6327,
         'recurringFee': 1.54,
@@ -108,8 +106,7 @@ getGuests = [{
         }
     },
 }, {
-    'id': 104,
-    'metricTrackingObjectId': 2,
+    'id': 202,
     'hostname': 'vs-test2',
     'domain': 'test.sftlyr.ws',
     'fullyQualifiedDomainName': 'vs-test2.test.sftlyr.ws',
@@ -133,6 +130,5 @@ getGuests = [{
                 }
             }
         }
-    },
-    'virtualRack': {'id': 1, 'bandwidthAllotmentTypeId': 2},
+    }
 }]

--- a/SoftLayer/fixtures/SoftLayer_Virtual_DedicatedHost.py
+++ b/SoftLayer/fixtures/SoftLayer_Virtual_DedicatedHost.py
@@ -76,3 +76,63 @@ getObjectById = {
     'id': 12345,
     'createDate': '2017-11-02T11:40:56-07:00'
 }
+
+deleteObject = True
+
+getGuests = [{
+    'id': 100,
+    'metricTrackingObjectId': 1,
+    'hostname': 'vs-test1',
+    'domain': 'test.sftlyr.ws',
+    'fullyQualifiedDomainName': 'vs-test1.test.sftlyr.ws',
+    'status': {'keyName': 'ACTIVE', 'name': 'Active'},
+    'datacenter': {'id': 50, 'name': 'TEST00',
+                   'description': 'Test Data Center'},
+    'powerState': {'keyName': 'RUNNING', 'name': 'Running'},
+    'maxCpu': 2,
+    'maxMemory': 1024,
+    'primaryIpAddress': '172.16.240.2',
+    'globalIdentifier': '1a2b3c-1701',
+    'primaryBackendIpAddress': '10.45.19.37',
+    'hourlyBillingFlag': False,
+
+    'billingItem': {
+        'id': 6327,
+        'recurringFee': 1.54,
+        'orderItem': {
+            'order': {
+                'userRecord': {
+                    'username': 'chechu',
+                }
+            }
+        }
+    },
+}, {
+    'id': 104,
+    'metricTrackingObjectId': 2,
+    'hostname': 'vs-test2',
+    'domain': 'test.sftlyr.ws',
+    'fullyQualifiedDomainName': 'vs-test2.test.sftlyr.ws',
+    'status': {'keyName': 'ACTIVE', 'name': 'Active'},
+    'datacenter': {'id': 50, 'name': 'TEST00',
+                   'description': 'Test Data Center'},
+    'powerState': {'keyName': 'RUNNING', 'name': 'Running'},
+    'maxCpu': 4,
+    'maxMemory': 4096,
+    'primaryIpAddress': '172.16.240.7',
+    'globalIdentifier': '05a8ac-6abf0',
+    'primaryBackendIpAddress': '10.45.19.35',
+    'hourlyBillingFlag': True,
+    'billingItem': {
+        'id': 6327,
+        'recurringFee': 1.54,
+        'orderItem': {
+            'order': {
+                'userRecord': {
+                    'username': 'chechu',
+                }
+            }
+        }
+    },
+    'virtualRack': {'id': 1, 'bandwidthAllotmentTypeId': 2},
+}]

--- a/SoftLayer/managers/dedicated_host.py
+++ b/SoftLayer/managers/dedicated_host.py
@@ -37,29 +37,111 @@ class DedicatedHostManager(utils.IdentifierMixin, object):
         if ordering_manager is None:
             self.ordering_manager = ordering.OrderingManager(client)
 
-    def cancel_host(self, host_id, immediate=True):
-        """Cancels a dedicated host server.
-
-        Example::
-            # Cancels dedicated host id 1234
-            result = mgr.cancel_host(host_id=1234)
+    def cancel_host(self, host_id):
+        """Cancel a dedicated host immediately, it fails if there are still guests in the host.
 
         :param host_id: The ID of the dedicated host to be cancelled.
-        :param immediate: If False the dedicated host will be reclaimed in the anniversary date.
-                          Default is True
         :return: True on success or an exception
-        """
-        mask = 'mask[id,billingItem[id,hourlyFlag]]'
-        host_billing = self.get_host(host_id, mask=mask)
-        billing_id = host_billing['billingItem']['id']
-        is_hourly = host_billing['billingItem']['hourlyFlag']
 
-        if is_hourly and immediate is False:
-            raise SoftLayer.SoftLayerError("Hourly Dedicated Hosts can only be cancelled immediately.")
-        else:
-            # Monthly dedicated host can be reclaimed immediately and no reasons are required
-            result = self.client['Billing_Item'].cancelItem(immediate, False, id=billing_id)
-        return result
+        Example::
+            # Cancels dedicated host id 12345
+            result = mgr.cancel_host(12345)
+
+        """
+        return self.host.deleteObject(id=host_id)
+
+    def list_guests(self, host_id, tags=None, cpus=None, memory=None, hostname=None,
+                    domain=None, local_disk=None, nic_speed=None, public_ip=None,
+                    private_ip=None, **kwargs):
+        """Retrieve a list of all virtual servers on the dedicated host.
+
+        Example::
+
+            # Print out a list of hourly instances in the host id 12345.
+
+            for vsi in mgr.list_guests(host_id=12345, hourly=True):
+               print vsi['fullyQualifiedDomainName'], vsi['primaryIpAddress']
+
+            # Using a custom object-mask. Will get ONLY what is specified
+            object_mask = "mask[hostname,monitoringRobot[robotStatus]]"
+            for vsi in mgr.list_guests(mask=object_mask,hourly=True):
+                print vsi
+
+        :param integer host_id: the identifier of dedicated host
+        :param boolean hourly: include hourly instances
+        :param boolean monthly: include monthly instances
+        :param list tags: filter based on list of tags
+        :param integer cpus: filter based on number of CPUS
+        :param integer memory: filter based on amount of memory
+        :param string hostname: filter based on hostname
+        :param string domain: filter based on domain
+        :param string local_disk: filter based on local_disk
+        :param integer nic_speed: filter based on network speed (in MBPS)
+        :param string public_ip: filter based on public ip address
+        :param string private_ip: filter based on private ip address
+        :param dict \\*\\*kwargs: response-level options (mask, limit, etc.)
+        :returns: Returns a list of dictionaries representing the matching
+                  virtual servers
+        """
+        if 'mask' not in kwargs:
+            items = [
+                'id',
+                'globalIdentifier',
+                'hostname',
+                'domain',
+                'fullyQualifiedDomainName',
+                'primaryBackendIpAddress',
+                'primaryIpAddress',
+                'lastKnownPowerState.name',
+                'hourlyBillingFlag',
+                'powerState',
+                'maxCpu',
+                'maxMemory',
+                'datacenter',
+                'activeTransaction.transactionStatus[friendlyName,name]',
+                'status',
+            ]
+            kwargs['mask'] = "mask[%s]" % ','.join(items)
+
+        _filter = utils.NestedDict(kwargs.get('filter') or {})
+
+        if tags:
+            _filter['guests']['tagReferences']['tag']['name'] = {
+                'operation': 'in',
+                'options': [{'name': 'data', 'value': tags}],
+            }
+
+        if cpus:
+            _filter['guests']['maxCpu'] = utils.query_filter(cpus)
+
+        if memory:
+            _filter['guests']['maxMemory'] = utils.query_filter(memory)
+
+        if hostname:
+            _filter['guests']['hostname'] = utils.query_filter(hostname)
+
+        if domain:
+            _filter['guests']['domain'] = utils.query_filter(domain)
+
+        if local_disk is not None:
+            _filter['guests']['localDiskFlag'] = (
+                utils.query_filter(bool(local_disk)))
+
+        if nic_speed:
+            _filter['guests']['networkComponents']['maxSpeed'] = (
+                utils.query_filter(nic_speed))
+
+        if public_ip:
+            _filter['guests']['primaryIpAddress'] = (
+                utils.query_filter(public_ip))
+
+        if private_ip:
+            _filter['guests']['primaryBackendIpAddress'] = (
+                utils.query_filter(private_ip))
+
+        kwargs['filter'] = _filter.to_dict()
+        kwargs['iter'] = True
+        return self.host.getGuests(id=host_id, **kwargs)
 
     def list_instances(self, tags=None, cpus=None, memory=None, hostname=None,
                        disk=None, datacenter=None, **kwargs):

--- a/SoftLayer/managers/dedicated_host.py
+++ b/SoftLayer/managers/dedicated_host.py
@@ -66,11 +66,11 @@ class DedicatedHostManager(utils.IdentifierMixin, object):
         """
         result = False
 
-        guest_list = self.host.getGuests(id=host_id, mask="id")
+        guests = self.host.getGuests(id=host_id, mask='id')
 
-        if guest_list:
-            for virtual_guest in guest_list:
-                result = self.guest.deleteObject(virtual_guest['id'])
+        if guests:
+            for vs in guests:
+                result = self.guest.deleteObject(id=vs['id'])
 
         return result
 

--- a/tests/CLI/modules/dedicatedhost_tests.py
+++ b/tests/CLI/modules/dedicatedhost_tests.py
@@ -342,10 +342,40 @@ class DedicatedHostsTests(testing.TestCase):
     def test_cancel_host(self, cancel_mock):
         result = self.run_command(['--really', 'dedicatedhost', 'cancel', '12345'])
         self.assert_no_fail(result)
-        cancel_mock.assert_called_with(12345, False)
-        self.assertEqual(str(result.output), 'Dedicated Host 12345 was successfully cancelled\n')
+        cancel_mock.assert_called_with(12345)
+        self.assertEqual(str(result.output), 'Dedicated Host 12345 was cancelled\n')
 
     def test_cancel_host_abort(self):
         result = self.run_command(['dedicatedhost', 'cancel', '12345'])
         self.assertEqual(result.exit_code, 2)
         self.assertIsInstance(result.exception, exceptions.CLIAbort)
+
+    @mock.patch('SoftLayer.DedicatedHostManager.cancel_host')
+    def test_cancel_all_guest(self, cancel_mock):
+        result = self.run_command(['--really', 'dedicatedhost', 'cancel', '12345'])
+        self.assert_no_fail(result)
+        cancel_mock.assert_called_with(12345)
+        self.assertEqual(str(result.output), 'Dedicated Host 12345 was cancelled\n')
+
+    def test_cancel_all_guest_empty_list(self):
+        result = self.run_command(['dedicatedhost', 'cancel', '12345'])
+        self.assertEqual(result.exit_code, 2)
+        self.assertIsInstance(result.exception, exceptions.CLIAbort)
+
+    def test_list_guests(self):
+        result = self.run_command(['dh', 'list-guests', '123', '--tag=tag'])
+
+        self.assert_no_fail(result)
+        self.assertEqual(json.loads(result.output),
+                         [{'hostname': 'vs-test1',
+                           'domain': 'test.sftlyr.ws',
+                           'primary_ip': '172.16.240.2',
+                           'id': 100,
+                           'power_state': 'Running',
+                           'backend_ip': '10.45.19.37'},
+                          {'hostname': 'vs-test2',
+                           'domain': 'test.sftlyr.ws',
+                           'primary_ip': '172.16.240.7',
+                           'id': 104,
+                           'power_state': 'Running',
+                           'backend_ip': '10.45.19.35'}])

--- a/tests/CLI/modules/dedicatedhost_tests.py
+++ b/tests/CLI/modules/dedicatedhost_tests.py
@@ -337,3 +337,15 @@ class DedicatedHostsTests(testing.TestCase):
             'quantity': 1},)
 
         self.assert_called_with('SoftLayer_Product_Order', 'verifyOrder', args=args)
+
+    @mock.patch('SoftLayer.DedicatedHostManager.cancel_host')
+    def test_cancel_host(self, cancel_mock):
+        result = self.run_command(['--really', 'dedicatedhost', 'cancel', '12345'])
+        self.assert_no_fail(result)
+        cancel_mock.assert_called_with(12345, False)
+        self.assertEqual(str(result.output), 'Dedicated Host 12345 was successfully cancelled\n')
+
+    def test_cancel_host_abort(self):
+        result = self.run_command(['dedicatedhost', 'cancel', '12345'])
+        self.assertEqual(result.exit_code, 2)
+        self.assertIsInstance(result.exception, exceptions.CLIAbort)

--- a/tests/CLI/modules/dedicatedhost_tests.py
+++ b/tests/CLI/modules/dedicatedhost_tests.py
@@ -353,13 +353,19 @@ class DedicatedHostsTests(testing.TestCase):
         self.assertIsInstance(result.exception, exceptions.CLIAbort)
 
     def test_cancel_guests(self):
+        vs1 = {'id': 987, 'fullyQualifiedDomainName': 'foobar.example.com'}
+        vs2 = {'id': 654, 'fullyQualifiedDomainName': 'wombat.example.com'}
         guests = self.set_mock('SoftLayer_Virtual_DedicatedHost', 'getGuests')
-        guests.return_value = [{'id': 987}, {'id': 654}]
+        guests.return_value = [vs1, vs2]
+
+        vs_status1 = {'id': 987, 'server name': 'foobar.example.com', 'status': 'Cancelled'}
+        vs_status2 = {'id': 654, 'server name': 'wombat.example.com', 'status': 'Cancelled'}
+        expected_result = [vs_status1, vs_status2]
 
         result = self.run_command(['--really', 'dedicatedhost', 'cancel-guests', '12345'])
         self.assert_no_fail(result)
 
-        self.assertEqual(str(result.output), 'All guests into the dedicated host 12345 were cancelled\n')
+        self.assertEqual(expected_result, json.loads(result.output))
 
     def test_cancel_guests_empty_list(self):
         guests = self.set_mock('SoftLayer_Virtual_DedicatedHost', 'getGuests')
@@ -393,3 +399,8 @@ class DedicatedHostsTests(testing.TestCase):
                            'id': 202,
                            'power_state': 'Running',
                            'backend_ip': '10.45.19.35'}])
+
+    def _get_cancel_guests_return(self):
+        vs_status1 = {'id': 123, 'fqdn': 'foobar.example.com', 'status': 'Cancelled'}
+        vs_status2 = {'id': 456, 'fqdn': 'wombat.example.com', 'status': 'Cancelled'}
+        return [vs_status1, vs_status2]

--- a/tests/CLI/modules/dedicatedhost_tests.py
+++ b/tests/CLI/modules/dedicatedhost_tests.py
@@ -352,26 +352,26 @@ class DedicatedHostsTests(testing.TestCase):
         self.assertEqual(result.exit_code, 2)
         self.assertIsInstance(result.exception, exceptions.CLIAbort)
 
-    def test_cancel_all_guests(self):
+    def test_cancel_guests(self):
         guests = self.set_mock('SoftLayer_Virtual_DedicatedHost', 'getGuests')
         guests.return_value = [{'id': 987}, {'id': 654}]
 
-        result = self.run_command(['--really', 'dedicatedhost', 'cancel-all-guests', '12345'])
+        result = self.run_command(['--really', 'dedicatedhost', 'cancel-guests', '12345'])
         self.assert_no_fail(result)
 
         self.assertEqual(str(result.output), 'All guests into the dedicated host 12345 were cancelled\n')
 
-    def test_cancel_all_guests_empty_list(self):
+    def test_cancel_guests_empty_list(self):
         guests = self.set_mock('SoftLayer_Virtual_DedicatedHost', 'getGuests')
         guests.return_value = []
 
-        result = self.run_command(['--really', 'dedicatedhost', 'cancel-all-guests', '12345'])
+        result = self.run_command(['--really', 'dedicatedhost', 'cancel-guests', '12345'])
         self.assert_no_fail(result)
 
         self.assertEqual(str(result.output), 'There is not any guest into the dedicated host 12345\n')
 
-    def test_cancel_all_guests_abort(self):
-        result = self.run_command(['dedicatedhost', 'cancel', '12345'])
+    def test_cancel_guests_abort(self):
+        result = self.run_command(['dedicatedhost', 'cancel-guests', '12345'])
         self.assertEqual(result.exit_code, 2)
 
         self.assertIsInstance(result.exception, exceptions.CLIAbort)

--- a/tests/managers/dedicated_host_tests.py
+++ b/tests/managers/dedicated_host_tests.py
@@ -546,6 +546,22 @@ class DedicatedHostTests(testing.TestCase):
         self.assertEqual(result, True)
         self.assert_called_with('SoftLayer_Virtual_DedicatedHost', 'deleteObject', identifier=789)
 
+    def test_cancel_guests(self):
+        self.dedicated_host.host = mock.Mock()
+        self.dedicated_host.host.getGuests.return_value = [{'id': 987}, {'id': 654}]
+
+        result = self.dedicated_host.cancel_guests(789)
+
+        self.assertEqual(result, True)
+
+    def test_cancel_guests_empty_list(self):
+        self.dedicated_host.host = mock.Mock()
+        self.dedicated_host.host.getGuests.return_value = []
+
+        result = self.dedicated_host.cancel_guests(789)
+
+        self.assertEqual(result, False)
+
     def _get_routers_sample(self):
         routers = [
             {
@@ -658,7 +674,7 @@ class DedicatedHostTests(testing.TestCase):
         results = self.dedicated_host.list_guests(12345)
 
         for result in results:
-            self.assertIn(result['id'], [100, 104])
+            self.assertIn(result['id'], [200, 202])
         self.assert_called_with('SoftLayer_Virtual_DedicatedHost', 'getGuests', identifier=12345)
 
     def test_list_guests_with_filters(self):

--- a/tests/managers/dedicated_host_tests.py
+++ b/tests/managers/dedicated_host_tests.py
@@ -540,6 +540,28 @@ class DedicatedHostTests(testing.TestCase):
         self.assertRaises(exceptions.SoftLayerError,
                           self.dedicated_host._get_default_router, routers, 'notFound')
 
+    def test_cancel_host(self):
+        self.dedicated_host.host = mock.Mock()
+        self.dedicated_host.host.getObject.return_value = {'id': 987, 'billingItem': {
+                                                           'id': 1234, 'hourlyFlag': False}}
+        # Immediate cancellation
+        result = self.dedicated_host.cancel_host(987)
+        self.assertEqual(True, result)
+
+        # Cancellation on anniversary
+        result = self.dedicated_host.cancel_host(987, immediate=False)
+        self.assertEqual(True, result)
+
+    def test_cancel_host_billing_hourly_no_immediate(self):
+        self.dedicated_host.host = mock.Mock()
+        self.dedicated_host.host.getObject.return_value = {'id': 987, 'billingItem': {
+                                                           'id': 1234, 'hourlyFlag': True}}
+
+        ex = self.assertRaises(SoftLayer.SoftLayerError,
+                               self.dedicated_host.cancel_host,
+                               987, immediate=False)
+        self.assertEqual("Hourly Dedicated Hosts can only be cancelled immediately.", str(ex))
+
     def _get_routers_sample(self):
         routers = [
             {


### PR DESCRIPTION
`slcli dh cancel` makes a simple call to the deleteObject method of dedicated host. 
`slcli dh cancel-guests` cancels all guests into the dedicated hosts
`slcli dh list-guests`  lists guests in the dedicated host, it should be possible to filter, sortby and display more columns in the table

It should cover the request #1041