### PR TITLE
IBMID auth support

### DIFF
--- a/SoftLayer/CLI/account/invoice_detail.py
+++ b/SoftLayer/CLI/account/invoice_detail.py
@@ -15,7 +15,7 @@ from SoftLayer import utils
               help="Shows a very detailed list of charges")
 @environment.pass_env
 def cli(env, identifier, details):
-    """Invoices and all that mess"""
+    """Invoice details"""
 
     manager = AccountManager(env.client)
     top_items = manager.get_billing_items(identifier)

--- a/SoftLayer/CLI/account/invoices.py
+++ b/SoftLayer/CLI/account/invoices.py
@@ -18,7 +18,7 @@ from SoftLayer import utils
               help="Return ALL invoices. There may be a lot of these.")
 @environment.pass_env
 def cli(env, limit, closed=False, get_all=False):
-    """Invoices and all that mess"""
+    """List invoices"""
 
     manager = AccountManager(env.client)
     invoices = manager.get_invoices(limit, closed, get_all)

--- a/SoftLayer/CLI/config/setup.py
+++ b/SoftLayer/CLI/config/setup.py
@@ -19,7 +19,7 @@ def get_api_key(client, username, secret):
     """
 
     # Try to use a client with username/api key
-    if len(secret) == 64:
+    if len(secret) == 64 or username == 'apikey':
         try:
             client['Account'].getCurrentUser()
             return secret
@@ -40,7 +40,10 @@ def get_api_key(client, username, secret):
 @click.command()
 @environment.pass_env
 def cli(env):
-    """Edit configuration."""
+    """Setup the ~/.softlayer file with username and apikey.
+
+    Set the username to 'apikey' for cloud.ibm.com accounts.
+    """
 
     username, secret, endpoint_url, timeout = get_user_input(env)
     new_client = SoftLayer.Client(username=username, api_key=secret, endpoint_url=endpoint_url, timeout=timeout)

--- a/SoftLayer/CLI/hardware/bandwidth.py
+++ b/SoftLayer/CLI/hardware/bandwidth.py
@@ -1,4 +1,4 @@
-"""Get details for a hardware device."""
+"""GBandwidth data over date range. Bandwidth is listed in GB"""
 # :license: MIT, see LICENSE for more details.
 
 import click

--- a/SoftLayer/auth.py
+++ b/SoftLayer/auth.py
@@ -73,10 +73,17 @@ class BasicAuthentication(AuthenticationBase):
 
     def get_request(self, request):
         """Sets token-based auth headers."""
-        request.headers['authenticate'] = {
-            'username': self.username,
-            'apiKey': self.api_key,
-        }
+
+        # See https://cloud.ibm.com/docs/iam?topic=iam-iamapikeysforservices for why this is the way it is
+        if self.username == 'apikey':
+            request.transport_user = self.username
+            request.transport_password = self.api_key
+        else:
+            request.headers['authenticate'] = {
+                'username': self.username,
+                'apiKey': self.api_key,
+            }
+
         return request
 
     def __repr__(self):

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -48,6 +48,8 @@ To check the configuration, you can use `slcli config show`.
 	:..............:..................................................................:
 
 
+If you are using an account created from the https://cloud.ibm.com portal, your username will be literally `apikey`, and use the key provided. `How to create an IBM apikey <https://cloud.ibm.com/docs/iam?topic=iam-userapikey#create_user_key>`_
+
 To see more about the config file format, see :ref:`config_file`.
 
 .. _usage-examples:

--- a/docs/cli/config.rst
+++ b/docs/cli/config.rst
@@ -1,0 +1,18 @@
+.. _cli_config:
+
+Config
+========
+
+`Creating an IBMID apikey <https://cloud.ibm.com/docs/iam?topic=iam-userapikey#create_user_key>`_
+`IBMid for services <https://cloud.ibm.com/docs/iam?topic=iam-iamapikeysforservices>`_
+
+`Creating a SoftLayer apikey <https://cloud.ibm.com/docs/customer-portal?topic=customer-portal-customerportal_api>`_
+
+.. click:: SoftLayer.CLI.config.setup:cli
+    :prog: config setup
+    :show-nested:
+
+
+.. click:: SoftLayer.CLI.config.show:cli
+    :prog: config show
+    :show-nested:

--- a/docs/config_file.rst
+++ b/docs/config_file.rst
@@ -25,3 +25,13 @@ automatically by the `slcli setup` command detailed here:
   api_key = oyVmeipYQCNrjVS4rF9bHWV7D75S6pa1fghFl384v7mwRCbHTfuJ8qRORIqoVnha
   endpoint_url = https://api.softlayer.com/xmlrpc/v3/
   timeout = 40
+
+
+*Cloud.ibm.com Config Example*
+::
+
+  [softlayer]
+  username = apikey
+  api_key = 123cNyhzg45Ab6789ADyzwR_2LAagNVbySgY73tAQOz1
+  endpoint_url = https://api.softlayer.com/rest/v3.1/
+  timeout = 40

--- a/tests/transport_tests.py
+++ b/tests/transport_tests.py
@@ -78,7 +78,8 @@ class TestXmlRpcAPICall(testing.TestCase):
                                    data=data,
                                    timeout=None,
                                    cert=None,
-                                   verify=True)
+                                   verify=True,
+                                   auth=None)
         self.assertEqual(resp, [])
         self.assertIsInstance(resp, transports.SoftLayerListResult)
         self.assertEqual(resp.total_count, 10)
@@ -114,7 +115,8 @@ class TestXmlRpcAPICall(testing.TestCase):
             headers=mock.ANY,
             timeout=None,
             cert=None,
-            verify=True)
+            verify=True,
+            auth=None)
 
     @mock.patch('SoftLayer.transports.requests.Session.request')
     def test_identifier(self, request):
@@ -264,6 +266,50 @@ class TestXmlRpcAPICall(testing.TestCase):
         output_text = self.transport.print_reproduceable(req)
         self.assertIn("https://test.com", output_text)
 
+    @mock.patch('SoftLayer.transports.requests.Session.request')
+    @mock.patch('requests.auth.HTTPBasicAuth')
+    def test_ibm_id_call(self, auth, request):
+        request.return_value = self.response
+
+        data = '''<?xml version='1.0'?>
+<methodCall>
+<methodName>getObject</methodName>
+<params>
+<param>
+<value><struct>
+<member>
+<name>headers</name>
+<value><struct>
+</struct></value>
+</member>
+</struct></value>
+</param>
+</params>
+</methodCall>
+'''
+
+        req = transports.Request()
+        req.service = 'SoftLayer_Service'
+        req.method = 'getObject'
+        req.transport_user = 'apikey'
+        req.transport_password = '1234567890qweasdzxc'
+        resp = self.transport(req)
+
+        auth.assert_called_with('apikey', '1234567890qweasdzxc')
+        request.assert_called_with('POST',
+                                   'http://something.com/SoftLayer_Service',
+                                   headers={'Content-Type': 'application/xml',
+                                            'User-Agent': consts.USER_AGENT},
+                                   proxies=None,
+                                   data=data,
+                                   timeout=None,
+                                   cert=None,
+                                   verify=True,
+                                   auth=mock.ANY)
+        self.assertEqual(resp, [])
+        self.assertIsInstance(resp, transports.SoftLayerListResult)
+        self.assertEqual(resp.total_count, 10)
+
 
 @mock.patch('SoftLayer.transports.requests.Session.request')
 @pytest.mark.parametrize(
@@ -311,7 +357,8 @@ def test_verify(request,
                                cert=mock.ANY,
                                proxies=mock.ANY,
                                timeout=mock.ANY,
-                               verify=expected)
+                               verify=expected,
+                               auth=None)
 
 
 class TestRestAPICall(testing.TestCase):


### PR DESCRIPTION
For users wanting to use an IBMid apikey, all they need to really do is edit their config file 

```
[softlayer]
username = apikey
api_key = <IBM ID API KEY>
```

This also does allow `slcli config setup` to setup the config with IBMid as well.
