### PR TITLE
Handle the new user creation exceptions

### DIFF
--- a/SoftLayer/managers/user.py
+++ b/SoftLayer/managers/user.py
@@ -243,7 +243,16 @@ class UserManager(utils.IdentifierMixin, object):
         :param dictionary user_object: https://softlayer.github.io/reference/datatypes/SoftLayer_User_Customer/
         """
         LOGGER.warning("Creating User %s", user_object['username'])
-        return self.user_service.createObject(user_object, password, None)
+
+        try:
+            return self.user_service.createObject(user_object, password, None)
+        except exceptions.SoftLayerAPIError as err:
+            if err.faultCode != "SoftLayer_Exception_User_Customer_DelegateIamIdInvitationToPaas":
+                raise
+            else:
+                raise exceptions.SoftLayerError("Your request for a new user was received, but it needs to be "
+                                                "processed by the Platform Services API first. Barring any errors on "
+                                                "the Platform Services side, your new user should be created shortly.")
 
     def edit_user(self, user_id, user_object):
         """Blindly sends user_object to SoftLayer_User_Customer::editObject

--- a/SoftLayer/managers/user.py
+++ b/SoftLayer/managers/user.py
@@ -246,13 +246,12 @@ class UserManager(utils.IdentifierMixin, object):
 
         try:
             return self.user_service.createObject(user_object, password, None)
-        except exceptions.SoftLayerAPIError as err:
-            if err.faultCode != "SoftLayer_Exception_User_Customer_DelegateIamIdInvitationToPaas":
-                raise
-            else:
+        except exceptions.SoftLayerAPIError as ex:
+            if ex.faultCode == "SoftLayer_Exception_User_Customer_DelegateIamIdInvitationToPaas":
                 raise exceptions.SoftLayerError("Your request for a new user was received, but it needs to be "
                                                 "processed by the Platform Services API first. Barring any errors on "
                                                 "the Platform Services side, your new user should be created shortly.")
+            raise
 
     def edit_user(self, user_id, user_object):
         """Blindly sends user_object to SoftLayer_User_Customer::editObject


### PR DESCRIPTION
Added try/except and unit tests to handle the exception that is not an error #1101 

output if SoftLayer_Exception_User_Customer_DelegateIamIdInvitationToPaas occurs
```
Do you wish to continue? [y/N]: y
Your request for a new user was received, but it needs to be processed by the Platform Services API first. Barring any errors on the Platform Services side, your new user should be created shortly.
```
output if a different exception occurs:
```
Do you wish to continue? [y/N]: y
SoftLayerAPIError(SoftLayer_Exception_User_Customer_IamIdAlreadyInvited): Account 11111111 is authenticated by IAMid, and this IAMid already has an active invitation to link to a user in this account.
```
output when account is not linked to bluemix:
```
Do you wish to continue? [y/N]: y
:.......................:......................................:...........:.........:
:        Username       :                Email                 :  Password : API Key :
:.......................:......................................:...........:.........:
: user_name_example01   :  user_name_example01@mailinator.com  : Pass@1234 :   None  :
:.......................:......................................:...........:.........:
```