### PR TITLE
#1129 Fixed unexpected errors in slcli subnet create

### DIFF
--- a/SoftLayer/CLI/subnet/create.py
+++ b/SoftLayer/CLI/subnet/create.py
@@ -13,7 +13,7 @@ from SoftLayer.CLI import formatting
 @click.argument('network', type=click.Choice(['public', 'private']))
 @click.argument('quantity', type=click.INT)
 @click.argument('vlan-id')
-@click.option('--v6', '--ipv6', is_flag=True, help="Order IPv6 Addresses")
+@click.option('--ipv6', '--v6', is_flag=True, help="Order IPv6 Addresses")
 @click.option('--test',
               is_flag=True,
               help="Do not order the subnet; just get a quote")

--- a/SoftLayer/CLI/subnet/create.py
+++ b/SoftLayer/CLI/subnet/create.py
@@ -42,14 +42,10 @@ def cli(env, network, quantity, vlan_id, ipv6, test):
     if ipv6:
         version = 6
 
-    result = mgr.add_subnet(network,
-                            quantity=quantity,
-                            vlan_id=vlan_id,
-                            version=version,
-                            test_order=test)
-    if not result:
-        raise exceptions.CLIAbort(
-            'Unable to place order: No valid price IDs found.')
+    try:
+        result = mgr.add_subnet(network, quantity=quantity, vlan_id=vlan_id, version=version, test_order=test)
+    except SoftLayer.SoftLayerAPIError:
+        raise exceptions.CLIAbort('There is no price id for {} {} ipv{}'.format(quantity, network, version))
 
     table = formatting.Table(['Item', 'cost'])
     table.align['Item'] = 'r'

--- a/SoftLayer/managers/network.py
+++ b/SoftLayer/managers/network.py
@@ -150,10 +150,6 @@ class NetworkManager(object):
                 price_id = item['prices'][0]['id']
                 break
 
-        if not price_id:
-            raise TypeError('Invalid combination specified for ordering a'
-                            ' subnet.')
-
         order = {
             'packageId': 0,
             'prices': [{'id': price_id}],

--- a/tests/CLI/modules/subnet_tests.py
+++ b/tests/CLI/modules/subnet_tests.py
@@ -59,8 +59,7 @@ class SubnetTests(testing.TestCase):
         self.assert_no_fail(result)
 
         output = [
-            {'Item': 'this is a thing', 'cost': '2.00'},
-            {'Item': 'Total monthly cost', 'cost': '2.00'}
+            {'Item': 'Total monthly cost', 'cost': '0.00'}
         ]
 
         self.assertEqual(output, json.loads(result.output))
@@ -72,8 +71,8 @@ class SubnetTests(testing.TestCase):
         item_mock = self.set_mock('SoftLayer_Product_Package', 'getItems')
         item_mock.return_value = SoftLayer_Product_Package.getItems
 
-        place_mock = self.set_mock('SoftLayer_Product_Order', 'placeOrder')
-        place_mock.return_value = SoftLayer_Product_Order.placeOrder
+        place_mock = self.set_mock('SoftLayer_Product_Order', 'verifyOrder')
+        place_mock.return_value = SoftLayer_Product_Order.verifyOrder
 
         result = self.run_command(['subnet', 'create', '--v6', 'public', '64', '12346', '--test'])
         self.assert_no_fail(result)

--- a/tests/CLI/modules/subnet_tests.py
+++ b/tests/CLI/modules/subnet_tests.py
@@ -4,12 +4,17 @@
 
     :license: MIT, see LICENSE for more details.
 """
+from SoftLayer.fixtures import SoftLayer_Product_Order
+from SoftLayer.fixtures import SoftLayer_Product_Package
 from SoftLayer import testing
 
 import json
+import mock
+import SoftLayer
 
 
 class SubnetTests(testing.TestCase):
+
     def test_detail(self):
         result = self.run_command(['subnet', 'detail', '1234'])
 
@@ -39,3 +44,55 @@ class SubnetTests(testing.TestCase):
     def test_list(self):
         result = self.run_command(['subnet',  'list'])
         self.assert_no_fail(result)
+
+    @mock.patch('SoftLayer.CLI.formatting.confirm')
+    def test_create_subnet_ipv4(self, confirm_mock):
+        confirm_mock.return_value = True
+
+        item_mock = self.set_mock('SoftLayer_Product_Package', 'getItems')
+        item_mock.return_value = SoftLayer_Product_Package.getItems
+
+        place_mock = self.set_mock('SoftLayer_Product_Order', 'placeOrder')
+        place_mock.return_value = SoftLayer_Product_Order.placeOrder
+
+        result = self.run_command(['subnet', 'create', 'private', '8', '12346'])
+        self.assert_no_fail(result)
+
+        output = [
+            {'Item': 'this is a thing', 'cost': '2.00'},
+            {'Item': 'Total monthly cost', 'cost': '2.00'}
+        ]
+
+        self.assertEqual(output, json.loads(result.output))
+
+    @mock.patch('SoftLayer.CLI.formatting.confirm')
+    def test_create_subnet_ipv6(self, confirm_mock):
+        confirm_mock.return_value = True
+
+        item_mock = self.set_mock('SoftLayer_Product_Package', 'getItems')
+        item_mock.return_value = SoftLayer_Product_Package.getItems
+
+        place_mock = self.set_mock('SoftLayer_Product_Order', 'placeOrder')
+        place_mock.return_value = SoftLayer_Product_Order.placeOrder
+
+        result = self.run_command(['subnet', 'create', '--v6', 'public', '64', '12346', '--test'])
+        self.assert_no_fail(result)
+
+        output = [
+            {'Item': 'this is a thing', 'cost': '2.00'},
+            {'Item': 'Total monthly cost', 'cost': '2.00'}
+        ]
+
+        self.assertEqual(output, json.loads(result.output))
+
+    def test_create_subnet_no_prices_found(self):
+        item_mock = self.set_mock('SoftLayer_Product_Package', 'getItems')
+        item_mock.return_value = SoftLayer_Product_Package.getItems
+
+        verify_mock = self.set_mock('SoftLayer_Product_Order', 'verifyOrder')
+        verify_mock.side_effect = SoftLayer.SoftLayerAPIError('SoftLayer_Exception', 'Price not found')
+
+        result = self.run_command(['subnet', 'create', '--v6', 'public', '32', '12346', '--test'])
+
+        self.assertRaises(SoftLayer.SoftLayerAPIError, verify_mock)
+        self.assertEqual(result.exception.message, 'There is no price id for 32 public ipv6')

--- a/tests/managers/network_tests.py
+++ b/tests/managers/network_tests.py
@@ -24,9 +24,6 @@ class NetworkTests(testing.TestCase):
                                 'getByIpAddress',
                                 args=('10.0.1.37',))
 
-    def test_add_subnet_raises_exception_on_failure(self):
-        self.assertRaises(TypeError, self.network.add_subnet, ('bad'))
-
     def test_add_global_ip(self):
         # Test a global IPv4 order
         result = self.network.add_global_ip(test_order=True)


### PR DESCRIPTION
Fixes #1129

I found an annoying error when no price is found:
```
$ slcli subnet create --v6 public 32 11223344 --test

An unexpected error has occured:
Traceback (most recent call last):
  File "/home/acamacho/Workspace/interpreters/python27/local/lib/python2.7/site-packages/SoftLayer-5.6.4-py2.7.egg/SoftLayer/CLI/core.py", line 182, in main
    cli.main(**kwargs)
  File "/home/acamacho/Workspace/interpreters/python27/local/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/acamacho/Workspace/interpreters/python27/local/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/acamacho/Workspace/interpreters/python27/local/lib/python2.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/acamacho/Workspace/interpreters/python27/local/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/acamacho/Workspace/interpreters/python27/local/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/acamacho/Workspace/interpreters/python27/local/lib/python2.7/site-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/home/acamacho/Workspace/interpreters/python27/local/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/acamacho/Workspace/interpreters/python27/local/lib/python2.7/site-packages/SoftLayer-5.6.4-py2.7.egg/SoftLayer/CLI/subnet/create.py", line 46, in cli
    result = mgr.add_subnet(network, quantity=quantity, vlan_id=vlan_id, version=version, test_order=test)
  File "/home/acamacho/Workspace/interpreters/python27/local/lib/python2.7/site-packages/SoftLayer-5.6.4-py2.7.egg/SoftLayer/managers/network.py", line 154, in add_subnet
    raise TypeError('Invalid combination specified for ordering a'
TypeError: Invalid combination specified for ordering a subnet.

Feel free to report this error as it is likely a bug:
    https://github.com/softlayer/softlayer-python/issues
The following snippet should be able to reproduce the error
```

So I removed the `TypeError` in `NetworkManager.add_subnet()` and improved the error message which comes from the api

```
$ slcli subnet create --v6 public 32 11223344 --test

There is no price id for 32 public ipv6
```