### PR TITLE
v5.8.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 
 
+## [5.8.5] - 2019-12-20
+https://github.com/softlayer/softlayer-python/compare/v5.8.3...v5.8.4
+
+- #1199 Fix block storage failback and failover.
+- #1202 Order a virtual server private. 
+
+
 ## [5.8.3] - 2019-12-11
 https://github.com/softlayer/softlayer-python/compare/v5.8.2...v5.8.3
 

--- a/SoftLayer/consts.py
+++ b/SoftLayer/consts.py
@@ -5,7 +5,7 @@
 
     :license: MIT, see LICENSE for more details.
 """
-VERSION = 'v5.8.3'
+VERSION = 'v5.8.4'
 API_PUBLIC_ENDPOINT = 'https://api.softlayer.com/xmlrpc/v3.1/'
 API_PRIVATE_ENDPOINT = 'https://api.service.softlayer.com/xmlrpc/v3.1/'
 API_PUBLIC_ENDPOINT_REST = 'https://api.softlayer.com/rest/v3.1/'

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ else:
 
 setup(
     name='SoftLayer',
-    version='5.8.3',
+    version='5.8.4',
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     author='SoftLayer Technologies, Inc.',


### PR DESCRIPTION
## [5.8.5] - 2019-12-20
https://github.com/softlayer/softlayer-python/compare/v5.8.3...v5.8.4

- #1199 Fix block storage failback and failover.
- #1202 Order a virtual server private. 
