### PR TITLE
removed power_state column option from "slcli server list"

### DIFF
--- a/SoftLayer/CLI/hardware/list.py
+++ b/SoftLayer/CLI/hardware/list.py
@@ -21,7 +21,6 @@ COLUMNS = [
         'action',
         lambda server: formatting.active_txn(server),
         mask='activeTransaction[id, transactionStatus[name, friendlyName]]'),
-    column_helper.Column('power_state', ('powerState', 'name')),
     column_helper.Column(
         'created_by',
         ('billingItem', 'orderItem', 'order', 'userRecord', 'username')),


### PR DESCRIPTION
This only affects to CLI, I reviewed managers and `powerState` is not present in `HardwareManager.list_hardware()`

It should fix #1088 