### PR TITLE
Fix order place quantity option

### DIFF
--- a/SoftLayer/CLI/order/place.py
+++ b/SoftLayer/CLI/order/place.py
@@ -25,7 +25,7 @@ COLUMNS = ['keyName',
               help="Flag denoting whether or not to only verify the order, not place it")
 @click.option('--quantity',
               type=int,
-              help="The quantity of the item being ordered ")
+              help="The quantity of the item being ordered")
 @click.option('--billing',
               type=click.Choice(['hourly', 'monthly']),
               default='hourly',

--- a/SoftLayer/CLI/order/place.py
+++ b/SoftLayer/CLI/order/place.py
@@ -23,6 +23,9 @@ COLUMNS = ['keyName',
 @click.option('--verify',
               is_flag=True,
               help="Flag denoting whether or not to only verify the order, not place it")
+@click.option('--quantity',
+              type=int,
+              help="The quantity of the item being ordered ")
 @click.option('--billing',
               type=click.Choice(['hourly', 'monthly']),
               default='hourly',
@@ -35,7 +38,7 @@ COLUMNS = ['keyName',
 @click.argument('order_items', nargs=-1)
 @environment.pass_env
 def cli(env, package_keyname, location, preset, verify, billing, complex_type,
-        extras, order_items):
+        quantity, extras, order_items):
     """Place or verify an order.
 
     This CLI command is used for placing/verifying an order of the specified package in
@@ -84,7 +87,7 @@ def cli(env, package_keyname, location, preset, verify, billing, complex_type,
     args = (package_keyname, location, order_items)
     kwargs = {'preset_keyname': preset,
               'extras': extras,
-              'quantity': 1,
+              'quantity': quantity,
               'complex_type': complex_type,
               'hourly': bool(billing == 'hourly')}
 

--- a/SoftLayer/CLI/order/place.py
+++ b/SoftLayer/CLI/order/place.py
@@ -25,6 +25,7 @@ COLUMNS = ['keyName',
               help="Flag denoting whether or not to only verify the order, not place it")
 @click.option('--quantity',
               type=int,
+              default=1,
               help="The quantity of the item being ordered")
 @click.option('--billing',
               type=click.Choice(['hourly', 'monthly']),

--- a/SoftLayer/managers/ordering.py
+++ b/SoftLayer/managers/ordering.py
@@ -415,7 +415,7 @@ class OrderingManager(object):
         return prices
 
     def verify_order(self, package_keyname, location, item_keynames, complex_type=None,
-                     hourly=True, preset_keyname=None, extras=None, quantity=1):
+                     hourly=True, preset_keyname=None, extras=None, quantity=None):
         """Verifies an order with the given package and prices.
 
         This function takes in parameters needed for an order and verifies the order
@@ -446,7 +446,7 @@ class OrderingManager(object):
         return self.order_svc.verifyOrder(order)
 
     def place_order(self, package_keyname, location, item_keynames, complex_type=None,
-                    hourly=True, preset_keyname=None, extras=None, quantity=1):
+                    hourly=True, preset_keyname=None, extras=None, quantity=None):
         """Places an order with the given package and prices.
 
         This function takes in parameters needed for an order and places the order.
@@ -509,7 +509,7 @@ class OrderingManager(object):
         return self.order_svc.placeQuote(order)
 
     def generate_order(self, package_keyname, location, item_keynames, complex_type=None,
-                       hourly=True, preset_keyname=None, extras=None, quantity=1):
+                       hourly=True, preset_keyname=None, extras=None, quantity=None):
         """Generates an order with the given package and prices.
 
         This function takes in parameters needed for an order and generates an order
@@ -546,7 +546,6 @@ class OrderingManager(object):
         order.update(extras)
         order['packageId'] = package['id']
         order['location'] = self.get_location_id(location)
-        order['quantity'] = quantity
         order['useHourlyPricing'] = hourly
 
         preset_core = None
@@ -561,6 +560,11 @@ class OrderingManager(object):
         if not complex_type:
             raise exceptions.SoftLayerError("A complex type must be specified with the order")
         order['complexType'] = complex_type
+
+        if not quantity:
+            order['quantity'] = 1
+        else:
+            order['quantity'] = quantity
 
         price_ids = self.get_price_id_list(package_keyname, item_keynames, preset_core)
         order['prices'] = [{'id': price_id} for price_id in price_ids]

--- a/SoftLayer/managers/ordering.py
+++ b/SoftLayer/managers/ordering.py
@@ -415,7 +415,7 @@ class OrderingManager(object):
         return prices
 
     def verify_order(self, package_keyname, location, item_keynames, complex_type=None,
-                     hourly=True, preset_keyname=None, extras=None, quantity=None):
+                     hourly=True, preset_keyname=None, extras=None, quantity=1):
         """Verifies an order with the given package and prices.
 
         This function takes in parameters needed for an order and verifies the order
@@ -446,7 +446,7 @@ class OrderingManager(object):
         return self.order_svc.verifyOrder(order)
 
     def place_order(self, package_keyname, location, item_keynames, complex_type=None,
-                    hourly=True, preset_keyname=None, extras=None, quantity=None):
+                    hourly=True, preset_keyname=None, extras=None, quantity=1):
         """Places an order with the given package and prices.
 
         This function takes in parameters needed for an order and places the order.
@@ -509,7 +509,7 @@ class OrderingManager(object):
         return self.order_svc.placeQuote(order)
 
     def generate_order(self, package_keyname, location, item_keynames, complex_type=None,
-                       hourly=True, preset_keyname=None, extras=None, quantity=None):
+                       hourly=True, preset_keyname=None, extras=None, quantity=1):
         """Generates an order with the given package and prices.
 
         This function takes in parameters needed for an order and generates an order
@@ -545,6 +545,7 @@ class OrderingManager(object):
         #                                    'domain': 'softlayer.com'}]}
         order.update(extras)
         order['packageId'] = package['id']
+        order['quantity'] = quantity
         order['location'] = self.get_location_id(location)
         order['useHourlyPricing'] = hourly
 
@@ -560,11 +561,6 @@ class OrderingManager(object):
         if not complex_type:
             raise exceptions.SoftLayerError("A complex type must be specified with the order")
         order['complexType'] = complex_type
-
-        if not quantity:
-            order['quantity'] = 1
-        else:
-            order['quantity'] = quantity
 
         price_ids = self.get_price_id_list(package_keyname, item_keynames, preset_core)
         order['prices'] = [{'id': price_id} for price_id in price_ids]

--- a/tests/CLI/modules/order_tests.py
+++ b/tests/CLI/modules/order_tests.py
@@ -115,7 +115,7 @@ class OrderTests(testing.TestCase):
         place_mock.return_value = order
         items_mock.return_value = self._get_order_items()
 
-        result = self.run_command(['-y', 'order', 'place', '--quantity=2','package', 'DALLAS13', 'ITEM1',
+        result = self.run_command(['-y', 'order', 'place', '--quantity=2', 'package', 'DALLAS13', 'ITEM1',
                                    '--complex-type', 'SoftLayer_Container_Product_Order_Thing'])
 
         self.assert_no_fail(result)

--- a/tests/CLI/modules/order_tests.py
+++ b/tests/CLI/modules/order_tests.py
@@ -104,6 +104,27 @@ class OrderTests(testing.TestCase):
                           'status': 'APPROVED'},
                          json.loads(result.output))
 
+    def test_place_with_quantity(self):
+        order_date = '2017-04-04 07:39:20'
+        order = {'orderId': 1234, 'orderDate': order_date, 'placedOrder': {'status': 'APPROVED'}}
+        verify_mock = self.set_mock('SoftLayer_Product_Order', 'verifyOrder')
+        place_mock = self.set_mock('SoftLayer_Product_Order', 'placeOrder')
+        items_mock = self.set_mock('SoftLayer_Product_Package', 'getItems')
+
+        verify_mock.return_value = self._get_verified_order_return()
+        place_mock.return_value = order
+        items_mock.return_value = self._get_order_items()
+
+        result = self.run_command(['-y', 'order', 'place', '--quantity=2','package', 'DALLAS13', 'ITEM1',
+                                   '--complex-type', 'SoftLayer_Container_Product_Order_Thing'])
+
+        self.assert_no_fail(result)
+        self.assert_called_with('SoftLayer_Product_Order', 'placeOrder')
+        self.assertEqual({'id': 1234,
+                          'created': order_date,
+                          'status': 'APPROVED'},
+                         json.loads(result.output))
+
     def test_place_extras_parameter_fail(self):
         result = self.run_command(['-y', 'order', 'place', 'package', 'DALLAS13', 'ITEM1',
                                    '--extras', '{"device":['])


### PR DESCRIPTION
Fix order place quantity option https://github.com/softlayer/softlayer-python/issues/1116.

**>slcli order place --help**

```
Options:
  --preset TEXT                         The order preset (if required by the package)
  --verify                              Flag denoting whether or not to only verify the order, not place it
  --quantity INTEGER                    The quantity of the item being ordered
  --billing [hourly|monthly]            Billing rate  [default: hourly]
  --complex-type TEXT                   The complex type of the order. This typically begins with                                                       'SoftLayer_Container_Product_Order_'.
  --extras TEXT                         JSON string denoting extra data that needs to be sent with the order
  -h, --help                            Show this message and exit.
```

**Example1:**
`>slcli order place --quantity 2 --billing monthly VIRTUAL_ROUTER_APPLIANCE_1_GPBS DALLAS05 INTEL_INTEL_XEON_E31270_V6_3_80 OS_JUNIPER_VSRX_15_X_UP_TO_1GBPS_STANDARD RAM_32_GB_DDR4_2133_ECC_NON_REG DISK_CONTROLLER_RAID HARD_DRIVE_3_00TB_SATA_III SRIOV_ENABLED BANDWIDTH_5000_GB MONITORING_HOST_PING 1_GBPS_REDUNDANT_PUBLIC_PRIVATE_NETWORK_UPLINKS REBOOT_KVM_OVER_IP 1_IP_ADDRESS NOTIFICATION_EMAIL_AND_TICKET AUTOMATED_NOTIFICATION UNLIMITED_SSL_VPN_USERS_1_PPTP_VPN_USER_PER_ACCOUNT NESSUS_VULNERABILITY_ASSESSMENT_REPORTING --complex-type SoftLayer_Container_Product_Order_Hardware_Server_Gateway_Appliance --extras '{"hardware":[{"hostname":"gateway01","domain":"example.com"},{"hostname":"gateway02","domain":"example.com"}]}'`

**Output:**
:...................................................................................:
: name : value :
:...................................................................................:
: id : 35311111 :
: created : 2019-03-19T10:04:09-06:00 :
: status : PENDING_AUTO_APPROVAL :
:....................................................................................

**Example2:
By default the quantity is 1:**
`>slcli order place --billing monthly VIRTUAL_ROUTER_APPLIANCE_1_GPBS DALLAS05 INTEL_INTEL_XEON_E31270_V6_3_80 OS_JUNIPER_VSRX_15_X_UP_TO_1GBPS_STANDARD RAM_32_GB_DDR4_2133_ECC_NON_REG DISK_CONTROLLER_RAID HARD_DRIVE_3_00TB_SATA_III SRIOV_ENABLED BANDWIDTH_5000_GB MONITORING_HOST_PING 1_GBPS_REDUNDANT_PUBLIC_PRIVATE_NETWORK_UPLINKS REBOOT_KVM_OVER_IP 1_IP_ADDRESS NOTIFICATION_EMAIL_AND_TICKET AUTOMATED_NOTIFICATION UNLIMITED_SSL_VPN_USERS_1_PPTP_VPN_USER_PER_ACCOUNT NESSUS_VULNERABILITY_ASSESSMENT_REPORTING --complex-type SoftLayer_Container_Product_Order_Hardware_Server_Gateway_Appliance --extras '{"hardware":[{"hostname":"gateway01","domain":"example.com"}]}'`

**Output:**
:...................................................................................:
: name : value :
:...................................................................................:
: id : 35322222 :
: created : 2019-03-19T11:08:14-06:00 :
: status : PENDING_AUTO_APPROVAL :
:....................................................................................

**Example3:
ORDER CLOUD_SERVER:**
`>slcli order place --quantity 2 --billing hourly CLOUD_SERVER AMSTERDAM GUEST_PRIVATE_CORE_1 RAM_2_GB OS_CENTOS_7_X_MINIMAL_64_BIT GUEST_DISK_25_GB_SAN BANDWIDTH_0_GB_2 1_GBPS_PUBLIC_PRIVATE_NETWORK_UPLINKS MONITORING_HOST_PING AUTOMATED_NOTIFICATION UNLIMITED_SSL_VPN_USERS_1_PPTP_VPN_USER_PER_ACCOUNT NESSUS_VULNERABILITY_ASSESSMENT_REPORTING 1_IP_ADDRESS NOTIFICATION_EMAIL_AND_TICKET REBOOT_REMOTE_CONSOLE --extras "{"privateCloudOrderFlag":false,"useHourlyPricing":true,""virtualGuests": [{"hostname": "test", "domain": "softlayer.com"},{"hostname": "test1", "domain": "softlayer.com"}]}" --complex-type SoftLayer_Container_Product_Order_Virtual_Guest`

**Output:**
:...................................................................................:
: name : value :
:...................................................................................:
: id : 35333333 :
: created : 2019-03-19T11:15:28-06:00 :
: status : PENDING_AUTO_APPROVAL :
:....................................................................................