### PR TITLE
Advanced filters

### DIFF
--- a/SoftLayer/CLI/call_api.py
+++ b/SoftLayer/CLI/call_api.py
@@ -1,6 +1,7 @@
 """Call arbitrary API endpoints."""
-import click
 import json
+
+import click
 
 from SoftLayer.CLI import environment
 from SoftLayer.CLI import exceptions
@@ -28,7 +29,7 @@ def _build_filters(_filters):
             if len(top_parts) == 2:
                 break
         else:
-            raise exceptions.CLIAbort('Failed to find valid operation for: %s'  % _filter)
+            raise exceptions.CLIAbort('Failed to find valid operation for: %s' % _filter)
 
         key, value = top_parts
         current = root
@@ -67,36 +68,39 @@ def _build_python_example(args, kwargs):
 
     return call_str
 
-def _validate_filter(ctx, param, value):
+
+def _validate_filter(ctx, param, value):  # pylint: disable=unused-argument
     """Validates a JSON style object filter"""
     _filter = None
-
+    # print("VALUE: {}".format(value))
     if value:
         try:
             _filter = json.loads(value)
             if not isinstance(_filter, dict):
                 raise exceptions.CLIAbort("\"{}\" should be a JSON object, but is a {} instead.".
                                           format(_filter, type(_filter)))
-        except json.JSONDecodeError as e:
-            raise exceptions.CLIAbort("\"{}\" is not valid JSON. {}".format(value, e))
+        except json.JSONDecodeError as error:
+            raise exceptions.CLIAbort("\"{}\" is not valid JSON. {}".format(value, error))
 
     return _filter
 
-def _validate_parameters(ctx, param, value):
+
+def _validate_parameters(ctx, param, value):  # pylint: disable=unused-argument
     """Checks if value is a JSON string, and converts it to a datastructure if that is true"""
 
     validated_values = []
-    for i, parameter in enumerate(value):
+    for parameter in value:
         if isinstance(parameter, str):
             # looks like a JSON string...
             if '{' in parameter or '[' in parameter:
                 try:
                     parameter = json.loads(parameter)
-                except json.JSONDecodeError as e:
-                    click.secho("{} looked like json, but wasn't valid, passing to API as is. {}".format(parameter, e),
-                                fg='red')
+                except json.JSONDecodeError as error:
+                    click.secho("{} looked like json, but was invalid, passing to API as is. {}".
+                                format(parameter, error), fg='red')
         validated_values.append(parameter)
     return validated_values
+
 
 @click.command('call', short_help="Call arbitrary API endpoints.")
 @click.argument('service')
@@ -138,6 +142,7 @@ def cli(env, service, method, parameters, _id, _filters, mask, limit, offset,
         slcli -v call-api SoftLayer_User_Customer addBulkPortalPermission --id=1234567 \\
             '[{"keyName": "NETWORK_MESSAGE_DELIVERY_MANAGE"}]'
     """
+
     if _filters and json_filter:
         raise exceptions.CLIAbort("--filter and --json-filter cannot be used together.")
 

--- a/SoftLayer/CLI/call_api.py
+++ b/SoftLayer/CLI/call_api.py
@@ -1,5 +1,6 @@
 """Call arbitrary API endpoints."""
 import click
+import json
 
 from SoftLayer.CLI import environment
 from SoftLayer.CLI import exceptions
@@ -27,8 +28,7 @@ def _build_filters(_filters):
             if len(top_parts) == 2:
                 break
         else:
-            raise exceptions.CLIAbort('Failed to find valid operation for: %s'
-                                      % _filter)
+            raise exceptions.CLIAbort('Failed to find valid operation for: %s'  % _filter)
 
         key, value = top_parts
         current = root
@@ -67,26 +67,59 @@ def _build_python_example(args, kwargs):
 
     return call_str
 
+def _validate_filter(ctx, param, value):
+    """Validates a JSON style object filter"""
+    _filter = None
+
+    if value:
+        try:
+            _filter = json.loads(value)
+            if not isinstance(_filter, dict):
+                raise exceptions.CLIAbort("\"{}\" should be a JSON object, but is a {} instead.".
+                                          format(_filter, type(_filter)))
+        except json.JSONDecodeError as e:
+            raise exceptions.CLIAbort("\"{}\" is not valid JSON. {}".format(value, e))
+
+    return _filter
+
+def _validate_parameters(ctx, param, value):
+    """Checks if value is a JSON string, and converts it to a datastructure if that is true"""
+
+    validated_values = []
+    for i, parameter in enumerate(value):
+        if isinstance(parameter, str):
+            # looks like a JSON string...
+            if '{' in parameter or '[' in parameter:
+                try:
+                    parameter = json.loads(parameter)
+                except json.JSONDecodeError as e:
+                    click.secho("{} looked like json, but wasn't valid, passing to API as is. {}".format(parameter, e),
+                                fg='red')
+        validated_values.append(parameter)
+    return validated_values
 
 @click.command('call', short_help="Call arbitrary API endpoints.")
 @click.argument('service')
 @click.argument('method')
-@click.argument('parameters', nargs=-1)
+@click.argument('parameters', nargs=-1, callback=_validate_parameters)
 @click.option('--id', '_id', help="Init parameter")
 @helpers.multi_option('--filter', '-f', '_filters',
-                      help="Object filters. This should be of the form: "
-                      "'property=value' or 'nested.property=value'. Complex "
-                      "filters like betweenDate are not currently supported.")
+                      help="Object filters. This should be of the form: 'property=value' or 'nested.property=value'."
+                           "Complex filters should use --json-filter.")
 @click.option('--mask', help="String-based object mask")
 @click.option('--limit', type=click.INT, help="Result limit")
 @click.option('--offset', type=click.INT, help="Result offset")
 @click.option('--output-python / --no-output-python',
               help="Show python example code instead of executing the call")
+@click.option('--json-filter', callback=_validate_filter,
+              help="A JSON string to be passed in as the object filter to the API call."
+                   "Remember to use double quotes (\") for variable names. Can NOT be used with --filter.")
 @environment.pass_env
 def cli(env, service, method, parameters, _id, _filters, mask, limit, offset,
-        output_python=False):
+        output_python=False, json_filter=None):
     """Call arbitrary API endpoints with the given SERVICE and METHOD.
 
+    For parameters that require a datatype, use a JSON string for that parameter.
     Example::
 
         slcli call-api Account getObject
@@ -100,12 +133,22 @@ def cli(env, service, method, parameters, _id, _filters, mask, limit, offset,
             --mask=id,hostname,datacenter.name,maxCpu
         slcli call-api Account getVirtualGuests \\
             -f 'virtualGuests.datacenter.name IN dal05,sng01'
+        slcli call-api Account getVirtualGuests \\
+            --json-filter  '{"virtualGuests":{"hostname": {"operation": "^= test"}}}' --limit=10
+        slcli -v call-api SoftLayer_User_Customer addBulkPortalPermission --id=1234567 \\
+            '[{"keyName": "NETWORK_MESSAGE_DELIVERY_MANAGE"}]'
     """
+    if _filters and json_filter:
+        raise exceptions.CLIAbort("--filter and --json-filter cannot be used together.")
+
+    object_filter = _build_filters(_filters)
+    if json_filter:
+        object_filter.update(json_filter)
 
     args = [service, method] + list(parameters)
     kwargs = {
         'id': _id,
-        'filter': _build_filters(_filters),
+        'filter': object_filter,
         'mask': mask,
         'limit': limit,
         'offset': offset,

--- a/SoftLayer/CLI/call_api.py
+++ b/SoftLayer/CLI/call_api.py
@@ -72,7 +72,6 @@ def _build_python_example(args, kwargs):
 def _validate_filter(ctx, param, value):  # pylint: disable=unused-argument
     """Validates a JSON style object filter"""
     _filter = None
-    # print("VALUE: {}".format(value))
     if value:
         try:
             _filter = json.loads(value)

--- a/docs/cli/commands.rst
+++ b/docs/cli/commands.rst
@@ -3,6 +3,14 @@
 Call API
 ========
 
+This function allows you to easily call any API. The format is
+
+`slcli call-api SoftLayer_Service method param1 param2 --id=1234 --mask="mask[id,name]"`
+
+Parameters should be in the order they are presented on sldn.softlayer.com. 
+Any complex parameters (those that link to other datatypes) should be presented as JSON strings. They need to be enclosed in single quotes (`'`), and variables and strings enclosed in double quotes (`"`).
+
+For example: `{"hostname":"test",ssh_keys:[{"id":1234}]}`
 
 .. click:: SoftLayer.CLI.call_api:cli
     :prog: call-api


### PR DESCRIPTION
Adds `--json-filter` to call-api, allowing more complex filters.

`./slcli -v  call-api SoftLayer_Account getVirtualGuests --limit=10 --json-filter '{"virtualGuests":{"hostname": {"operation": "^= test"}}}'`

Adds json parsing for parameters. If a json-looking string is passed in as a parameter, call api will try to format it properly, instead of sending a string in.

```
$ ./slcli -vvv call-api SoftLayer_Virtual_Guest editObject --id=98316716 '{"hostname":"test-a271e"}'

Calling: SoftLayer_Virtual_Guest::editObject(id=98316716, mask='', filter='{}', args=({'hostname': 'test-a271e'},), limit=None, offset=None))

curl -u $SL_USER:$SL_APIKEY -X POST -H "Accept: */*" -H "Accept-Encoding: gzip, deflate, compress" -d '{"parameters": [{"hostname": "test-a271e"}]}' 'https://api.softlayer.com/rest/v3.1/SoftLayer_Virtual_Guest/98316716/editObject.json'

```


Fixes #801 