### PR TITLE
Use default retry logic in requests adapter (which is zero).

### DIFF
--- a/SoftLayer/transports.py
+++ b/SoftLayer/transports.py
@@ -13,7 +13,6 @@ import time
 
 import requests
 from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
 
 from SoftLayer import consts
 from SoftLayer import exceptions

--- a/SoftLayer/transports.py
+++ b/SoftLayer/transports.py
@@ -50,8 +50,7 @@ def get_session(user_agent):
         'Content-Type': 'application/json',
         'User-Agent': user_agent,
     })
-    retry = Retry(connect=3, backoff_factor=3)
-    adapter = HTTPAdapter(max_retries=retry)
+    adapter = HTTPAdapter()
     client.mount('https://', adapter)
     return client
 


### PR DESCRIPTION
The original commit doesn't explain why retry=3 was introduced in the first place.
Before, it was default, zero. Now it seems to conflict with retry decorator used
in some call in managers code resulting in 16 retries in total when combined.