### PR TITLE
Fixed vs reboot unable to resolve vs names

### DIFF
--- a/SoftLayer/CLI/virt/power.py
+++ b/SoftLayer/CLI/virt/power.py
@@ -35,7 +35,7 @@ def reboot(env, identifier, hard):
     """Reboot an active virtual server."""
 
     virtual_guest = env.client['Virtual_Guest']
-    mgr = SoftLayer.HardwareManager(env.client)
+    mgr = SoftLayer.VSManager(env.client)
     vs_id = helpers.resolve_id(mgr.resolve_ids, identifier, 'VS')
     if not (env.skip_confirmations or
             formatting.confirm('This will reboot the VS with id %s. '

--- a/SoftLayer/transports.py
+++ b/SoftLayer/transports.py
@@ -9,6 +9,7 @@ import importlib
 import json
 import logging
 import re
+from string import Template
 import time
 import xmlrpc.client
 
@@ -256,7 +257,6 @@ class XmlRpcTransport(object):
 
         :param request request: Request object
         """
-        from string import Template
         output = Template('''============= testing.py =============
 import requests
 from requests.auth import HTTPBasicAuth

--- a/tests/CLI/modules/autoscale_tests.py
+++ b/tests/CLI/modules/autoscale_tests.py
@@ -74,6 +74,9 @@ class AutoscaleTests(testing.TestCase):
 
     @mock.patch('SoftLayer.managers.autoscale.AutoScaleManager.edit')
     def test_autoscale_edit_userfile(self, manager):
+        # On windows, python cannot edit a NamedTemporaryFile.
+        if(sys.platform.startswith("win")):
+            self.skipTest("Test doesn't work in Windows")
         group = fixtures.SoftLayer_Scale_Group.getObject
         template = {
             'virtualGuestMemberTemplate': group['virtualGuestMemberTemplate']

--- a/tests/CLI/modules/autoscale_tests.py
+++ b/tests/CLI/modules/autoscale_tests.py
@@ -8,6 +8,7 @@
     Tests for the autoscale cli command
 """
 import mock
+import sys
 
 from SoftLayer import fixtures
 from SoftLayer import testing


### PR DESCRIPTION
Fixes #1181  `vs reboot` was using the wrong ID resolver.