### PR TITLE
Add the option network component by router to slcli hw create.

### DIFF
--- a/SoftLayer/CLI/hardware/create.py
+++ b/SoftLayer/CLI/hardware/create.py
@@ -31,6 +31,10 @@ from SoftLayer.CLI import template
               help="Exports options to a template file")
 @click.option('--wait', type=click.INT,
               help="Wait until the server is finished provisioning for up to X seconds before returning")
+@click.option('--router-public', type=click.INT,
+              help="The ID of the public ROUTER on which you want the virtual server placed")
+@click.option('--router-private', type=click.INT,
+              help="The ID of the private ROUTER on which you want the virtual server placed")
 @helpers.multi_option('--key', '-k', help="SSH keys to add to the root user")
 @helpers.multi_option('--extra', '-e', help="Extra option Key Names")
 @environment.pass_env
@@ -57,7 +61,9 @@ def cli(env, **args):
         'port_speed': args.get('port_speed'),
         'no_public': args.get('no_public') or False,
         'extras': args.get('extra'),
-        'network': args.get('network')
+        'network': args.get('network'),
+        'public_router': args.get('router_public', None),
+        'private_router': args.get('router_private', None)
     }
 
     # Do not create hardware server with --test or --export

--- a/SoftLayer/managers/hardware.py
+++ b/SoftLayer/managers/hardware.py
@@ -492,7 +492,9 @@ class HardwareManager(utils.IdentifierMixin, object):
                               hourly=True,
                               no_public=False,
                               extras=None,
-                              network=None):
+                              network=None,
+                              public_router=None,
+                              private_router=None):
         """Translates arguments into a dictionary for creating a server."""
 
         extras = extras or []
@@ -535,6 +537,10 @@ class HardwareManager(utils.IdentifierMixin, object):
                 'domain': domain,
             }]
         }
+        if private_router:
+            extras['hardware'][0]['primaryBackendNetworkComponent'] = {"router": {"id": int(private_router)}}
+        if public_router:
+            extras['hardware'][0]['primaryNetworkComponent'] = {"router": {"id": int(public_router)}}
         if post_uri:
             extras['provisionScripts'] = [post_uri]
 

--- a/tests/CLI/modules/server_tests.py
+++ b/tests/CLI/modules/server_tests.py
@@ -418,6 +418,26 @@ class ServerCLITests(testing.TestCase):
         self.assertIn("Successfully exported options to a template file.", result.output)
         export_mock.assert_called_once()
 
+    @mock.patch('SoftLayer.HardwareManager.place_order')
+    def test_create_server_with_router(self, order_mock):
+        order_mock.return_value = {
+            'orderId': 98765,
+            'orderDate': '2013-08-02 15:23:47'
+        }
+
+        result = self.run_command(['--really', 'server', 'create',
+                                   '--size=S1270_8GB_2X1TBSATA_NORAID',
+                                   '--hostname=test',
+                                   '--domain=example.com',
+                                   '--datacenter=TEST00',
+                                   '--port-speed=100',
+                                   '--os=OS_UBUNTU_14_04_LTS_TRUSTY_TAHR_64_BIT',
+                                   '--router-private=123',
+                                   '--router-public=1234'
+                                   ])
+
+        self.assert_no_fail(result)
+
     def test_edit_server_userdata_and_file(self):
         # Test both userdata and userfile at once
         with tempfile.NamedTemporaryFile() as userfile:

--- a/tests/managers/hardware_tests.py
+++ b/tests/managers/hardware_tests.py
@@ -318,6 +318,52 @@ class HardwareTests(testing.TestCase):
             'port_speed': 10,
             'hourly': True,
             'extras': ['1_IPV6_ADDRESS'],
+            'post_uri': 'http://example.com/script.php',
+            'ssh_keys': [10],
+        }
+
+        package = 'BARE_METAL_SERVER'
+        location = 'wdc07'
+        item_keynames = [
+            '1_IP_ADDRESS',
+            'UNLIMITED_SSL_VPN_USERS_1_PPTP_VPN_USER_PER_ACCOUNT',
+            'REBOOT_KVM_OVER_IP',
+            'OS_UBUNTU_14_04_LTS_TRUSTY_TAHR_64_BIT',
+            'BANDWIDTH_0_GB_2',
+            '10_MBPS_PUBLIC_PRIVATE_NETWORK_UPLINKS',
+            '1_IPV6_ADDRESS'
+        ]
+        hourly = True
+        preset_keyname = 'S1270_8GB_2X1TBSATA_NORAID'
+        extras = {
+            'hardware': [{
+                'domain': 'giggles.woo',
+                'hostname': 'unicorn',
+            }],
+            'provisionScripts': ['http://example.com/script.php'],
+            'sshKeys': [{'sshKeyIds': [10]}]
+        }
+
+        data = self.hardware._generate_create_dict(**args)
+
+        self.assertEqual(package, data['package_keyname'])
+        self.assertEqual(location, data['location'])
+        for keyname in item_keynames:
+            self.assertIn(keyname, data['item_keynames'])
+        self.assertEqual(extras, data['extras'])
+        self.assertEqual(preset_keyname, data['preset_keyname'])
+        self.assertEqual(hourly, data['hourly'])
+
+    def test_generate_create_dict_by_router_network_component(self):
+        args = {
+            'size': 'S1270_8GB_2X1TBSATA_NORAID',
+            'hostname': 'unicorn',
+            'domain': 'giggles.woo',
+            'location': 'wdc07',
+            'os': 'OS_UBUNTU_14_04_LTS_TRUSTY_TAHR_64_BIT',
+            'port_speed': 10,
+            'hourly': True,
+            'extras': ['1_IPV6_ADDRESS'],
             'public_router': 1111,
             'private_router': 1234
         }

--- a/tests/managers/hardware_tests.py
+++ b/tests/managers/hardware_tests.py
@@ -318,41 +318,29 @@ class HardwareTests(testing.TestCase):
             'port_speed': 10,
             'hourly': True,
             'extras': ['1_IPV6_ADDRESS'],
-            'post_uri': 'http://example.com/script.php',
-            'ssh_keys': [10],
+            'public_router': 1111,
+            'private_router': 1234
         }
 
-        package = 'BARE_METAL_SERVER'
-        location = 'wdc07'
-        item_keynames = [
-            '1_IP_ADDRESS',
-            'UNLIMITED_SSL_VPN_USERS_1_PPTP_VPN_USER_PER_ACCOUNT',
-            'REBOOT_KVM_OVER_IP',
-            'OS_UBUNTU_14_04_LTS_TRUSTY_TAHR_64_BIT',
-            'BANDWIDTH_0_GB_2',
-            '10_MBPS_PUBLIC_PRIVATE_NETWORK_UPLINKS',
-            '1_IPV6_ADDRESS'
-        ]
-        hourly = True
-        preset_keyname = 'S1270_8GB_2X1TBSATA_NORAID'
         extras = {
             'hardware': [{
                 'domain': 'giggles.woo',
                 'hostname': 'unicorn',
-            }],
-            'provisionScripts': ['http://example.com/script.php'],
-            'sshKeys': [{'sshKeyIds': [10]}]
+                'primaryNetworkComponent': {
+                    "router": {
+                        "id": 1111
+                    }
+                },
+                'primaryBackendNetworkComponent': {
+                    "router": {
+                        "id": 1234
+                    }
+                }
+            }]
         }
 
         data = self.hardware._generate_create_dict(**args)
-
-        self.assertEqual(package, data['package_keyname'])
-        self.assertEqual(location, data['location'])
-        for keyname in item_keynames:
-            self.assertIn(keyname, data['item_keynames'])
         self.assertEqual(extras, data['extras'])
-        self.assertEqual(preset_keyname, data['preset_keyname'])
-        self.assertEqual(hourly, data['hourly'])
 
     def test_generate_create_dict_network_key(self):
         args = {


### PR DESCRIPTION
Add the option network component by router to `slcli hw create` https://github.com/softlayer/softlayer-python/issues/1416.

The `slcli hw create` uses the SoftLayer_Product_Order fast provisioning using the package 200 (BARE_METAL_SERVER) to create the server the same that the ui. Using the package 200 to order the fast provisioning server it seems that this package does not support to add the network component manually for vlan and vlan with subnet by ui and api but it support only by router using only by api.