### PR TITLE
Handle missing/empty bandwidth allocation information 

### DIFF
--- a/SoftLayer/CLI/hardware/detail.py
+++ b/SoftLayer/CLI/hardware/detail.py
@@ -99,7 +99,9 @@ def _bw_table(bw_data):
         allotment = 'N/A'
         if bw_point['type']['alias'] == 'PUBLIC_SERVER_BW':
             bw_type = 'Public'
-            allotment = bw_data['allotment'].get('amount', '-')
+            allotment = utils.lookup(bw_data, 'allotment', 'amount')
+            if allotment is None:
+                allotment = '-'
 
         table.add_row([bw_type, bw_point['amountIn'], bw_point['amountOut'], allotment])
     return table

--- a/SoftLayer/CLI/virt/detail.py
+++ b/SoftLayer/CLI/virt/detail.py
@@ -131,7 +131,9 @@ def _bw_table(bw_data):
         allotment = 'N/A'
         if bw_point['type']['alias'] == 'PUBLIC_SERVER_BW':
             bw_type = 'Public'
-            allotment = bw_data['allotment'].get('amount', '-')
+            allotment = utils.lookup(bw_data, 'allotment', 'amount')
+            if allotment is None:
+                allotment = '-'
 
         table.add_row([bw_type, bw_point['amountIn'], bw_point['amountOut'], allotment])
     return table

--- a/SoftLayer/managers/hardware.py
+++ b/SoftLayer/managers/hardware.py
@@ -698,7 +698,7 @@ class HardwareManager(utils.IdentifierMixin, object):
         allotment = self.client.call('Hardware_Server', 'getBandwidthAllotmentDetail', id=instance_id, mask=a_mask)
         u_mask = "mask[amountIn,amountOut,type]"
         useage = self.client.call('Hardware_Server', 'getBillingCycleBandwidthUsage', id=instance_id, mask=u_mask)
-        return {'allotment': allotment['allocation'], 'useage': useage}
+        return {'allotment': allotment.get('allocation'), 'useage': useage}
 
 
 def _get_extra_price_id(items, key_name, hourly, location):

--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -1067,7 +1067,7 @@ class VSManager(utils.IdentifierMixin, object):
         allotment = self.client.call('Virtual_Guest', 'getBandwidthAllotmentDetail', id=instance_id, mask=a_mask)
         u_mask = "mask[amountIn,amountOut,type]"
         useage = self.client.call('Virtual_Guest', 'getBillingCycleBandwidthUsage', id=instance_id, mask=u_mask)
-        return {'allotment': allotment['allocation'], 'useage': useage}
+        return {'allotment': allotment.get('allocation'), 'useage': useage}
 
     # pylint: disable=inconsistent-return-statements
     def _get_price_id_for_upgrade(self, package_items, option, value, public=True):

--- a/tests/managers/hardware_tests.py
+++ b/tests/managers/hardware_tests.py
@@ -448,6 +448,14 @@ class HardwareTests(testing.TestCase):
         self.assertEqual(result['allotment']['amount'], '250')
         self.assertEqual(result['useage'][0]['amountIn'], '.448')
 
+    def test_get_bandwidth_allocation_no_allotment(self):
+        mock = self.set_mock('SoftLayer_Hardware_Server', 'getBandwidthAllotmentDetail')
+        mock.return_value = {}
+
+        result = self.hardware.get_bandwidth_allocation(1234)
+
+        self.assertEqual(None, result['allotment'])
+
 
 class HardwareHelperTests(testing.TestCase):
     def test_get_extra_price_id_no_items(self):

--- a/tests/managers/vs/vs_tests.py
+++ b/tests/managers/vs/vs_tests.py
@@ -903,3 +903,11 @@ class VSTests(testing.TestCase):
         self.assert_called_with('SoftLayer_Virtual_Guest', 'getBillingCycleBandwidthUsage', identifier=1234)
         self.assertEqual(result['allotment']['amount'], '250')
         self.assertEqual(result['useage'][0]['amountIn'], '.448')
+
+    def test_get_bandwidth_allocation_no_allotment(self):
+        mock = self.set_mock('SoftLayer_Virtual_Guest', 'getBandwidthAllotmentDetail')
+        mock.return_value = {}
+
+        result = self.vs.get_bandwidth_allocation(1234)
+
+        self.assertEqual(None, result['allotment'])


### PR DESCRIPTION
When getting bandwidth details for hardware and virtual servers and when building the bandwidth detail tables for them.

Fixes #1159 