### PR TITLE
Feature usage option for a vs.

### DIFF
--- a/SoftLayer/CLI/routes.py
+++ b/SoftLayer/CLI/routes.py
@@ -36,6 +36,7 @@ ALL_ROUTES = [
     ('virtual:reboot', 'SoftLayer.CLI.virt.power:reboot'),
     ('virtual:reload', 'SoftLayer.CLI.virt.reload:cli'),
     ('virtual:upgrade', 'SoftLayer.CLI.virt.upgrade:cli'),
+    ('virtual:usage', 'SoftLayer.CLI.virt.usage:cli'),
     ('virtual:credentials', 'SoftLayer.CLI.virt.credentials:cli'),
     ('virtual:capacity', 'SoftLayer.CLI.virt.capacity:cli'),
     ('virtual:placementgroup', 'SoftLayer.CLI.virt.placementgroup:cli'),

--- a/SoftLayer/CLI/virt/usage.py
+++ b/SoftLayer/CLI/virt/usage.py
@@ -4,9 +4,10 @@
 import click
 
 import SoftLayer
-from SoftLayer.CLI import environment, helpers
+from SoftLayer.CLI import environment
 from SoftLayer.CLI import exceptions
 from SoftLayer.CLI import formatting
+from SoftLayer.CLI import helpers
 
 
 @click.command(short_help="Usage information of a virtual server.")

--- a/SoftLayer/CLI/virt/usage.py
+++ b/SoftLayer/CLI/virt/usage.py
@@ -1,0 +1,44 @@
+"""Usage information of a virtual server."""
+# :license: MIT, see LICENSE for more details.
+
+import click
+
+import SoftLayer
+from SoftLayer.CLI import environment, helpers
+from SoftLayer.CLI import exceptions
+from SoftLayer.CLI import formatting
+
+
+@click.command(short_help="Usage information of a virtual server.")
+@click.argument('identifier')
+@click.option('--start_date', '-s', type=click.STRING, required=True, help="Start Date e.g. 2019-3-4")
+@click.option('--end_date', '-e', type=click.STRING, required=True, help="End Date e.g. 2019-4-2")
+@click.option('--valid_type', '-t', type=click.STRING, required=True,
+              help="Metric_Data_Type keyName e.g. CPU0, CPU1, MEMORY_USAGE, etc.")
+@click.option('--summary_period', '-summary', type=click.INT, required=True,
+              help="300, 600, 1800, 3600, 43200 or 86400 seconds")
+@environment.pass_env
+def cli(env, identifier, start_date, end_date, valid_type, summary_period):
+    """Usage information of a virtual server."""
+
+    vsi = SoftLayer.VSManager(env.client)
+    table = formatting.Table(['counter', 'dateTime', 'type'])
+
+    if not any([start_date, end_date, valid_type, summary_period]):
+        raise exceptions.ArgumentError(
+            "Must provide [--start_date], [--end_date], [--valid_type], or [--summary_period] to retrieve the usage "
+            "information")
+
+    vs_id = helpers.resolve_id(vsi.resolve_ids, identifier, 'VS')
+
+    result = vsi.get_summary_data_usage(instance_id=vs_id, start_date=start_date, end_date=end_date,
+                                        valid_type=valid_type, summary_period=summary_period)
+
+    for data in result:
+        table.add_row([
+            data['counter'],
+            data['dateTime'],
+            data['type'],
+        ])
+
+    env.fout(table)

--- a/SoftLayer/fixtures/SoftLayer_Metric_Tracking_Object.py
+++ b/SoftLayer/fixtures/SoftLayer_Metric_Tracking_Object.py
@@ -1,0 +1,12 @@
+getSummaryData = [
+    {
+        "counter": 1.44,
+        "dateTime": "2019-03-04T00:00:00-06:00",
+        "type": "cpu0"
+    },
+    {
+        "counter": 1.53,
+        "dateTime": "2019-03-04T00:05:00-06:00",
+        "type": "cpu0"
+    },
+]

--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -51,6 +51,7 @@ class VSManager(utils.IdentifierMixin, object):
         self.account = client['Account']
         self.guest = client['Virtual_Guest']
         self.package_svc = client['Product_Package']
+        self.metric_tracking_object = client['Metric_Tracking_Object']
         self.resolvers = [self._get_ids_from_ip, self._get_ids_from_hostname]
         if ordering_manager is None:
             self.ordering_manager = ordering.OrderingManager(client)
@@ -1001,6 +1002,25 @@ class VSManager(utils.IdentifierMixin, object):
                         return price.get('id')
                 else:
                     return price.get('id')
+
+    def get_summary_data_usage(self, instance_id, start_date=None, end_date=None, valid_type=None, summary_period=None):
+        """Retrieve the usage information of a virtual server.
+
+        :param string instance_id: a string identifier used to resolve ids
+        :param string start_date: the start data to retrieve the vs usage information
+        :param string end_date: the start data to retrieve the vs usage information
+        :param string string valid_type: the Metric_Data_Type keyName.
+        :param int summary_period: summary period.
+        """
+        valid_types = [
+            {
+                "keyName": valid_type,
+                "summaryType": "max"
+            }
+        ]
+
+        return self.metric_tracking_object.getSummaryData(start_date, end_date, valid_types, summary_period,
+                                                          id=instance_id)
 
     # pylint: disable=inconsistent-return-statements
     def _get_price_id_for_upgrade(self, package_items, option, value, public=True):

--- a/tests/CLI/modules/vs/vs_tests.py
+++ b/tests/CLI/modules/vs/vs_tests.py
@@ -660,3 +660,27 @@ class VirtTests(testing.TestCase):
         result = self.run_command(['vs', 'capture', '100', '--name', 'TestName'])
         self.assert_no_fail(result)
         self.assert_called_with('SoftLayer_Virtual_Guest', 'createArchiveTransaction', identifier=100)
+
+    @mock.patch('SoftLayer.CLI.formatting.no_going_back')
+    def test_usage_no_confirm(self, confirm_mock):
+        confirm_mock.return_value = False
+
+        result = self.run_command(['vs', 'usage', '100'])
+        self.assertEqual(result.exit_code, 2)
+
+    def test_usage_startdate_enddate_type_no_summary(self):
+        result = self.run_command(
+            ['vs', 'usage', '100'])
+        self.assertEqual(result.exit_code, 2)
+
+    def test_usage_vs(self):
+
+        result = self.run_command(
+            ['vs', 'usage', '100', '--start_date=2019-3-4', '--end_date=2019-4-2', '--valid_type=CPU0',
+             '--summary_period=300'])
+
+        self.assert_no_fail(result)
+        self.assertEqual(json.loads(result.output),
+                         [{'counter': 1.44, 'dateTime': '2019-03-04T00:00:00-06:00', 'type': 'cpu0'},
+                          {'counter': 1.53, 'dateTime': '2019-03-04T00:05:00-06:00', 'type': 'cpu0'}]
+                         )

--- a/tests/managers/vs/vs_tests.py
+++ b/tests/managers/vs/vs_tests.py
@@ -830,3 +830,13 @@ class VSTests(testing.TestCase):
                                 'createArchiveTransaction',
                                 args=args,
                                 identifier=1)
+
+    def test_usage_vs(self):
+        result = self.vs.get_summary_data_usage('100',
+                                                start_date='2019-3-4',
+                                                end_date='2019-4-2',
+                                                valid_type='CPU0',
+                                                summary_period=300)
+
+        self.assertEqual(result, [{'counter': 1.44, 'dateTime': '2019-03-04T00:00:00-06:00', 'type': 'cpu0'},
+                                  {'counter': 1.53, 'dateTime': '2019-03-04T00:05:00-06:00', 'type': 'cpu0'}])


### PR DESCRIPTION
Feature usage option for a vs https://github.com/softlayer/softlayer-python/issues/1113.

**slcli virtual**

```
Commands:
  cancel          Cancel virtual servers.
  capacity        Base command for all capacity related concerns
  capture         Capture SoftLayer image.
  create          Order/create virtual servers.
  create-options  Virtual server order options.
  credentials     List virtual server credentials.
  detail          Get details for a virtual server.
  dns-sync        Sync DNS records.
  edit            Edit a virtual server's details.
  list            List virtual servers.
  pause           Pauses an active virtual server.
  placementgroup  Base command for all capacity related concerns
  power-off       Power off an active virtual server.
  power-on        Power on a virtual server.
  ready           Check if a virtual server is ready.
  reboot          Reboot an active virtual server.
  reload          Reload operating system on a virtual server.
  rescue          Reboot into a rescue image.
  resume          Resumes a paused virtual server.
  upgrade         Upgrade a virtual server.
  usage           Usage information of a virtual server.
```

**slcli virtual usage --help**

```
Options:
  -s, --start_date TEXT          Start Date e.g. 2019-3-4  [required]
  -e, --end_date TEXT            End Date e.g. 2019-4-2  [required]
  -t, --type TEXT                The type is the Metric_Data_Type keyName e.g. CPU0, CPU1, MEMORY_USAGE, etc.  [required]
  -su, --summary_period INTEGER  300, 600, 1800, 3600, 43200 or 86400 seconds  [required]
  -h, --help                     Show this message and exit.

```
**slcli virtual usage --start_date 2019-3-4 --end_date 2019-4-2 --valid_type CPU0 --summary_period 300 11111**

```
:.........:...........................:......:
: counter :          dateTime         : type :
:.........:...........................:......:
:   1.44  : 2019-03-04T00:00:00-06:00 : cpu0 :
:   1.53  : 2019-03-04T00:05:00-06:00 : cpu0 :
:   1.46  : 2019-03-04T00:10:00-06:00 : cpu0 :
:   1.44  : 2019-03-04T00:15:00-06:00 : cpu0 :
:   1.6   : 2019-03-04T00:20:00-06:00 : cpu0 :
:   1.41  : 2019-03-04T00:25:00-06:00 : cpu0 :
:   1.48  : 2019-03-04T00:30:00-06:00 : cpu0 :
:   1.42  : 2019-03-04T00:35:00-06:00 : cpu0 :
:   1.43  : 2019-03-04T00:40:00-06:00 : cpu0 :
:   1.33  : 2019-03-04T00:45:00-06:00 : cpu0 :
:   1.41  : 2019-03-04T00:50:00-06:00 : cpu0 :
```