### PR TITLE
Fix the registration subnet detail to use the subnet id to look up a subnets registration.

### DIFF
--- a/SoftLayer/CLI/registration/subnet_detail.py
+++ b/SoftLayer/CLI/registration/subnet_detail.py
@@ -5,6 +5,7 @@ import click
 
 from SoftLayer.CLI import environment
 from SoftLayer.CLI import formatting
+from SoftLayer.CLI import exceptions
 from SoftLayer.managers.registration import RegistrationManager
 
 
@@ -16,6 +17,11 @@ def cli(env, identifier):
 
     env.registerClient = RegistrationManager(env.client)
     registration = env.registerClient.detail(identifier)
+
+    if not registration:
+        raise exceptions.CLIAbort(
+            'No Active Registration found for this Subnet'
+        )
 
     table = formatting.KeyValueTable(['name', 'value'])
     table.align['name'] = 'r'

--- a/SoftLayer/CLI/registration/subnet_detail.py
+++ b/SoftLayer/CLI/registration/subnet_detail.py
@@ -4,8 +4,8 @@
 import click
 
 from SoftLayer.CLI import environment
-from SoftLayer.CLI import formatting
 from SoftLayer.CLI import exceptions
+from SoftLayer.CLI import formatting
 from SoftLayer.managers.registration import RegistrationManager
 
 

--- a/SoftLayer/fixtures/SoftLayer_Network_Subnet.py
+++ b/SoftLayer/fixtures/SoftLayer_Network_Subnet.py
@@ -41,6 +41,17 @@ getObject = {
          'ipAddress': '16.26.26.26'}]
 }
 
+getActiveRegistration = {
+    "accountId": 307213,
+    "createDate": "2020-12-02T14:35:57-06:00",
+    "id": 1926123,
+    "statusId": 3,
+    "status": {
+        "id": 3,
+        "keyName": "REGISTRATION_COMPLETE",
+    }
+}
+
 editNote = True
 setTags = True
 cancel = True

--- a/SoftLayer/managers/registration.py
+++ b/SoftLayer/managers/registration.py
@@ -17,6 +17,7 @@ class RegistrationManager(object):
     def __init__(self, client):
         self.client = client
         self.account = client['Account']
+        self.subnet = client['SoftLayer_Network_Subnet']
         self.registration = self.client['Network_Subnet_Registration']
         self.person_type_id = 3  # a person has a detailTypeId == 3
         self.regional_register = self.client['Account_Regional_Registry_Detail']
@@ -26,9 +27,12 @@ class RegistrationManager(object):
 
         :return: subnet registration object
         """
-
         mask = 'account,personDetail,networkDetail'
-        return self.registration.getObject(mask=mask, id=identifier)
+        registration = self.subnet.getActiveRegistration(id=identifier)
+
+        if registration:
+            return self.registration.getObject(mask=mask, id=registration['id'])
+        return None
 
     def get_registration_detail_object(self, identifier, mask=None):
         """Calls SoftLayer_Account_Regional_Registry_Detail::getObject()

--- a/tests/managers/registration_tests.py
+++ b/tests/managers/registration_tests.py
@@ -19,7 +19,7 @@ class RegistrationTests(testing.TestCase):
     def test_detail(self):
         result = self.registration_mgr.detail(1536487)
         self.assertEqual(result['id'], 1536487)
-        self.assert_called_with('SoftLayer_Network_Subnet_Registration', 'getObject', identifier=1536487)
+        self.assert_called_with('SoftLayer_Network_Subnet', 'getActiveRegistration', identifier=1536487)
 
     def test_get_registration_detail_object(self):
         result = self.registration_mgr.get_registration_detail_object(51990)
@@ -47,8 +47,8 @@ class RegistrationTests(testing.TestCase):
     def test_get_detail(self):
         identifier = 12345
         self.registration_mgr.detail(identifier)
-        self.assert_called_with('SoftLayer_Network_Subnet_Registration',
-                                'getObject', identifier=identifier)
+        self.assert_called_with('SoftLayer_Network_Subnet',
+                                'getActiveRegistration', identifier=identifier)
 
     def test_get_contact_properties(self):
         identifier = 12345


### PR DESCRIPTION
Fix the registration subnet detail to use the subnet id to look up a subnets registration https://github.com/softlayer/softlayer-python/issues/1386.