### PR TITLE
Added exception to handle json parsing error when ordering

### DIFF
--- a/SoftLayer/CLI/order/place.py
+++ b/SoftLayer/CLI/order/place.py
@@ -79,7 +79,7 @@ def cli(env, package_keyname, location, preset, verify, billing, complex_type,
         try:
             extras = json.loads(extras)
         except ValueError as err:
-            raise exceptions.CLIAbort("There was an error when parsing the --extras value: {}".format(err.message))
+            raise exceptions.CLIAbort("There was an error when parsing the --extras value: {}".format(err))
 
     args = (package_keyname, location, order_items)
     kwargs = {'preset_keyname': preset,

--- a/SoftLayer/CLI/order/place.py
+++ b/SoftLayer/CLI/order/place.py
@@ -76,7 +76,10 @@ def cli(env, package_keyname, location, preset, verify, billing, complex_type,
     manager = ordering.OrderingManager(env.client)
 
     if extras:
-        extras = json.loads(extras)
+        try:
+            extras = json.loads(extras)
+        except ValueError as err:
+            raise exceptions.CLIAbort("There was an error when parsing the --extras value: {}".format(err.message))
 
     args = (package_keyname, location, order_items)
     kwargs = {'preset_keyname': preset,

--- a/SoftLayer/CLI/order/place_quote.py
+++ b/SoftLayer/CLI/order/place_quote.py
@@ -72,7 +72,7 @@ def cli(env, package_keyname, location, preset, name, send_email, complex_type,
         try:
             extras = json.loads(extras)
         except ValueError as err:
-            raise exceptions.CLIAbort("There was an error when parsing the --extras value: {}".format(err.message))
+            raise exceptions.CLIAbort("There was an error when parsing the --extras value: {}".format(err))
 
     args = (package_keyname, location, order_items)
     kwargs = {'preset_keyname': preset,

--- a/SoftLayer/CLI/order/place_quote.py
+++ b/SoftLayer/CLI/order/place_quote.py
@@ -6,6 +6,7 @@ import json
 import click
 
 from SoftLayer.CLI import environment
+from SoftLayer.CLI import exceptions
 from SoftLayer.CLI import formatting
 from SoftLayer.managers import ordering
 
@@ -68,7 +69,10 @@ def cli(env, package_keyname, location, preset, name, send_email, complex_type,
     manager = ordering.OrderingManager(env.client)
 
     if extras:
-        extras = json.loads(extras)
+        try:
+            extras = json.loads(extras)
+        except ValueError as err:
+            raise exceptions.CLIAbort("There was an error when parsing the --extras value: {}".format(err.message))
 
     args = (package_keyname, location, order_items)
     kwargs = {'preset_keyname': preset,

--- a/tests/CLI/modules/order_tests.py
+++ b/tests/CLI/modules/order_tests.py
@@ -6,6 +6,7 @@
 import json
 
 from SoftLayer import testing
+from SoftLayer.CLI import exceptions
 
 
 class OrderTests(testing.TestCase):
@@ -103,6 +104,13 @@ class OrderTests(testing.TestCase):
                           'status': 'APPROVED'},
                          json.loads(result.output))
 
+    def test_place_extras_parameter_fail(self):
+        result = self.run_command(['-y', 'order', 'place', 'package', 'DALLAS13', 'ITEM1',
+                                   '--extras', '{"device":['])
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertIsInstance(result.exception, exceptions.CLIAbort)
+
     def test_place_quote(self):
         order_date = '2018-04-04 07:39:20'
         expiration_date = '2018-05-04 07:39:20'
@@ -131,6 +139,13 @@ class OrderTests(testing.TestCase):
                           'expires': expiration_date,
                           'status': 'PENDING'},
                          json.loads(result.output))
+
+    def test_place_quote_extras_parameter_fail(self):
+        result = self.run_command(['-y', 'order', 'place-quote', 'package', 'DALLAS13', 'ITEM1',
+                                   '--extras', '{"device":['])
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertIsInstance(result.exception, exceptions.CLIAbort)
 
     def test_verify_hourly(self):
         order_date = '2017-04-04 07:39:20'

--- a/tests/CLI/modules/order_tests.py
+++ b/tests/CLI/modules/order_tests.py
@@ -5,8 +5,8 @@
 """
 import json
 
-from SoftLayer import testing
 from SoftLayer.CLI import exceptions
+from SoftLayer import testing
 
 
 class OrderTests(testing.TestCase):


### PR DESCRIPTION
try/catch was added to handle json decode errors  in the  `--extras` value, it should fix #1107 

`slcli order place` and `slcli order place-quote`

output python 2.7:
```There was an error when parsing the --extras value: No JSON object could be decoded```

output python 3:
```There was an error when parsing the --extras value: Expecting value: line 1 column 28 (char 27)```
