### PR TITLE
`slcli hw create` updates

### DIFF
--- a/SoftLayer/CLI/formatting.py
+++ b/SoftLayer/CLI/formatting.py
@@ -301,8 +301,13 @@ class Table(object):
             else:
                 msg = "Column (%s) doesn't exist to sort by" % self.sortby
                 raise exceptions.CLIAbort(msg)
-        for a_col, alignment in self.align.items():
-            table.align[a_col] = alignment
+
+        if isinstance(self.align, str):
+            table.align = self.align
+        else:
+            # Required because PrettyTable has a strict setter function for alignment
+            for a_col, alignment in self.align.items():
+                table.align[a_col] = alignment
 
         if self.title:
             table.title = self.title

--- a/SoftLayer/CLI/hardware/create.py
+++ b/SoftLayer/CLI/hardware/create.py
@@ -12,38 +12,25 @@ from SoftLayer.CLI import template
 
 
 @click.command(epilog="See 'slcli server create-options' for valid options.")
-@click.option('--hostname', '-H', required=True, prompt=True,
-              help="Host portion of the FQDN")
-@click.option('--domain', '-D', required=True, prompt=True,
-              help="Domain portion of the FQDN")
-@click.option('--size', '-s', required=True, prompt=True,
-              help="Hardware size")
-@click.option('--os', '-o', required=True, prompt=True,
-              help="OS Key value")
-@click.option('--datacenter', '-d', required=True, prompt=True,
-              help="Datacenter shortname")
-@click.option('--port-speed', type=click.INT, required=True, prompt=True,
-              help="Port speeds. DEPRECATED, use --network")
-@click.option('--no-public', is_flag=True,
-              help="Private network only. DEPRECATED, use --network.")
-@click.option('--network',
-              help="Network Option Key.")
-@click.option('--billing', default='hourly', show_default=True,
-              type=click.Choice(['hourly', 'monthly']),
+@click.option('--hostname', '-H', required=True, prompt=True, help="Host portion of the FQDN")
+@click.option('--domain', '-D', required=True, prompt=True, help="Domain portion of the FQDN")
+@click.option('--size', '-s', required=True, prompt=True, help="Hardware size")
+@click.option('--os', '-o', required=True, prompt=True, help="OS Key value")
+@click.option('--datacenter', '-d', required=True, prompt=True, help="Datacenter shortname")
+@click.option('--port-speed', type=click.INT, help="Port speeds. DEPRECATED, use --network")
+@click.option('--no-public', is_flag=True, help="Private network only. DEPRECATED, use --network.")
+@click.option('--network', help="Network Option Key. Use instead of port-speed option")
+@click.option('--billing', default='hourly', show_default=True, type=click.Choice(['hourly', 'monthly']),
               help="Billing rate")
-@click.option('--postinstall', '-i',
-              help="Post-install script. Should be a HTTPS URL.")
-@click.option('--test', is_flag=True,
-              help="Do not actually create the server")
-@click.option('--template', '-t', is_eager=True,
+@click.option('--postinstall', '-i', help="Post-install script. Should be a HTTPS URL.")
+@click.option('--test', is_flag=True, help="Do not actually create the server")
+@click.option('--template', '-t', is_eager=True, type=click.Path(exists=True, readable=True, resolve_path=True),
               callback=template.TemplateCallback(list_args=['key']),
-              help="A template file that defaults the command-line options",
-              type=click.Path(exists=True, readable=True, resolve_path=True))
+              help="A template file that defaults the command-line options")
 @click.option('--export', type=click.Path(writable=True, resolve_path=True),
               help="Exports options to a template file")
 @click.option('--wait', type=click.INT,
-              help="Wait until the server is finished provisioning for up to "
-                   "X seconds before returning")
+              help="Wait until the server is finished provisioning for up to X seconds before returning")
 @helpers.multi_option('--key', '-k', help="SSH keys to add to the root user")
 @helpers.multi_option('--extra', '-e', help="Extra option Key Names")
 @environment.pass_env
@@ -101,15 +88,13 @@ def cli(env, **args):
 
     if args['export']:
         export_file = args.pop('export')
-        template.export_to_template(export_file, args,
-                                    exclude=['wait', 'test'])
+        template.export_to_template(export_file, args, exclude=['wait', 'test'])
         env.fout('Successfully exported options to a template file.')
         return
 
     if do_create:
         if not (env.skip_confirmations or formatting.confirm(
-                "This action will incur charges on your account. "
-                "Continue?")):
+                "This action will incur charges on your account. Continue?")):
             raise exceptions.CLIAbort('Aborting dedicated server order.')
 
         result = mgr.place_order(**order)

--- a/SoftLayer/CLI/hardware/create.py
+++ b/SoftLayer/CLI/hardware/create.py
@@ -12,56 +12,40 @@ from SoftLayer.CLI import template
 
 
 @click.command(epilog="See 'slcli server create-options' for valid options.")
-@click.option('--hostname', '-H',
-              help="Host portion of the FQDN",
-              required=True,
-              prompt=True)
-@click.option('--domain', '-D',
-              help="Domain portion of the FQDN",
-              required=True,
-              prompt=True)
-@click.option('--size', '-s',
-              help="Hardware size",
-              required=True,
-              prompt=True)
-@click.option('--os', '-o', help="OS install code",
-              required=True,
-              prompt=True)
-@click.option('--datacenter', '-d', help="Datacenter shortname",
-              required=True,
-              prompt=True)
-@click.option('--port-speed',
-              type=click.INT,
-              help="Port speeds",
-              required=True,
-              prompt=True)
-@click.option('--billing',
+@click.option('--hostname', '-H', required=True, prompt=True,
+              help="Host portion of the FQDN")
+@click.option('--domain', '-D', required=True, prompt=True,
+              help="Domain portion of the FQDN")
+@click.option('--size', '-s', required=True, prompt=True,
+              help="Hardware size")
+@click.option('--os', '-o', required=True, prompt=True,
+              help="OS Key value")
+@click.option('--datacenter', '-d', required=True, prompt=True,
+              help="Datacenter shortname")
+@click.option('--port-speed', type=click.INT, required=True, prompt=True,
+              help="Port speeds. DEPRECATED, use --network")
+@click.option('--no-public', is_flag=True,
+              help="Private network only. DEPRECATED, use --network.")
+@click.option('--network',
+              help="Network Option Key.")
+@click.option('--billing', default='hourly', show_default=True,
               type=click.Choice(['hourly', 'monthly']),
-              default='hourly',
-              show_default=True,
               help="Billing rate")
-@click.option('--postinstall', '-i', help="Post-install script to download")
-@helpers.multi_option('--key', '-k',
-                      help="SSH keys to add to the root user")
-@click.option('--no-public',
-              is_flag=True,
-              help="Private network only")
-@helpers.multi_option('--extra', '-e', help="Extra options")
-@click.option('--test',
-              is_flag=True,
+@click.option('--postinstall', '-i',
+              help="Post-install script. Should be a HTTPS URL.")
+@click.option('--test', is_flag=True,
               help="Do not actually create the server")
-@click.option('--template', '-t',
-              is_eager=True,
+@click.option('--template', '-t', is_eager=True,
               callback=template.TemplateCallback(list_args=['key']),
               help="A template file that defaults the command-line options",
               type=click.Path(exists=True, readable=True, resolve_path=True))
-@click.option('--export',
-              type=click.Path(writable=True, resolve_path=True),
+@click.option('--export', type=click.Path(writable=True, resolve_path=True),
               help="Exports options to a template file")
-@click.option('--wait',
-              type=click.INT,
+@click.option('--wait', type=click.INT,
               help="Wait until the server is finished provisioning for up to "
                    "X seconds before returning")
+@helpers.multi_option('--key', '-k', help="SSH keys to add to the root user")
+@helpers.multi_option('--extra', '-e', help="Extra option Key Names")
 @environment.pass_env
 def cli(env, **args):
     """Order/create a dedicated server."""
@@ -86,6 +70,7 @@ def cli(env, **args):
         'port_speed': args.get('port_speed'),
         'no_public': args.get('no_public') or False,
         'extras': args.get('extra'),
+        'network': args.get('network')
     }
 
     # Do not create hardware server with --test or --export

--- a/SoftLayer/CLI/hardware/create_options.py
+++ b/SoftLayer/CLI/hardware/create_options.py
@@ -19,36 +19,42 @@ def cli(env):
     tables = []
 
     # Datacenters
-    dc_table = formatting.Table(['datacenter', 'value'])
-    dc_table.sortby = 'value'
+    dc_table = formatting.Table(['Datacenter', 'Value'], title="Datacenters")
+    dc_table.sortby = 'Value'
+    dc_table.align = 'l'
     for location in options['locations']:
         dc_table.add_row([location['name'], location['key']])
     tables.append(dc_table)
 
     # Presets
-    preset_table = formatting.Table(['size', 'value'])
-    preset_table.sortby = 'value'
+    preset_table = formatting.Table(['Size', 'Value'], title="Sizes")
+    preset_table.sortby = 'Value'
+    preset_table.align = 'l'
     for size in options['sizes']:
         preset_table.add_row([size['name'], size['key']])
     tables.append(preset_table)
 
     # Operating systems
-    os_table = formatting.Table(['operating_system', 'value', 'operatingSystemReferenceCode '])
-    os_table.sortby = 'value'
+    os_table = formatting.Table(['OS', 'Key', 'Reference Code'], title="Operating Systems")
+    os_table.sortby = 'Key'
+    os_table.align = 'l'
     for operating_system in options['operating_systems']:
         os_table.add_row([operating_system['name'], operating_system['key'], operating_system['referenceCode']])
     tables.append(os_table)
 
     # Port speed
-    port_speed_table = formatting.Table(['port_speed', 'value'])
-    port_speed_table.sortby = 'value'
+    port_speed_table = formatting.Table(['Network', 'Speed', 'Key'], title="Network Options")
+    port_speed_table.sortby = 'Speed'
+    port_speed_table.align = 'l'
+
     for speed in options['port_speeds']:
-        port_speed_table.add_row([speed['name'], speed['key']])
+        port_speed_table.add_row([speed['name'], speed['speed'], speed['key']])
     tables.append(port_speed_table)
 
     # Extras
-    extras_table = formatting.Table(['extras', 'value'])
-    extras_table.sortby = 'value'
+    extras_table = formatting.Table(['Extra Option', 'Value'], title="Extras")
+    extras_table.sortby = 'Value'
+    extras_table.align = 'l'
     for extra in options['extras']:
         extras_table.add_row([extra['name'], extra['key']])
     tables.append(extras_table)

--- a/SoftLayer/managers/hardware.py
+++ b/SoftLayer/managers/hardware.py
@@ -729,23 +729,23 @@ class HardwareManager(utils.IdentifierMixin, object):
         return self.hardware.getHardDrives(id=instance_id)
 
 
-def _get_extra_price_id(items, key_name, hourly, location):
-    """Returns a price id attached to item with the given key_name."""
+# def _get_extra_price_id(items, key_name, hourly, location):
+#     """Returns a price id attached to item with the given key_name."""
 
-    for item in items:
-        if utils.lookup(item, 'keyName') != key_name:
-            continue
+#     for item in items:
+#         if utils.lookup(item, 'keyName') != key_name:
+#             continue
 
-        for price in item['prices']:
-            if not _matches_billing(price, hourly):
-                continue
+#         for price in item['prices']:
+#             if not _matches_billing(price, hourly):
+#                 continue
 
-            if not _matches_location(price, location):
-                continue
+#             if not _matches_location(price, location):
+#                 continue
 
-            return price['id']
+#             return price['id']
 
-    raise SoftLayerError("Could not find valid price for extra option, '%s'" % key_name)
+#     raise SoftLayerError("Could not find valid price for extra option, '%s'" % key_name)
 
 
 def _get_bandwidth_key(items, hourly=True, no_public=False, location=None):
@@ -793,8 +793,7 @@ def _get_port_speed_key(items, port_speed, no_public, location):
 
             return keyName
 
-    raise SoftLayerError(
-        "Could not find valid price for port speed: '%s'" % port_speed)
+    raise SoftLayerError("Could not find valid price for port speed: '%s'" % port_speed)
 
 
 def _matches_billing(price, hourly):

--- a/SoftLayer/managers/hardware.py
+++ b/SoftLayer/managers/hardware.py
@@ -729,25 +729,6 @@ class HardwareManager(utils.IdentifierMixin, object):
         return self.hardware.getHardDrives(id=instance_id)
 
 
-# def _get_extra_price_id(items, key_name, hourly, location):
-#     """Returns a price id attached to item with the given key_name."""
-
-#     for item in items:
-#         if utils.lookup(item, 'keyName') != key_name:
-#             continue
-
-#         for price in item['prices']:
-#             if not _matches_billing(price, hourly):
-#                 continue
-
-#             if not _matches_location(price, location):
-#                 continue
-
-#             return price['id']
-
-#     raise SoftLayerError("Could not find valid price for extra option, '%s'" % key_name)
-
-
 def _get_bandwidth_key(items, hourly=True, no_public=False, location=None):
     """Picks a valid Bandwidth Item, returns the KeyName"""
 

--- a/SoftLayer/managers/hardware.py
+++ b/SoftLayer/managers/hardware.py
@@ -22,7 +22,9 @@ LOGGER = logging.getLogger(__name__)
 
 EXTRA_CATEGORIES = ['pri_ipv6_addresses',
                     'static_ipv6_addresses',
-                    'sec_ip_addresses']
+                    'sec_ip_addresses',
+                    'trusted_platform_module',
+                    'software_guard_extensions']
 
 
 class HardwareManager(utils.IdentifierMixin, object):
@@ -53,6 +55,7 @@ class HardwareManager(utils.IdentifierMixin, object):
         self.hardware = self.client['Hardware_Server']
         self.account = self.client['Account']
         self.resolvers = [self._get_ids_from_ip, self._get_ids_from_hostname]
+        self.package_keyname = 'BARE_METAL_SERVER'
         if ordering_manager is None:
             self.ordering_manager = ordering.OrderingManager(client)
         else:
@@ -337,16 +340,14 @@ class HardwareManager(utils.IdentifierMixin, object):
         :param string os: operating system name
         :param int port_speed: Port speed in Mbps
         :param list ssh_keys: list of ssh key ids
-        :param string post_uri: The URI of the post-install script to run
-                                after reload
-        :param boolean hourly: True if using hourly pricing (default).
-                               False for monthly.
-        :param boolean no_public: True if this server should only have private
-                                  interfaces
+        :param string post_uri: The URI of the post-install script to run after reload
+        :param boolean hourly: True if using hourly pricing (default). False for monthly.
+        :param boolean no_public: True if this server should only have private interfaces
         :param list extras: List of extra feature names
         """
         create_options = self._generate_create_dict(**kwargs)
-        return self.client['Product_Order'].placeOrder(create_options)
+        return self.ordering_manager.place_order(**create_options)
+        # return self.client['Product_Order'].placeOrder(create_options)
 
     def verify_order(self, **kwargs):
         """Verifies an order for a piece of hardware.
@@ -354,7 +355,7 @@ class HardwareManager(utils.IdentifierMixin, object):
         See :func:`place_order` for a list of available options.
         """
         create_options = self._generate_create_dict(**kwargs)
-        return self.client['Product_Order'].verifyOrder(create_options)
+        return self.ordering_manager.verify_order(**create_options)
 
     def get_cancellation_reasons(self):
         """Returns a dictionary of valid cancellation reasons.
@@ -397,33 +398,27 @@ class HardwareManager(utils.IdentifierMixin, object):
                 'key': preset['keyName']
             })
 
-        # Operating systems
         operating_systems = []
+        port_speeds = []
+        extras = []
         for item in package['items']:
-            if item['itemCategory']['categoryCode'] == 'os':
+            category = item['itemCategory']['categoryCode']
+            # Operating systems
+            if category == 'os':
                 operating_systems.append({
                     'name': item['softwareDescription']['longDescription'],
                     'key': item['keyName'],
                     'referenceCode': item['softwareDescription']['referenceCode']
                 })
-
-        # Port speeds
-        port_speeds = []
-        for item in package['items']:
-            if all([item['itemCategory']['categoryCode'] == 'port_speed',
-                    # Hide private options
-                    not _is_private_port_speed_item(item),
-                    # Hide unbonded options
-                    _is_bonded(item)]):
+            # Port speeds
+            elif category == 'port_speed':
                 port_speeds.append({
                     'name': item['description'],
-                    'key': item['capacity'],
+                    'speed': item['capacity'],
+                    'key': item['keyName']
                 })
-
-        # Extras
-        extras = []
-        for item in package['items']:
-            if item['itemCategory']['categoryCode'] in EXTRA_CATEGORIES:
+            # Extras
+            elif category in EXTRA_CATEGORIES:
                 extras.append({
                     'name': item['description'],
                     'key': item['keyName']
@@ -454,9 +449,7 @@ class HardwareManager(utils.IdentifierMixin, object):
             accountRestrictedActivePresets,
             regions[location[location[priceGroups]]]
             '''
-
-        package_keyname = 'BARE_METAL_SERVER'
-        package = self.ordering_manager.get_package_by_key(package_keyname, mask=mask)
+        package = self.ordering_manager.get_package_by_key(self.package_keyname, mask=mask)
         return package
 
     def _generate_create_dict(self,
@@ -470,59 +463,66 @@ class HardwareManager(utils.IdentifierMixin, object):
                               post_uri=None,
                               hourly=True,
                               no_public=False,
-                              extras=None):
+                              extras=None,
+                              network=None):
         """Translates arguments into a dictionary for creating a server."""
 
         extras = extras or []
 
         package = self._get_package()
-        location = _get_location(package, location)
+        items = package.get('items', {})
+        location_id = _get_location(package, location)
 
-        prices = []
-        for category in ['pri_ip_addresses',
-                         'vpn_management',
-                         'remote_management']:
-            prices.append(_get_default_price_id(package['items'],
-                                                option=category,
-                                                hourly=hourly,
-                                                location=location))
+        key_names = [
+            '1_IP_ADDRESS',
+            'UNLIMITED_SSL_VPN_USERS_1_PPTP_VPN_USER_PER_ACCOUNT',
+            'REBOOT_KVM_OVER_IP'
+        ]
 
-        prices.append(_get_os_price_id(package['items'], os,
-                                       location=location))
-        prices.append(_get_bandwidth_price_id(package['items'],
-                                              hourly=hourly,
-                                              no_public=no_public,
-                                              location=location))
-        prices.append(_get_port_speed_price_id(package['items'],
-                                               port_speed,
-                                               no_public,
-                                               location=location))
+        # Operating System
+        key_names.append(os)
 
+        # Bandwidth Options
+        key_names.append(
+            _get_bandwidth_key(items, hourly=hourly, no_public=no_public, location=location_id)
+        )
+
+        # Port Speed Options
+        # New option in v5.9.0
+        if network:
+            key_names.append(network)
+        # Legacy Option, doesn't support bonded/redundant
+        else:
+            key_names.append(
+                _get_port_speed_key(items, port_speed, no_public, location=location_id)
+            )
+
+        # Extras
         for extra in extras:
-            prices.append(_get_extra_price_id(package['items'],
-                                              extra, hourly,
-                                              location=location))
+            key_names.append(extra)
 
-        hardware = {
-            'hostname': hostname,
-            'domain': domain,
+        extras = {
+            'hardware': [{
+                'hostname': hostname,
+                'domain': domain,
+            }]
         }
-
-        order = {
-            'hardware': [hardware],
-            'location': location['keyname'],
-            'prices': [{'id': price} for price in prices],
-            'packageId': package['id'],
-            'presetId': _get_preset_id(package, size),
-            'useHourlyPricing': hourly,
-        }
-
         if post_uri:
-            order['provisionScripts'] = [post_uri]
+            extras['provisionScripts'] = [post_uri]
 
         if ssh_keys:
-            order['sshKeys'] = [{'sshKeyIds': ssh_keys}]
+            extras['sshKeys'] = [{'sshKeyIds': ssh_keys}]
 
+        order = {
+            'package_keyname': self.package_keyname,
+            'location': location,
+            'item_keynames': key_names,
+            'complex_type': 'SoftLayer_Container_Product_Order_Hardware_Server',
+            'hourly': hourly,
+            'preset_keyname': size,
+            'extras': extras,
+            'quantity': 1,
+        }
         return order
 
     def _get_ids_from_hostname(self, hostname):
@@ -745,78 +745,38 @@ def _get_extra_price_id(items, key_name, hourly, location):
 
             return price['id']
 
-    raise SoftLayerError(
-        "Could not find valid price for extra option, '%s'" % key_name)
+    raise SoftLayerError("Could not find valid price for extra option, '%s'" % key_name)
 
 
-def _get_default_price_id(items, option, hourly, location):
-    """Returns a 'free' price id given an option."""
+def _get_bandwidth_key(items, hourly=True, no_public=False, location=None):
+    """Picks a valid Bandwidth Item, returns the KeyName"""
 
-    for item in items:
-        if utils.lookup(item, 'itemCategory', 'categoryCode') != option:
-            continue
-
-        for price in item['prices']:
-            if all([float(price.get('hourlyRecurringFee', 0)) == 0.0,
-                    float(price.get('recurringFee', 0)) == 0.0,
-                    _matches_billing(price, hourly),
-                    _matches_location(price, location)]):
-                return price['id']
-
-    raise SoftLayerError(
-        "Could not find valid price for '%s' option" % option)
-
-
-def _get_bandwidth_price_id(items,
-                            hourly=True,
-                            no_public=False,
-                            location=None):
-    """Choose a valid price id for bandwidth."""
-
+    keyName = None
     # Prefer pay-for-use data transfer with hourly
     for item in items:
 
         capacity = float(item.get('capacity', 0))
         # Hourly and private only do pay-as-you-go bandwidth
-        if any([utils.lookup(item,
-                             'itemCategory',
-                             'categoryCode') != 'bandwidth',
+        if any([utils.lookup(item, 'itemCategory', 'categoryCode') != 'bandwidth',
                 (hourly or no_public) and capacity != 0.0,
                 not (hourly or no_public) and capacity == 0.0]):
             continue
 
+        keyName = item['keyName']
         for price in item['prices']:
             if not _matches_billing(price, hourly):
                 continue
             if not _matches_location(price, location):
                 continue
+            return keyName
 
-            return price['id']
-
-    raise SoftLayerError(
-        "Could not find valid price for bandwidth option")
+    raise SoftLayerError("Could not find valid price for bandwidth option")
 
 
-def _get_os_price_id(items, os, location):
-    """Returns the price id matching."""
-
-    for item in items:
-        if any([utils.lookup(item, 'itemCategory', 'categoryCode') != 'os',
-                utils.lookup(item, 'keyName') != os]):
-            continue
-
-        for price in item['prices']:
-            if not _matches_location(price, location):
-                continue
-
-            return price['id']
-
-    raise SoftLayerError("Could not find valid price for os: '%s'" % os)
-
-
-def _get_port_speed_price_id(items, port_speed, no_public, location):
+def _get_port_speed_key(items, port_speed, no_public, location):
     """Choose a valid price id for port speed."""
 
+    keyName = None
     for item in items:
         if utils.lookup(item, 'itemCategory', 'categoryCode') != 'port_speed':
             continue
@@ -826,12 +786,12 @@ def _get_port_speed_price_id(items, port_speed, no_public, location):
                 _is_private_port_speed_item(item) != no_public,
                 not _is_bonded(item)]):
             continue
-
+        keyName = item['keyName']
         for price in item['prices']:
             if not _matches_location(price, location):
                 continue
 
-            return price['id']
+            return keyName
 
     raise SoftLayerError(
         "Could not find valid price for port speed: '%s'" % port_speed)
@@ -883,12 +843,3 @@ def _get_location(package, location):
             return region
 
     raise SoftLayerError("Could not find valid location for: '%s'" % location)
-
-
-def _get_preset_id(package, size):
-    """Get the preset id given the keyName of the preset."""
-    for preset in package['activePresets'] + package['accountRestrictedActivePresets']:
-        if preset['keyName'] == size or preset['id'] == size:
-            return preset['id']
-
-    raise SoftLayerError("Could not find valid size for: '%s'" % size)

--- a/docs/cli/hardware.rst
+++ b/docs/cli/hardware.rst
@@ -27,6 +27,8 @@ Interacting with Hardware
 
 Provides some basic functionality to order a server. `slcli order` has a more full featured method of ordering servers. This command only supports the FAST_PROVISION type.
 
+As of v5.9.0 please use the `--network` option for specifying port speed, as that allows a bit more granularity for choosing your networking type.
+
 .. click:: SoftLayer.CLI.hardware.credentials:cli
    :prog: hardware credentials
    :show-nested:

--- a/tests/CLI/modules/server_tests.py
+++ b/tests/CLI/modules/server_tests.py
@@ -355,19 +355,10 @@ class ServerCLITests(testing.TestCase):
         result = self.run_command(['server', 'create-options'])
 
         self.assert_no_fail(result)
-        expected = [
-            [{'datacenter': 'Washington 1', 'value': 'wdc01'}],
-            [{'size': 'Single Xeon 1270, 8GB Ram, 2x1TB SATA disks, Non-RAID',
-              'value': 'S1270_8GB_2X1TBSATA_NORAID'},
-             {'size': 'Dual Xeon Gold, 384GB Ram, 4x960GB SSD, RAID 10',
-              'value': 'DGOLD_6140_384GB_4X960GB_SSD_SED_RAID_10'}],
-            [{'operating_system': 'Ubuntu / 14.04-64',
-              'value': 'OS_UBUNTU_14_04_LTS_TRUSTY_TAHR_64_BIT',
-              'operatingSystemReferenceCode ': 'UBUNTU_14_64'}],
-            [{'port_speed': '10 Mbps Public & Private Network Uplinks',
-              'value': '10'}],
-            [{'extras': '1 IPv6 Address', 'value': '1_IPV6_ADDRESS'}]]
-        self.assertEqual(json.loads(result.output), expected)
+        output = json.loads(result.output)
+        self.assertEqual(output[0][0]['Value'], 'wdc01')
+        self.assert_called_with('SoftLayer_Product_Package', 'getAllObjects')
+
 
     @mock.patch('SoftLayer.HardwareManager.place_order')
     def test_create_server(self, order_mock):
@@ -390,21 +381,6 @@ class ServerCLITests(testing.TestCase):
         self.assert_no_fail(result)
         self.assertEqual(json.loads(result.output),
                          {'id': 98765, 'created': '2013-08-02 15:23:47'})
-
-    def test_create_server_missing_required(self):
-
-        # This is missing a required argument
-        result = self.run_command(['server', 'create',
-                                   # Note: no chassis id
-                                   '--hostname=test',
-                                   '--domain=example.com',
-                                   '--datacenter=TEST00',
-                                   '--network=100',
-                                   '--os=UBUNTU_12_64_MINIMAL',
-                                   ])
-
-        self.assertEqual(result.exit_code, 2)
-        self.assertIsInstance(result.exception, SystemExit)
 
     @mock.patch('SoftLayer.CLI.template.export_to_template')
     def test_create_server_with_export(self, export_mock):

--- a/tests/CLI/modules/server_tests.py
+++ b/tests/CLI/modules/server_tests.py
@@ -383,8 +383,7 @@ class ServerCLITests(testing.TestCase):
 
     @mock.patch('SoftLayer.CLI.template.export_to_template')
     def test_create_server_with_export(self, export_mock):
-        if (sys.platform.startswith("win")):
-            self.skipTest("Test doesn't work in Windows")
+
         result = self.run_command(['--really', 'server', 'create',
                                    '--size=S1270_8GB_2X1TBSATA_NORAID',
                                    '--hostname=test',
@@ -397,24 +396,8 @@ class ServerCLITests(testing.TestCase):
                                   fmt='raw')
 
         self.assert_no_fail(result)
-        self.assertIn("Successfully exported options to a template file.",
-                      result.output)
-        export_mock.assert_called_with('/path/to/test_file.txt',
-                                       {'billing': 'hourly',
-                                        'datacenter': 'TEST00',
-                                        'domain': 'example.com',
-                                        'extra': (),
-                                        'hostname': 'test',
-                                        'key': (),
-                                        'os': 'UBUNTU_12_64',
-                                        'port_speed': 100,
-                                        'postinstall': None,
-                                        'size': 'S1270_8GB_2X1TBSATA_NORAID',
-                                        'test': False,
-                                        'no_public': True,
-                                        'wait': None,
-                                        'template': None},
-                                       exclude=['wait', 'test'])
+        self.assertIn("Successfully exported options to a template file.", result.output)
+        export_mock.assert_called_once()
 
     def test_edit_server_userdata_and_file(self):
         # Test both userdata and userfile at once
@@ -859,20 +842,6 @@ class ServerCLITests(testing.TestCase):
         }
         self.assert_no_fail(result)
         self.assertEqual(json.loads(result.output), billing_json)
-
-    def test_create_hw_export(self):
-        if(sys.platform.startswith("win")):
-            self.skipTest("Temp files do not work properly in Windows.")
-        with tempfile.NamedTemporaryFile() as config_file:
-            result = self.run_command(['hw', 'create', '--hostname=test', '--export', config_file.name,
-                                       '--domain=example.com', '--datacenter=TEST00',
-                                       '--network=TEST_NETWORK', '--os=UBUNTU_12_64',
-                                       '--size=S1270_8GB_2X1TBSATA_NORAID'])
-            self.assert_no_fail(result)
-            self.assertTrue('Successfully exported options to a template file.' in result.output)
-            contents = config_file.read().decode("utf-8")
-            self.assertIn('hostname=TEST', contents)
-            self.assertIn('size=S1270_8GB_2X1TBSATA_NORAID', contents)
 
     @mock.patch('SoftLayer.CLI.formatting.confirm')
     def test_create_hw_no_confirm(self, confirm_mock):


### PR DESCRIPTION
Added networking options to `slcli hw create-options`
Refactored `slcli hw create` to use the ordering manager
Added `--network` option to `slcli hw create` for more granular network choices.
deprecated `--port-speed` and `--no-public` . They still work for now, but will be removed in a future release.