### PR TITLE
Some improvements to the dns commands

### DIFF
--- a/SoftLayer/CLI/dns/record_list.py
+++ b/SoftLayer/CLI/dns/record_list.py
@@ -14,36 +14,28 @@ from SoftLayer.CLI import helpers
 @click.argument('zone')
 @click.option('--data', help='Record data, such as an IP address')
 @click.option('--record', help='Host record, such as www')
-@click.option('--ttl',
-              type=click.INT,
+@click.option('--ttl', type=click.INT,
               help='TTL value in seconds, such as 86400')
-@click.option('--type', help='Record type, such as A or CNAME')
+@click.option('--type', 'record_type', help='Record type, such as A or CNAME')
 @environment.pass_env
-def cli(env, zone, data, record, ttl, type):
+def cli(env, zone, data, record, ttl, record_type):
     """List all records in a zone."""
 
     manager = SoftLayer.DNSManager(env.client)
     table = formatting.Table(['id', 'record', 'type', 'ttl', 'data'])
-
-    table.align['ttl'] = 'l'
-    table.align['record'] = 'r'
-    table.align['data'] = 'l'
+    table.align = 'l'
 
     zone_id = helpers.resolve_id(manager.resolve_ids, zone, name='zone')
 
-    records = manager.get_records(zone_id,
-                                  record_type=type,
-                                  host=record,
-                                  ttl=ttl,
-                                  data=data)
+    records = manager.get_records(zone_id, record_type=record_type, host=record, ttl=ttl, data=data)
 
     for the_record in records:
         table.add_row([
-            the_record['id'],
-            the_record['host'],
-            the_record['type'].upper(),
-            the_record['ttl'],
-            the_record['data']
+            the_record.get('id'),
+            the_record.get('host', ''),
+            the_record.get('type').upper(),
+            the_record.get('ttl'),
+            the_record.get('data')
         ])
 
     env.fout(table)

--- a/SoftLayer/CLI/dns/zone_list.py
+++ b/SoftLayer/CLI/dns/zone_list.py
@@ -6,6 +6,7 @@ import click
 import SoftLayer
 from SoftLayer.CLI import environment
 from SoftLayer.CLI import formatting
+from SoftLayer.utils import clean_time
 
 
 @click.command()
@@ -14,17 +15,22 @@ def cli(env):
     """List all zones."""
 
     manager = SoftLayer.DNSManager(env.client)
-    zones = manager.list_zones()
-    table = formatting.Table(['id', 'zone', 'serial', 'updated'])
-    table.align['serial'] = 'c'
-    table.align['updated'] = 'c'
-
+    objectMask = "mask[id,name,serial,updateDate,resourceRecordCount]"
+    zones = manager.list_zones(mask=objectMask)
+    table = formatting.Table(['id', 'zone', 'serial', 'updated', 'records'])
+    table.align = 'l'
     for zone in zones:
+        zone_serial = str(zone.get('serial'))
+        zone_date = zone.get('updateDate', None)
+        if zone_date is None:
+            # The serial is just YYYYMMDD##, and since there is no createDate, just format it like it was one.
+            zone_date = "{}-{}-{}T00:00:00-06:00".format(zone_serial[0:4], zone_serial[4:6], zone_serial[6:8])
         table.add_row([
             zone['id'],
             zone['name'],
-            zone['serial'],
-            zone['updateDate'],
+            zone_serial,
+            clean_time(zone_date),
+            zone.get('resourceRecordCount', 0)
         ])
 
     env.fout(table)

--- a/SoftLayer/CLI/dns/zone_list.py
+++ b/SoftLayer/CLI/dns/zone_list.py
@@ -15,8 +15,8 @@ def cli(env):
     """List all zones."""
 
     manager = SoftLayer.DNSManager(env.client)
-    objectMask = "mask[id,name,serial,updateDate,resourceRecordCount]"
-    zones = manager.list_zones(mask=objectMask)
+    object_mask = "mask[id,name,serial,updateDate,resourceRecordCount]"
+    zones = manager.list_zones(mask=object_mask)
     table = formatting.Table(['id', 'zone', 'serial', 'updated', 'records'])
     table.align = 'l'
     for zone in zones:

--- a/SoftLayer/fixtures/SoftLayer_Dns_Domain_ResourceRecord.py
+++ b/SoftLayer/fixtures/SoftLayer_Dns_Domain_ResourceRecord.py
@@ -1,3 +1,4 @@
 createObject = {'name': 'example.com'}
 deleteObject = True
 editObject = True
+getObject = {'id': 12345, 'ttl': 7200, 'data': 'd', 'host': 'a', 'type': 'cname'}

--- a/SoftLayer/managers/dns.py
+++ b/SoftLayer/managers/dns.py
@@ -39,7 +39,10 @@ class DNSManager(utils.IdentifierMixin, object):
         :returns: A list of dictionaries representing the matching zones.
 
         """
-        return self.client['Account'].getDomains(**kwargs)
+        if kwargs.get('iter') is None:
+            kwargs['iter'] = True
+        return self.client.call('SoftLayer_Account', 'getDomains', **kwargs)
+        # return self.client['Account'].getDomains(**kwargs)
 
     def get_zone(self, zone_id, records=True):
         """Get a zone and its records.
@@ -181,8 +184,7 @@ class DNSManager(utils.IdentifierMixin, object):
         """
         return self.record.getObject(id=record_id)
 
-    def get_records(self, zone_id, ttl=None, data=None, host=None,
-                    record_type=None):
+    def get_records(self, zone_id, ttl=None, data=None, host=None, record_type=None):
         """List, and optionally filter, records within a zone.
 
         :param zone: the zone name in which to search.
@@ -191,8 +193,7 @@ class DNSManager(utils.IdentifierMixin, object):
         :param str host: record's host
         :param str record_type: the type of record
 
-        :returns: A list of dictionaries representing the matching records
-                  within the specified zone.
+        :returns: A list of dictionaries representing the matching records within the specified zone.
         """
         _filter = utils.NestedDict()
 
@@ -208,12 +209,9 @@ class DNSManager(utils.IdentifierMixin, object):
         if record_type:
             _filter['resourceRecords']['type'] = utils.query_filter(record_type.lower())
 
-        results = self.service.getResourceRecords(
-            id=zone_id,
-            mask='id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson',
-            filter=_filter.to_dict(),
-        )
-
+        objectMask = 'id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson'
+        results = self.client.call('SoftLayer_Dns_Domain', 'getResourceRecords', id=zone_id,
+                                    mask=objectMask, filter=_filter.to_dict(), iter=True)
         return results
 
     def edit_record(self, record):

--- a/SoftLayer/managers/dns.py
+++ b/SoftLayer/managers/dns.py
@@ -209,9 +209,9 @@ class DNSManager(utils.IdentifierMixin, object):
         if record_type:
             _filter['resourceRecords']['type'] = utils.query_filter(record_type.lower())
 
-        objectMask = 'id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson'
+        object_mask = 'id,expire,domainId,host,minimum,refresh,retry,mxPriority,ttl,type,data,responsiblePerson'
         results = self.client.call('SoftLayer_Dns_Domain', 'getResourceRecords', id=zone_id,
-                                    mask=objectMask, filter=_filter.to_dict(), iter=True)
+                                   mask=object_mask, filter=_filter.to_dict(), iter=True)
         return results
 
     def edit_record(self, record):

--- a/tests/CLI/modules/dns_tests.py
+++ b/tests/CLI/modules/dns_tests.py
@@ -6,6 +6,7 @@
 """
 import json
 import os.path
+import sys
 
 import mock
 
@@ -281,6 +282,7 @@ spf  IN TXT "v=spf1 ip4:192.0.2.0/24 ip4:198.51.100.123 a"
         self.assertEqual(actual_output['record'], '')
 
     def test_list_zones_no_update(self):
+        pyversion = sys.version_info
         fake_zones = [
             {
                 'name': 'example.com',
@@ -294,4 +296,7 @@ spf  IN TXT "v=spf1 ip4:192.0.2.0/24 ip4:198.51.100.123 a"
 
         self.assert_no_fail(result)
         actual_output = json.loads(result.output)
-        self.assertEqual(actual_output[0]['updated'], '2014-03-07 00:00')
+        if pyversion.major >= 3 and pyversion.minor >= 7:
+            self.assertEqual(actual_output[0]['updated'], '2014-03-07 00:00')
+        else:
+            self.assertEqual(actual_output[0]['updated'], '2014-03-07T00:00:00-06:00')

--- a/tests/CLI/modules/dns_tests.py
+++ b/tests/CLI/modules/dns_tests.py
@@ -54,11 +54,8 @@ class DnsTests(testing.TestCase):
         result = self.run_command(['dns', 'zone-list'])
 
         self.assert_no_fail(result)
-        self.assertEqual(json.loads(result.output),
-                         [{'serial': 2014030728,
-                           'updated': '2014-03-07T13:52:31-06:00',
-                           'id': 12345,
-                           'zone': 'example.com'}])
+        actual_output = json.loads(result.output)
+        self.assertEqual(actual_output[0]['zone'], 'example.com')
 
     def test_list_records(self):
         result = self.run_command(['dns', 'record-list', '1234'])
@@ -261,3 +258,24 @@ spf  IN TXT "v=spf1 ip4:192.0.2.0/24 ip4:198.51.100.123 a"
             self.assertEqual(call.args[0], expected_call)
 
         self.assertIn("Finished", result.output)
+
+    def test_issues_999(self):
+        """Makes sure certain zones with a None host record are pritable"""
+
+        # SRV records can have a None `host` record, or just a plain missing one.
+        fake_records = [
+            {
+                'data': '1.2.3.4',
+                'id': 137416416,
+                'ttl': 900,
+                'type': 'srv'
+            }
+        ]
+        record_mock = self.set_mock('SoftLayer_Dns_Domain', 'getResourceRecords')
+        record_mock.return_value = fake_records
+        result = self.run_command(['dns', 'record-list', '1234'])
+
+        self.assert_no_fail(result)
+        actual_output = json.loads(result.output)[0]
+        self.assertEqual(actual_output['id'], 137416416)
+        self.assertEqual(actual_output['record'], '')

--- a/tests/CLI/modules/dns_tests.py
+++ b/tests/CLI/modules/dns_tests.py
@@ -279,3 +279,19 @@ spf  IN TXT "v=spf1 ip4:192.0.2.0/24 ip4:198.51.100.123 a"
         actual_output = json.loads(result.output)[0]
         self.assertEqual(actual_output['id'], 137416416)
         self.assertEqual(actual_output['record'], '')
+
+    def test_list_zones_no_update(self):
+        fake_zones = [
+            {
+                'name': 'example.com',
+                'id': 12345,
+                'serial': 2014030728,
+                'updateDate': None}
+        ]
+        domains_mock = self.set_mock('SoftLayer_Account', 'getDomains')
+        domains_mock.return_value = fake_zones
+        result = self.run_command(['dns', 'zone-list'])
+
+        self.assert_no_fail(result)
+        actual_output = json.loads(result.output)
+        self.assertEqual(actual_output[0]['updated'], '2014-03-07 00:00')

--- a/tests/managers/dns_tests.py
+++ b/tests/managers/dns_tests.py
@@ -25,24 +25,19 @@ class DNSTests(testing.TestCase):
         res = self.dns_client.get_zone(12345)
 
         self.assertEqual(res, fixtures.SoftLayer_Dns_Domain.getObject)
-        self.assert_called_with('SoftLayer_Dns_Domain', 'getObject',
-                                identifier=12345,
-                                mask='mask[resourceRecords]')
+        self.assert_called_with('SoftLayer_Dns_Domain', 'getObject', identifier=12345, mask='mask[resourceRecords]')
 
     def test_get_zone_without_records(self):
         self.dns_client.get_zone(12345, records=False)
 
-        self.assert_called_with('SoftLayer_Dns_Domain', 'getObject',
-                                identifier=12345,
-                                mask=None)
+        self.assert_called_with('SoftLayer_Dns_Domain', 'getObject', identifier=12345, mask=None)
 
     def test_resolve_zone_name(self):
         res = self.dns_client._get_zone_id_from_name('example.com')
 
         self.assertEqual([12345], res)
         _filter = {"domains": {"name": {"operation": "_= example.com"}}}
-        self.assert_called_with('SoftLayer_Account', 'getDomains',
-                                filter=_filter)
+        self.assert_called_with('SoftLayer_Account', 'getDomains', filter=_filter)
 
     def test_resolve_zone_name_no_matches(self):
         mock = self.set_mock('SoftLayer_Account', 'getDomains')
@@ -52,8 +47,7 @@ class DNSTests(testing.TestCase):
 
         self.assertEqual([], res)
         _filter = {"domains": {"name": {"operation": "_= example.com"}}}
-        self.assert_called_with('SoftLayer_Account', 'getDomains',
-                                filter=_filter)
+        self.assert_called_with('SoftLayer_Account', 'getDomains', filter=_filter)
 
     def test_create_zone(self):
         res = self.dns_client.create_zone('example.com', serial='2014110201')
@@ -61,27 +55,22 @@ class DNSTests(testing.TestCase):
         args = ({'serial': '2014110201',
                  'name': 'example.com',
                  'resourceRecords': {}},)
-        self.assert_called_with('SoftLayer_Dns_Domain', 'createObject',
-                                args=args)
+        self.assert_called_with('SoftLayer_Dns_Domain', 'createObject', args=args)
         self.assertEqual(res, {'name': 'example.com'})
 
     def test_delete_zone(self):
         self.dns_client.delete_zone(1)
-        self.assert_called_with('SoftLayer_Dns_Domain', 'deleteObject',
-                                identifier=1)
+        self.assert_called_with('SoftLayer_Dns_Domain', 'deleteObject', identifier=1)
 
     def test_edit_zone(self):
         self.dns_client.edit_zone('example.com')
 
-        self.assert_called_with('SoftLayer_Dns_Domain', 'editObject',
-                                args=('example.com',))
+        self.assert_called_with('SoftLayer_Dns_Domain', 'editObject', args=('example.com',))
 
     def test_create_record(self):
-        res = self.dns_client.create_record(1, 'test', 'TXT', 'testing',
-                                            ttl=1200)
+        res = self.dns_client.create_record(1, 'test', 'TXT', 'testing', ttl=1200)
 
-        self.assert_called_with('SoftLayer_Dns_Domain_ResourceRecord',
-                                'createObject',
+        self.assert_called_with('SoftLayer_Dns_Domain_ResourceRecord', 'createObject',
                                 args=({
                                     'domainId': 1,
                                     'ttl': 1200,
@@ -94,8 +83,7 @@ class DNSTests(testing.TestCase):
     def test_create_record_mx(self):
         res = self.dns_client.create_record_mx(1, 'test', 'testing', ttl=1200, priority=21)
 
-        self.assert_called_with('SoftLayer_Dns_Domain_ResourceRecord',
-                                'createObject',
+        self.assert_called_with('SoftLayer_Dns_Domain_ResourceRecord', 'createObject',
                                 args=({
                                     'domainId': 1,
                                     'ttl': 1200,
@@ -110,8 +98,7 @@ class DNSTests(testing.TestCase):
         res = self.dns_client.create_record_srv(1, 'record', 'test_data', 'SLS', 8080, 'foobar',
                                                 ttl=1200, priority=21, weight=15)
 
-        self.assert_called_with('SoftLayer_Dns_Domain_ResourceRecord',
-                                'createObject',
+        self.assert_called_with('SoftLayer_Dns_Domain_ResourceRecord', 'createObject',
                                 args=({
                                     'complexType': 'SoftLayer_Dns_Domain_ResourceRecord_SrvType',
                                     'domainId': 1,
@@ -130,14 +117,8 @@ class DNSTests(testing.TestCase):
     def test_create_record_ptr(self):
         res = self.dns_client.create_record_ptr('test', 'testing', ttl=1200)
 
-        self.assert_called_with('SoftLayer_Dns_Domain_ResourceRecord',
-                                'createObject',
-                                args=({
-                                    'ttl': 1200,
-                                    'host': 'test',
-                                    'type': 'PTR',
-                                    'data': 'testing'
-                                },))
+        self.assert_called_with('SoftLayer_Dns_Domain_ResourceRecord', 'createObject',
+                                args=({'ttl': 1200, 'host': 'test', 'type': 'PTR', 'data': 'testing'},))
         self.assertEqual(res, {'name': 'example.com'})
 
     def test_generate_create_dict(self):
@@ -161,27 +142,21 @@ class DNSTests(testing.TestCase):
     def test_delete_record(self):
         self.dns_client.delete_record(1)
 
-        self.assert_called_with('SoftLayer_Dns_Domain_ResourceRecord',
-                                'deleteObject',
-                                identifier=1)
+        self.assert_called_with('SoftLayer_Dns_Domain_ResourceRecord', 'deleteObject', identifier=1)
 
     def test_edit_record(self):
         self.dns_client.edit_record({'id': 1, 'name': 'test', 'ttl': '1800'})
 
-        self.assert_called_with('SoftLayer_Dns_Domain_ResourceRecord',
-                                'editObject',
-                                args=({'id': 1,
-                                       'name': 'test',
-                                       'ttl': '1800'},),
+        self.assert_called_with('SoftLayer_Dns_Domain_ResourceRecord', 'editObject',
+                                args=({'id': 1, 'name': 'test', 'ttl': '1800'},),
                                 identifier=1)
 
     def test_dump_zone(self):
         self.dns_client.dump_zone(1)
 
-        self.assert_called_with('SoftLayer_Dns_Domain', 'getZoneFileContents',
-                                identifier=1)
+        self.assert_called_with('SoftLayer_Dns_Domain', 'getZoneFileContents', identifier=1)
 
-    def test_get_record(self):
+    def test_get_records(self):
         # maybe valid domain, but no records matching
         mock = self.set_mock('SoftLayer_Dns_Domain', 'getResourceRecords')
         mock.return_value = []
@@ -190,11 +165,7 @@ class DNSTests(testing.TestCase):
         mock.reset_mock()
         records = fixtures.SoftLayer_Dns_Domain.getResourceRecords
         mock.return_value = [records[0]]
-        self.dns_client.get_records(12345,
-                                    record_type='a',
-                                    host='hostname',
-                                    data='a',
-                                    ttl='86400')
+        self.dns_client.get_records(12345, record_type='a', host='hostname', data='a', ttl='86400')
 
         _filter = {'resourceRecords': {'type': {'operation': '_= a'},
                                        'host': {'operation': '_= hostname'},
@@ -203,3 +174,9 @@ class DNSTests(testing.TestCase):
         self.assert_called_with('SoftLayer_Dns_Domain', 'getResourceRecords',
                                 identifier=12345,
                                 filter=_filter)
+
+    def test_get_record(self):
+        record_id = 1234
+        record = self.dns_client.get_record(record_id)
+        self.assertEqual(record['id'], 12345)
+        self.assert_called_with('SoftLayer_Dns_Domain_ResourceRecord', 'getObject', identifier=record_id)


### PR DESCRIPTION
- dns zone-list: added resourceRecordCount, added automatic pagination for large zones
- dns record-list: fixed an issue where a record (like SRV types) that don't have a `host` would cause the command to fail