### PR TITLE
v5.9.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [5.9.1] - 2020-09-15
+https://github.com/softlayer/softlayer-python/compare/v5.9.0...v5.9.1
+
+- Fix the ha option for firewalls, add and implement unit test #1327
+- BluePages_Search and IntegratedOfferingTeam_Region don't need SoftLayer_ prefix #972
+- Fix new TOX issues #1330
+- Add more unit test coverage #1331
+- Set notes for network storage #1322
+- Some improvements to the dns commands #999
+  + dns zone-list: added resourceRecordCount, added automatic pagination for large zones
+  + dns record-list: fixed an issue where a record (like SRV types) that don't have a host would cause the command to fail
+- Renamed managers.storage.refresh_dep_dupe to  SoftLayer.managers.storage.refresh_dupe #1342 to support the new API method. CLI commands now use this method.
+
 ## [5.9.0] - 2020-08-03
 https://github.com/softlayer/softlayer-python/compare/v5.8.9...v5.9.0
 

--- a/SoftLayer/consts.py
+++ b/SoftLayer/consts.py
@@ -5,7 +5,7 @@
 
     :license: MIT, see LICENSE for more details.
 """
-VERSION = 'v5.9.0'
+VERSION = 'v5.9.1'
 API_PUBLIC_ENDPOINT = 'https://api.softlayer.com/xmlrpc/v3.1/'
 API_PRIVATE_ENDPOINT = 'https://api.service.softlayer.com/xmlrpc/v3.1/'
 API_PUBLIC_ENDPOINT_REST = 'https://api.softlayer.com/rest/v3.1/'

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ else:
 
 setup(
     name='SoftLayer',
-    version='5.9.0',
+    version='5.9.1',
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     author='SoftLayer Technologies, Inc.',


### PR DESCRIPTION
## [5.9.1] - 2020-09-15
https://github.com/softlayer/softlayer-python/compare/v5.9.0...v5.9.1

- Fix the ha option for firewalls, add and implement unit test #1327
- BluePages_Search and IntegratedOfferingTeam_Region don't need SoftLayer_ prefix #972
- Fix new TOX issues #1330
- Add more unit test coverage #1331
- Set notes for network storage #1322
- Some improvements to the dns commands #999
  + dns zone-list: added resourceRecordCount, added automatic pagination for large zones
  + dns record-list: fixed an issue where a record (like SRV types) that don't have a host would cause the command to fail
- Renamed managers.storage.refresh_dep_dupe to  SoftLayer.managers.storage.refresh_dupe #1342 to support the new API method. CLI commands now use this method.