### PR TITLE
Fix ticket upload to be able to run with rest and xmlrpc endpoint.

### DIFF
--- a/SoftLayer/managers/ticket.py
+++ b/SoftLayer/managers/ticket.py
@@ -5,6 +5,9 @@
 
     :license: MIT, see LICENSE for more details.
 """
+import base64
+from json import dumps
+
 from SoftLayer import utils
 
 
@@ -92,9 +95,11 @@ class TicketManager(utils.IdentifierMixin, object):
         :param string file_name: The name of the attachment shown in the ticket
         :returns: dict -- The uploaded attachment
         """
-        file_content = None
         with open(file_path, 'rb') as attached_file:
-            file_content = attached_file.read()
+            base64_bytes = base64.b64encode(attached_file.read())
+            base64_string = base64_bytes.decode('utf-8')
+            raw_data = {file_path: base64_string}
+            file_content = dumps(raw_data, indent=2)
 
         file_object = {
             "filename": file_name,

--- a/tests/CLI/modules/ticket_tests.py
+++ b/tests/CLI/modules/ticket_tests.py
@@ -208,7 +208,8 @@ class TicketTests(testing.TestCase):
         self.assert_called_with('SoftLayer_Ticket',
                                 'addAttachedFile',
                                 args=({"filename": "attachment_upload",
-                                       "data": b"ticket attached data"},),
+                                       "data": '{\n  "tests/resources/attachment_upload": '
+                                               '"dGlja2V0IGF0dGFjaGVkIGRhdGE="\n}'},),
                                 identifier=1)
 
     def test_ticket_upload(self):
@@ -220,7 +221,8 @@ class TicketTests(testing.TestCase):
         self.assert_called_with('SoftLayer_Ticket',
                                 'addAttachedFile',
                                 args=({"filename": "a_file_name",
-                                       "data": b"ticket attached data"},),
+                                       "data": '{\n  "tests/resources/attachment_upload": '
+                                               '"dGlja2V0IGF0dGFjaGVkIGRhdGE="\n}'},),
                                 identifier=1)
 
     def test_init_ticket_results(self):


### PR DESCRIPTION
Fix ticket upload to be able to run with rest and xmlrpc endpoint https://github.com/softlayer/softlayer-python/issues/1266.
