### PR TITLE
Fixes shift+ins when pasteing into a password field for windows users.

### DIFF
--- a/SoftLayer/CLI/environment.py
+++ b/SoftLayer/CLI/environment.py
@@ -67,7 +67,22 @@ class Environment(object):
 
     def getpass(self, prompt, default=None):
         """Provide a password prompt."""
-        return click.prompt(prompt, hide_input=True, default=default)
+        password = click.prompt(prompt, hide_input=True, default=default)
+
+        # https://github.com/softlayer/softlayer-python/issues/1436
+        # click.prompt uses python's getpass() in the background
+        # https://github.com/python/cpython/blob/3.9/Lib/getpass.py#L97
+        # In windows, shift+insert actually inputs the below 2 characters
+        # If we detect those 2 characters, need to manually read from the clipbaord instead
+        # https://stackoverflow.com/questions/101128/how-do-i-read-text-from-the-clipboard
+        if password == 'àR':
+            # tkinter is a built in python gui, but it has clipboard reading functions.
+            from tkinter import Tk
+            tk_manager = Tk()
+            password = tk_manager.clipboard_get()
+            # keep the window from showing
+            tk_manager.withdraw()
+        return password
 
     # Command loading methods
     def list_commands(self, *path):

--- a/SoftLayer/CLI/environment.py
+++ b/SoftLayer/CLI/environment.py
@@ -77,6 +77,7 @@ class Environment(object):
         # https://stackoverflow.com/questions/101128/how-do-i-read-text-from-the-clipboard
         if password == 'àR':
             # tkinter is a built in python gui, but it has clipboard reading functions.
+            # pylint: disable=import-outside-toplevel
             from tkinter import Tk
             tk_manager = Tk()
             password = tk_manager.clipboard_get()

--- a/tests/CLI/environment_tests.py
+++ b/tests/CLI/environment_tests.py
@@ -7,6 +7,7 @@
 
 import click
 import mock
+# from unittest.mock import MagicMock
 
 from SoftLayer.CLI import environment
 from SoftLayer import testing
@@ -56,13 +57,13 @@ class EnvironmentTests(testing.TestCase):
         self.assertEqual(prompt_mock(), r)
 
     @mock.patch('click.prompt')
-    @mock.patch('tkinter.Tk.clipboard_get')
+    @mock.patch('tkinter.Tk')
     def test_getpass_issues1436(self, tk, prompt_mock):
-        tk.return_value = 'test_from_clipboard'
         prompt_mock.return_value = 'àR'
         r = self.env.getpass('input')
         prompt_mock.assert_called_with('input', default=None, hide_input=True)
-        self.assertEqual('test_from_clipboard', r)
+        tk.assert_called_with()
+
 
     def test_resolve_alias(self):
         self.env.aliases = {'aliasname': 'realname'}

--- a/tests/CLI/environment_tests.py
+++ b/tests/CLI/environment_tests.py
@@ -60,10 +60,9 @@ class EnvironmentTests(testing.TestCase):
     @mock.patch('tkinter.Tk')
     def test_getpass_issues1436(self, tk, prompt_mock):
         prompt_mock.return_value = 'àR'
-        r = self.env.getpass('input')
+        self.env.getpass('input')
         prompt_mock.assert_called_with('input', default=None, hide_input=True)
         tk.assert_called_with()
-
 
     def test_resolve_alias(self):
         self.env.aliases = {'aliasname': 'realname'}

--- a/tests/CLI/environment_tests.py
+++ b/tests/CLI/environment_tests.py
@@ -55,6 +55,15 @@ class EnvironmentTests(testing.TestCase):
         prompt_mock.assert_called_with('input', default=None, hide_input=True)
         self.assertEqual(prompt_mock(), r)
 
+    @mock.patch('click.prompt')
+    @mock.patch('tkinter.Tk.clipboard_get')
+    def test_getpass_issues1436(self, tk, prompt_mock):
+        tk.return_value = 'test_from_clipboard'
+        prompt_mock.return_value = 'àR'
+        r = self.env.getpass('input')
+        prompt_mock.assert_called_with('input', default=None, hide_input=True)
+        self.assertEqual('test_from_clipboard', r)
+
     def test_resolve_alias(self):
         self.env.aliases = {'aliasname': 'realname'}
         r = self.env.resolve_alias('aliasname')


### PR DESCRIPTION
Fixes #1436

`getpass()` is only ever called in `slcli config setup`, so that command is the only one that needs to be tested.

The problem specifically is with windows environments (powershell and cmd.exe) and shift+insert. When inputting a password, the user should be able to use shift+insert to paste their API key/password. Previously, shift+insert would put the character sequence `àR`, so this fix looks for that sequence, then reads from the clipboard. 

Shift+insert works just fine with `input()`, its only when the text is hidden does this problem occur. 