### PR TITLE
Remove contents from the new_ticket object and unittests

### DIFF
--- a/SoftLayer/managers/ticket.py
+++ b/SoftLayer/managers/ticket.py
@@ -68,7 +68,6 @@ class TicketManager(utils.IdentifierMixin, object):
         current_user = self.account.getCurrentUser()
         new_ticket = {
             'subjectId': subject,
-            'contents': body,
             'assignedUserId': current_user['id'],
             'title': title,
         }

--- a/tests/CLI/modules/ticket_tests.py
+++ b/tests/CLI/modules/ticket_tests.py
@@ -55,7 +55,6 @@ class TicketTests(testing.TestCase):
         self.assert_no_fail(result)
 
         args = ({'subjectId': 1000,
-                 'contents': 'ticket body',
                  'assignedUserId': 12345,
                  'title': 'Test'}, 'ticket body')
 
@@ -70,7 +69,6 @@ class TicketTests(testing.TestCase):
         self.assert_no_fail(result)
 
         args = ({'subjectId': 1000,
-                 'contents': 'ticket body',
                  'assignedUserId': 12345,
                  'title': 'Test',
                  'priority': 1}, 'ticket body')
@@ -87,7 +85,6 @@ class TicketTests(testing.TestCase):
         self.assert_no_fail(result)
 
         args = ({'subjectId': 1000,
-                 'contents': 'ticket body',
                  'assignedUserId': 12345,
                  'title': 'Test'}, 'ticket body')
 
@@ -108,7 +105,6 @@ class TicketTests(testing.TestCase):
         self.assert_no_fail(result)
 
         args = ({'subjectId': 1000,
-                 'contents': 'ticket body',
                  'assignedUserId': 12345,
                  'title': 'Test'}, 'ticket body')
 

--- a/tests/managers/ticket_tests.py
+++ b/tests/managers/ticket_tests.py
@@ -72,7 +72,6 @@ class TicketTests(testing.TestCase):
             subject=1004)
 
         args = ({"assignedUserId": 12345,
-                 "contents": "body",
                  "subjectId": 1004,
                  "title": "Cloud Instance Cancellation - 08/01/13"},
                 "body")


### PR DESCRIPTION
Fixes #1147 

`create_ticket()` method in the TicketManager works with REST and XMLRPC endpoint
