### PR TITLE
Implement slcli vlan edit functionality.

### DIFF
--- a/SoftLayer/CLI/routes.py
+++ b/SoftLayer/CLI/routes.py
@@ -322,6 +322,7 @@ ALL_ROUTES = [
 
     ('vlan', 'SoftLayer.CLI.vlan'),
     ('vlan:detail', 'SoftLayer.CLI.vlan.detail:cli'),
+    ('vlan:edit', 'SoftLayer.CLI.vlan.edit:cli'),
     ('vlan:list', 'SoftLayer.CLI.vlan.list:cli'),
 
     ('summary', 'SoftLayer.CLI.summary:cli'),

--- a/SoftLayer/CLI/vlan/edit.py
+++ b/SoftLayer/CLI/vlan/edit.py
@@ -4,8 +4,7 @@
 import click
 
 import SoftLayer
-from SoftLayer.CLI import environment, exceptions
-from SoftLayer.CLI import formatting
+from SoftLayer.CLI import environment
 from SoftLayer.CLI import helpers
 
 

--- a/SoftLayer/CLI/vlan/edit.py
+++ b/SoftLayer/CLI/vlan/edit.py
@@ -22,17 +22,14 @@ from SoftLayer.CLI import helpers
 def cli(env, identifier, name, note, tags):
     """Edit a vlan's details."""
 
-    data = {
-        'name': name,
-        'note': note
-    }
+    new_tags = None
 
     if tags:
-        data['tags'] = ','.join(tags)
+        new_tags = ','.join(tags)
 
     mgr = SoftLayer.NetworkManager(env.client)
     vlan_id = helpers.resolve_id(mgr.resolve_vlan_ids, identifier, 'VLAN')
-    vlan = mgr.edit(vlan_id, **data)
+    vlan = mgr.edit(vlan_id, name=name, note=note, tags=new_tags)
 
     if vlan:
         click.secho("Vlan edited successfully", fg='green')

--- a/SoftLayer/CLI/vlan/edit.py
+++ b/SoftLayer/CLI/vlan/edit.py
@@ -1,0 +1,41 @@
+"""Edit a vlan's details."""
+# :license: MIT, see LICENSE for more details.
+
+import click
+
+import SoftLayer
+from SoftLayer.CLI import environment, exceptions
+from SoftLayer.CLI import formatting
+from SoftLayer.CLI import helpers
+
+
+@click.command()
+@click.argument('identifier')
+@click.option('--name', '-n',
+              help="The optional name for this VLAN")
+@click.option('--note', '-e',
+              help="The note for this vlan.")
+@click.option('--tags', '-g',
+              multiple=True,
+              help='Tags to set e.g. "tag1,tag2", or empty string to remove all'
+              )
+@environment.pass_env
+def cli(env, identifier, name, note, tags):
+    """Edit a vlan's details."""
+
+    data = {
+        'name': name,
+        'note': note
+    }
+
+    if tags:
+        data['tags'] = ','.join(tags)
+
+    mgr = SoftLayer.NetworkManager(env.client)
+    vlan_id = helpers.resolve_id(mgr.resolve_vlan_ids, identifier, 'VLAN')
+    vlan = mgr.edit(vlan_id, **data)
+
+    if vlan:
+        click.secho("Vlan edited successfully", fg='green')
+    else:
+        click.secho("Failed to edit the vlan", fg='red')

--- a/SoftLayer/fixtures/SoftLayer_Network_Vlan.py
+++ b/SoftLayer/fixtures/SoftLayer_Network_Vlan.py
@@ -7,3 +7,6 @@ getObject = {
     'vlanNumber': 4444,
     'firewallInterfaces': None
 }
+
+editObject = True
+setTags = True

--- a/SoftLayer/managers/network.py
+++ b/SoftLayer/managers/network.py
@@ -698,7 +698,7 @@ class NetworkManager(object):
 
         :param integer instance_id: the instance ID to edit.
         :param string name: valid name.
-        :param string note: note about this particular v;am.
+        :param string note: note about this particular vlan.
         :param string tags: tags to set on the vlan as a comma separated list.
                             Use the empty string to remove all tags.
         :returns: bool -- True or an Exception

--- a/SoftLayer/managers/network.py
+++ b/SoftLayer/managers/network.py
@@ -18,7 +18,7 @@ from SoftLayer.managers import event_log
 
 LOGGER = logging.getLogger(__name__)
 
-# pylint: disable=no-self-use,too-many-lines
+# pylint: disable=too-many-public-methods
 
 DEFAULT_SUBNET_MASK = ','.join(['hardware',
                                 'datacenter',

--- a/SoftLayer/managers/network.py
+++ b/SoftLayer/managers/network.py
@@ -18,6 +18,8 @@ from SoftLayer.managers import event_log
 
 LOGGER = logging.getLogger(__name__)
 
+# pylint: disable=no-self-use,too-many-lines
+
 DEFAULT_SUBNET_MASK = ','.join(['hardware',
                                 'datacenter',
                                 'ipAddressCount',

--- a/docs/cli/vlan.rst
+++ b/docs/cli/vlan.rst
@@ -7,6 +7,10 @@ VLANs
     :prog: vlan detail
     :show-nested:
 
+.. click:: SoftLayer.CLI.vlan.edit:cli
+    :prog: vlan edit
+    :show-nested:
+
 .. click:: SoftLayer.CLI.vlan.list:cli
     :prog: vlan list
     :show-nested:

--- a/tests/CLI/modules/vlan_tests.py
+++ b/tests/CLI/modules/vlan_tests.py
@@ -4,6 +4,8 @@
 
     :license: MIT, see LICENSE for more details.
 """
+import mock
+
 from SoftLayer import testing
 
 
@@ -76,3 +78,19 @@ class VlanTests(testing.TestCase):
         vlan_mock.return_value = getObject
         result = self.run_command(['vlan', 'detail', '1234'])
         self.assert_no_fail(result)
+
+    @mock.patch('SoftLayer.CLI.vlan.edit.click')
+    def test_vlan_edit(self, click):
+        result = self.run_command(['vlan', 'edit', '--name=nameTest', '--note=noteTest', '--tags=tag1,tag2', '100'])
+        click.secho.assert_called_with('Vlan edited successfully', fg='green')
+        self.assert_no_fail(result)
+        self.assert_called_with('SoftLayer_Network_Vlan', 'editObject', identifier=100)
+
+    @mock.patch('SoftLayer.CLI.vlan.edit.click')
+    def test_vlan_edit_failure(self, click):
+        mock = self.set_mock('SoftLayer_Network_Vlan', 'editObject')
+        mock.return_value = False
+        result = self.run_command(['vlan', 'edit', '--name=nameTest', '--note=noteTest', '--tags=tag1,tag2', '100'])
+        click.secho.assert_called_with('Failed to edit the vlan', fg='red')
+        self.assert_no_fail(result)
+        self.assert_called_with('SoftLayer_Network_Vlan', 'editObject', identifier=100)

--- a/tests/managers/network_tests.py
+++ b/tests/managers/network_tests.py
@@ -625,3 +625,12 @@ class NetworkTests(testing.TestCase):
         _filter = {'objectName': {'operation': 'CCI'}}
         self.assert_called_with('SoftLayer_Event_Log', 'getAllObjects', filter=_filter)
         self.assertEqual(100, log['accountId'])
+
+    def test_vlan_edit(self):
+        vlan_id = 100
+        name = "test"
+        note = "test note"
+        tags = "tag1,tag2"
+
+        self.network.edit(vlan_id, name, note, tags)
+        self.assert_called_with('SoftLayer_Network_Vlan', 'editObject')


### PR DESCRIPTION
Implement slcli vlan edit functionalityhttps://github.com/softlayer/softlayer-python/issues/1282.

**slcli vlan edit --help**

Usage: slcli vlan edit [OPTIONS] IDENTIFIER

  Edit a vlan's details.

Options:
  -n, --name TEXT  The optional name for this VLAN
  -e, --note TEXT  The note for this vlan.
  -g, --tag TEXT   Tags to set e.g. "tag1,tag2", or empty string to remove all
  -h, --help       Show this message and exit.

The SoftLayer_Network_Vlan::editObject request allow to edit the note attribute but this is not shown by ui and api too.