### PR TITLE
Add testing and support for python 3.9.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,13 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         arch: ['armhf','amd64','arm64','ppc64el','s390x','i386']
     steps:
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v1.1.1
+        uses: samuelmeuli/action-snapcraft@v1.2.0
         with:
           snapcraft_token: ${{ secrets.snapcraft_token }}
       - name: Push to stable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5,3.6,3.7,3.8]
+        python-version: [3.5,3.6,3.7,3.8,3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,7 @@ If you are using the library directly in python, you can do something like this.
 
 System Requirements
 -------------------
-* Python 3.5, 3.6, 3.7, or 3.8.
+* Python 3.5, 3.6, 3.7, 3.8, or 3.9.
 * A valid SoftLayer API username and key.
 * A connection to SoftLayer's private network is required to use
   our private network API endpoints.
@@ -150,6 +150,6 @@ Python Packages
 
 Copyright
 ---------
-This software is Copyright (c) 2016-2019 SoftLayer Technologies, Inc.
+This software is Copyright (c) 2016-2021 SoftLayer Technologies, Inc.
 
 See the bundled LICENSE file for more information.

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/tests/CLI/modules/user_tests.py
+++ b/tests/CLI/modules/user_tests.py
@@ -6,6 +6,7 @@
 """
 import json
 import sys
+import unittest
 
 import mock
 
@@ -167,12 +168,10 @@ class UserCLITests(testing.TestCase):
         result = self.run_command(['user', 'create', 'test', '-e', 'test@us.ibm.com', '-p', 'testword'])
         self.assertEqual(result.exit_code, 2)
 
+    @unittest.SkipIf(sys.version_info < (3, 6), "Secrets module only exists in version 3.6+")
     @mock.patch('secrets.choice')
     @mock.patch('SoftLayer.CLI.formatting.confirm')
     def test_create_user_generate_password_36(self, confirm_mock, secrets):
-        if sys.version_info < (3, 6):
-            self.skipTest("Secrets module only exists in version 3.6+")
-
         secrets.return_value = 'Q'
         confirm_mock.return_value = True
         result = self.run_command(['user', 'create', 'test', '-e', 'test@us.ibm.com', '-p', 'generate'])

--- a/tests/CLI/modules/user_tests.py
+++ b/tests/CLI/modules/user_tests.py
@@ -168,7 +168,7 @@ class UserCLITests(testing.TestCase):
         result = self.run_command(['user', 'create', 'test', '-e', 'test@us.ibm.com', '-p', 'testword'])
         self.assertEqual(result.exit_code, 2)
 
-    @unittest.SkipIf(sys.version_info < (3, 6), "Secrets module only exists in version 3.6+")
+    @unittest.skipIf(sys.version_info < (3, 6), "Secrets module only exists in version 3.6+")
     @mock.patch('secrets.choice')
     @mock.patch('SoftLayer.CLI.formatting.confirm')
     def test_create_user_generate_password_36(self, confirm_mock, secrets):

--- a/tests/CLI/modules/user_tests.py
+++ b/tests/CLI/modules/user_tests.py
@@ -8,7 +8,6 @@ import json
 import sys
 
 import mock
-import testtools
 
 from SoftLayer import testing
 
@@ -168,10 +167,12 @@ class UserCLITests(testing.TestCase):
         result = self.run_command(['user', 'create', 'test', '-e', 'test@us.ibm.com', '-p', 'testword'])
         self.assertEqual(result.exit_code, 2)
 
-    @testtools.skipIf(sys.version_info < (3, 6), "Secrets module only exists in version 3.6+")
     @mock.patch('secrets.choice')
     @mock.patch('SoftLayer.CLI.formatting.confirm')
     def test_create_user_generate_password_36(self, confirm_mock, secrets):
+        if sys.version_info < (3, 6):
+            self.skipTest("Secrets module only exists in version 3.6+")
+
         secrets.return_value = 'Q'
         confirm_mock.return_value = True
         result = self.run_command(['user', 'create', 'test', '-e', 'test@us.ibm.com', '-p', 'generate'])

--- a/tools/test-requirements.txt
+++ b/tools/test-requirements.txt
@@ -4,7 +4,6 @@ pytest
 pytest-cov
 mock
 sphinx
-testtools
 ptable >= 0.9.2
 click >= 7
 requests >= 2.20.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,pypy3,analysis,coverage,docs
+envlist = py35,py36,py37,py38,py39,pypy3,analysis,coverage,docs
 
 
 [flake8]


### PR DESCRIPTION
Remove testtools as a test dependency. It's not used except for a
version skip that is easy to replace. testtools still relies on
unittest2, a python 2-ism that generates warnings in python 3.9.

Fix the snapcraft release by updating to a newer snapcraft action
that fixes the 'add-path' error.

Fixes #1392 