### PR TITLE
v5.8.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,25 @@
 # Change Log
 
 
-## [5.8.5] - 2019-12-20
+## [5.8.5] - 2012-01-29
+https://github.com/softlayer/softlayer-python/compare/v5.8.4...v5.8.5
+
+-  #1195 Fixed an issue with `slcli vs dns-sync --ptr`. Added `slcli hw dns-sync`
+-  #1199 Fix File Storage failback and failover.
+-  #1198 Fix issue where the summary command fails due to None being provided as the datacenter name.
+-  #1208 Added The following commands:
+    - `slcli block volume-limits` 
+    - `slcli file  volume-limits`
+- #1209  Add testing/CI for python 3.8.
+- #1212 Fix vs detail erroring on servers pending cancellation.
+- #1210 support subnet ACL management through cli
+    + `slcli block subnets-list`
+    + `slcli block subnets-assign`
+    + `slcli block subnets-remove`
+- #1215 Added documentation for all SLCLI commands.
+
+
+## [5.8.4] - 2019-12-20
 https://github.com/softlayer/softlayer-python/compare/v5.8.3...v5.8.4
 
 - #1199 Fix block storage failback and failover.

--- a/SoftLayer/consts.py
+++ b/SoftLayer/consts.py
@@ -5,7 +5,7 @@
 
     :license: MIT, see LICENSE for more details.
 """
-VERSION = 'v5.8.4'
+VERSION = 'v5.8.5'
 API_PUBLIC_ENDPOINT = 'https://api.softlayer.com/xmlrpc/v3.1/'
 API_PRIVATE_ENDPOINT = 'https://api.service.softlayer.com/xmlrpc/v3.1/'
 API_PUBLIC_ENDPOINT_REST = 'https://api.softlayer.com/rest/v3.1/'

--- a/docs/cli/block.rst
+++ b/docs/cli/block.rst
@@ -110,3 +110,16 @@ Block Commands
 .. click:: SoftLayer.CLI.block.limit:cli
     :prog: block volume-limits
     :show-nested:
+
+
+.. click:: SoftLayer.CLI.block.subnets.list:cli
+    :prog: block subnets-list
+    :show-nested:
+
+.. click:: SoftLayer.CLI.block.subnets.assign:cli
+    :prog: block subnets-assign
+    :show-nested:
+
+.. click:: SoftLayer.CLI.block.subnets.remove:cli
+    :prog: block subnets-remove
+    :show-nested:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ else:
 
 setup(
     name='SoftLayer',
-    version='5.8.4',
+    version='5.8.5',
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     author='SoftLayer Technologies, Inc.',


### PR DESCRIPTION
https://github.com/softlayer/softlayer-python/compare/v5.8.4...v5.8.5

-  #1195 Fixed an issue with `slcli vs dns-sync --ptr`. Added `slcli hw dns-sync`
-  #1199 Fix File Storage failback and failover.
-  #1198 Fix issue where the summary command fails due to None being provided as the datacenter name.
-  #1208 Added The following commands:
    - `slcli block volume-limits` 
    - `slcli file  volume-limits`
- #1209  Add testing/CI for python 3.8.
- #1212 Fix vs detail erroring on servers pending cancellation.
- #1210 support subnet ACL management through cli
    + `slcli block subnets-list`
    + `slcli block subnets-assign`
    + `slcli block subnets-remove`
- #1215 Added documentation for all SLCLI commands.