### PR TITLE
Add functionality to order a hw for capacityRestrictionType PROCCESOR.

### DIFF
--- a/SoftLayer/managers/ordering.py
+++ b/SoftLayer/managers/ordering.py
@@ -396,7 +396,7 @@ class OrderingManager(object):
                 capacity_min = int(price.get('capacityRestrictionMinimum', -1))
                 capacity_max = int(price.get('capacityRestrictionMaximum', -1))
                 # return first match if no restirction, or no core to check
-                if capacity_min == -1 or core is None:
+                if capacity_min == -1 or core is None or "PROCESSOR" in price.get("capacityRestrictionType"):
                     price_id = price['id']
                 # this check is mostly to work nicely with preset configs
                 elif capacity_min <= int(core) <= capacity_max:

--- a/SoftLayer/managers/ordering.py
+++ b/SoftLayer/managers/ordering.py
@@ -393,16 +393,23 @@ class OrderingManager(object):
         price_id = None
         for price in prices:
             if not price['locationGroupId']:
-                capacity_min = int(price.get('capacityRestrictionMinimum', -1))
-                capacity_max = int(price.get('capacityRestrictionMaximum', -1))
-                # return first match if no restirction, or no core to check
-                if capacity_min == -1 or core is None or "PROCESSOR" in price.get("capacityRestrictionType"):
-                    price_id = price['id']
-                # this check is mostly to work nicely with preset configs
-                elif capacity_min <= int(core) <= capacity_max:
-                    if "STORAGE" in price.get("capacityRestrictionType") or "CORE" in price.get(
-                            "capacityRestrictionType"):
+                restriction = price.get('capacityRestrictionType', False)
+                # There is a price restriction. Make sure the price is within the restriction
+                if restriction and core is not None:
+                    capacity_min = int(price.get('capacityRestrictionMinimum', -1))
+                    capacity_max = int(price.get('capacityRestrictionMaximum', -1))
+                    if "STORAGE" in restriction:
+                        if capacity_min <= int(core) <= capacity_max:
+                            price_id = price['id']
+                    if "CORE" in restriction:
+                        if capacity_min <= int(core) <= capacity_max:
+                            price_id = price['id']
+                    if "PROCESSOR" in restriction:
                         price_id = price['id']
+                # No price restrictions
+                else:
+                    price_id = price['id']
+
         return price_id
 
     def get_item_capacity(self, items, item_keynames):

--- a/tests/managers/ordering_tests.py
+++ b/tests/managers/ordering_tests.py
@@ -666,6 +666,16 @@ class OrderingTests(testing.TestCase):
 
         self.assertEqual(1234, price_id)
 
+    def test_get_item_price_id_processor_with_capacity_restriction(self):
+        category1 = {'categoryCode': 'cat1'}
+        price1 = [{'id': 1234, 'locationGroupId': '', "capacityRestrictionMaximum": "1",
+                   "capacityRestrictionMinimum": "1", "capacityRestrictionType": "PROCESSOR",
+                   'categories': [category1]}]
+
+        price_id = self.ordering.get_item_price_id("8", price1)
+
+        self.assertEqual(1234, price_id)
+
     def test_issues1067(self):
         # https://github.com/softlayer/softlayer-python/issues/1067
         item_mock = self.set_mock('SoftLayer_Product_Package', 'getItems')


### PR DESCRIPTION
Add functionality to order a hw for capacityRestrictionType PROCCESOR https://github.com/softlayer/softlayer-python/issues/1289.