### PR TITLE
#882 - Added table which shows the status of each url

### DIFF
--- a/SoftLayer/CLI/cdn/purge.py
+++ b/SoftLayer/CLI/cdn/purge.py
@@ -5,6 +5,7 @@ import click
 
 import SoftLayer
 from SoftLayer.CLI import environment
+from SoftLayer.CLI import formatting
 
 
 @click.command()
@@ -15,4 +16,14 @@ def cli(env, account_id, content_url):
     """Purge cached files from all edge nodes."""
 
     manager = SoftLayer.CDNManager(env.client)
-    manager.purge_content(account_id, content_url)
+    content_list = manager.purge_content(account_id, content_url)
+
+    table = formatting.Table(['url', 'status'])
+
+    for content in content_list:
+        table.add_row([
+            content['url'],
+            content['statusCode']
+        ])
+
+    env.fout(table)

--- a/SoftLayer/CLI/cdn/purge.py
+++ b/SoftLayer/CLI/cdn/purge.py
@@ -13,7 +13,12 @@ from SoftLayer.CLI import formatting
 @click.argument('content_url', nargs=-1)
 @environment.pass_env
 def cli(env, account_id, content_url):
-    """Purge cached files from all edge nodes."""
+    """Purge cached files from all edge nodes.
+
+    Examples:
+         slcli cdn purge 97794 http://example.com/cdn/file.txt
+         slcli cdn purge 97794 http://example.com/cdn/file.txt https://dal01.example.softlayer.net/image.png
+    """
 
     manager = SoftLayer.CDNManager(env.client)
     content_list = manager.purge_content(account_id, content_url)

--- a/SoftLayer/fixtures/SoftLayer_Network_ContentDelivery_Account.py
+++ b/SoftLayer/fixtures/SoftLayer_Network_ContentDelivery_Account.py
@@ -32,6 +32,10 @@ deleteOriginPullRule = True
 
 loadContent = True
 
-purgeContent = True
+purgeContent = [
+    {'url': 'http://z/img/0z020.png', 'statusCode': 'SUCCESS'},
+    {'url': 'http://y/img/0z010.png', 'statusCode': 'FAILED'},
+    {'url': 'http://', 'statusCode': 'INVALID_URL'}
+]
 
-purgeCache = True
+purgeCache = [{'url': 'http://example.com', 'statusCode': 'SUCCESS'}]

--- a/SoftLayer/managers/cdn.py
+++ b/SoftLayer/managers/cdn.py
@@ -136,10 +136,9 @@ class CDNManager(utils.IdentifierMixin, object):
         if isinstance(urls, six.string_types):
             urls = [urls]
 
+        content_list = []
         for i in range(0, len(urls), MAX_URLS_PER_PURGE):
-            result = self.account.purgeCache(urls[i:i + MAX_URLS_PER_PURGE],
-                                             id=account_id)
-            if not result:
-                return result
+            content = self.account.purgeCache(urls[i:i + MAX_URLS_PER_PURGE], id=account_id)
+            content_list.extend(content)
 
-        return True
+        return content_list

--- a/SoftLayer/managers/cdn.py
+++ b/SoftLayer/managers/cdn.py
@@ -129,8 +129,8 @@ class CDNManager(utils.IdentifierMixin, object):
                                be purged.
         :param urls: a string or a list of strings representing the CDN URLs
                      that should be purged.
-        :returns: true if all purge requests were successfully submitted;
-                  otherwise, returns the first error encountered.
+        :returns: a list of SoftLayer_Container_Network_ContentDelivery_PurgeService_Response objects
+                  which indicates if the purge for each url was SUCCESS, FAILED or INVALID_URL.
         """
 
         if isinstance(urls, six.string_types):

--- a/tests/CLI/modules/cdn_tests.py
+++ b/tests/CLI/modules/cdn_tests.py
@@ -49,9 +49,9 @@ class CdnTests(testing.TestCase):
     def test_purge_content(self):
         result = self.run_command(['cdn', 'purge', '1234',
                                    'http://example.com'])
-
+        expected = [{"url": "http://example.com", "status": "SUCCESS"}]
         self.assert_no_fail(result)
-        self.assertEqual(result.output, "")
+        self.assertEqual(json.loads(result.output), expected)
 
     def test_list_origins(self):
         result = self.run_command(['cdn', 'origin-list', '1234'])


### PR DESCRIPTION
This should fix the issue #882 

Example:
```
$ slcli cdn purge 77777 http:// https:// http://par01.objectstorage.softlayer.net/v1/AUTH_26979667-f76a-47e8-92b6-20f0a8226fc8/ http://test01.http.par01.cdn.softlayer.net/ http://test01.http.che01.cdn.softlayer.net/ http://seo01.objectstorage.softlayer.net/v1/AUTH_26979667-f76a-47e8-92b6-20f0a8226fc8/
:........................................................................................:.............:
:                                          url                                           :    status   :
:........................................................................................:.............:
:                                        http://                                         : INVALID_URL :
:                                        https://                                        : INVALID_URL :
: http://par01.objectstorage.softlayer.net/v1/AUTH_26979667-f76a-47e8-92b6-20f0a8226fc8/ :    FAILED   :
:                       http://test01.http.par01.cdn.softlayer.net/                      :   SUCCESS   :
:                       http://test01.http.che01.cdn.softlayer.net/                      :   SUCCESS   :
: http://seo01.objectstorage.softlayer.net/v1/AUTH_26979667-f76a-47e8-92b6-20f0a8226fc8/ :    FAILED   :
:........................................................................................:.............:
```