### PR TITLE
Fix object storage apiType for S3 and Swift.

### DIFF
--- a/SoftLayer/CLI/object_storage/list_accounts.py
+++ b/SoftLayer/CLI/object_storage/list_accounts.py
@@ -15,12 +15,19 @@ def cli(env):
 
     mgr = SoftLayer.ObjectStorageManager(env.client)
     accounts = mgr.list_accounts()
-    table = formatting.Table(['id', 'name'])
+    table = formatting.Table(['id', 'name', 'apiType'])
     table.sortby = 'id'
+    global api_type
     for account in accounts:
+        if 'vendorName' in account and 'Swift' == account['vendorName']:
+            api_type = 'Swift'
+        elif 'Cleversafe' in account['serviceResource']['name']:
+            api_type = 'S3'
+
         table.add_row([
             account['id'],
             account['username'],
+            api_type,
         ])
 
     env.fout(table)

--- a/SoftLayer/CLI/object_storage/list_accounts.py
+++ b/SoftLayer/CLI/object_storage/list_accounts.py
@@ -17,9 +17,9 @@ def cli(env):
     accounts = mgr.list_accounts()
     table = formatting.Table(['id', 'name', 'apiType'])
     table.sortby = 'id'
-    global api_type
+    api_type = None
     for account in accounts:
-        if 'vendorName' in account and 'Swift' == account['vendorName']:
+        if 'vendorName' in account and account['vendorName'] == 'Swift':
             api_type = 'Swift'
         elif 'Cleversafe' in account['serviceResource']['name']:
             api_type = 'S3'

--- a/SoftLayer/fixtures/SoftLayer_Account.py
+++ b/SoftLayer/fixtures/SoftLayer_Account.py
@@ -525,8 +525,8 @@ getBalance = 40
 
 getNextInvoiceTotalAmount = 2
 
-getHubNetworkStorage = [{'id': 12345, 'username': 'SLOS12345-1'},
-                        {'id': 12346, 'username': 'SLOS12345-2'}]
+getHubNetworkStorage = [{'id': 12345, 'username': 'SLOS12345-1', 'serviceResource': {'name': 'Cleversafe - US Region'}},
+                        {'id': 12346, 'username': 'SLOS12345-2', 'vendorName': 'Swift'}]
 
 getIscsiNetworkStorage = [{
     'accountId': 1234,

--- a/SoftLayer/managers/object_storage.py
+++ b/SoftLayer/managers/object_storage.py
@@ -6,8 +6,8 @@
     :license: MIT, see LICENSE for more details.
 """
 
-LIST_ACCOUNTS_MASK = '''mask(SoftLayer_Network_Storage_Hub_Swift)[
-    id,username,notes
+LIST_ACCOUNTS_MASK = '''mask[
+    id,username,notes,vendorName,serviceResource
 ]'''
 
 ENDPOINT_MASK = '''mask(SoftLayer_Network_Storage_Hub_Swift)[
@@ -29,12 +29,8 @@ class ObjectStorageManager(object):
 
     def list_accounts(self):
         """Lists your object storage accounts."""
-        _filter = {
-            'hubNetworkStorage': {'vendorName': {'operation': 'Swift'}},
-        }
         return self.client.call('Account', 'getHubNetworkStorage',
-                                mask=LIST_ACCOUNTS_MASK,
-                                filter=_filter)
+                                mask=LIST_ACCOUNTS_MASK)
 
     def list_endpoints(self):
         """Lists the known object storage endpoints."""

--- a/tests/CLI/modules/object_storage_tests.py
+++ b/tests/CLI/modules/object_storage_tests.py
@@ -16,8 +16,9 @@ class ObjectStorageTests(testing.TestCase):
 
         self.assert_no_fail(result)
         self.assertEqual(json.loads(result.output),
-                         [{'id': 12345, 'name': 'SLOS12345-1'},
-                          {'id': 12346, 'name': 'SLOS12345-2'}])
+                         [{'apiType': 'S3', 'id': 12345, 'name': 'SLOS12345-1'},
+                          {'apiType': 'Swift', 'id': 12346, 'name': 'SLOS12345-2'}]
+                         )
 
     def test_list_endpoints(self):
         accounts = self.set_mock('SoftLayer_Account', 'getHubNetworkStorage')


### PR DESCRIPTION
Fix object storage apiType for S3 and Swift https://github.com/softlayer/softlayer-python/issues/1121.

slcli object-storage accounts

**Output:**

```
:..........:................:.........:.
:    id    :      name     : apiType :
:..........:................:.........:.
: 2441111   :  SLOS307-2   :  Swift  :
: 2446222   :  SLOS307-3   :  Swift  :
: 4423000   : SLOS307-19   :  Swift  :
: 4422354   : SLOS307-21   :  Swift  :
: 4432481   : SLOS307-23   :  Swift  :
: 4432358   : SLOS307-26   :  Swift  :
: 4434571   : SLOS307-33   :  Swift  :
: 4435124   : SLOS307-35   :  Swift  :
: 6761245   : SLOS307-36   :  Swift  :
: 8934578   : SLOS307-37   :  Swift  :
: 1855457   : SLOS307-39   :  Swift  :
: 1954458   : SLOSC30-4    :    S3   :
: 1954245   : SLOSC30-5    :    S3   :
: 2062415   : SLOSC30-6    :    S3   :
: 2471245   : SLOSC30-7    :    S3   :
: 2478124   : SLOS30-40    :  Swift  :
: 2611245   : SLOSC30-8    :    S3   :
: 2676457   : SLOSC30-9    :    S3   :
: 3402124   : SLOSC30-10   :    S3   :
: 4112123   : SLOS307-41   :  Swift  :
: 4262212   : SLOS307-42   :  Swift  :
:..........:................:.........:.
```