### PR TITLE
Added a utility to merge objectFilters, 

### DIFF
--- a/SoftLayer/utils.py
+++ b/SoftLayer/utils.py
@@ -67,7 +67,7 @@ def dict_merge(dct1, dct2):
     """
 
     dct = dct1.copy()
-    for k, v in dct2.items():
+    for k, _ in dct2.items():
         if (k in dct1 and isinstance(dct1[k], dict) and isinstance(dct2[k], collections.Mapping)):
             dct[k] = dict_merge(dct1[k], dct2[k])
         else:

--- a/SoftLayer/utils.py
+++ b/SoftLayer/utils.py
@@ -5,6 +5,7 @@
 
     :license: MIT, see LICENSE for more details.
 """
+import collections
 import datetime
 import re
 import time
@@ -55,6 +56,21 @@ class NestedDict(dict):
         """
         return {key: val.to_dict() if isinstance(val, NestedDict) else val
                 for key, val in self.items()}
+
+
+def dict_merge(dct1, dct2):
+    """Recursively merges dct2 into dct1, ideal for merging objectFilter together.
+
+    :param dct1: dict onto which the merge is executed
+    :param dct2: dct merged into dct
+    :return: None
+    """
+
+    for k, v in dct2.items():
+        if (k in dct1 and isinstance(dct1[k], dict) and isinstance(dct2[k], collections.Mapping)):
+            dict_merge(dct1[k], dct2[k])
+        else:
+            dct1[k] = dct2[k]
 
 
 def query_filter(query):

--- a/SoftLayer/utils.py
+++ b/SoftLayer/utils.py
@@ -59,18 +59,20 @@ class NestedDict(dict):
 
 
 def dict_merge(dct1, dct2):
-    """Recursively merges dct2 into dct1, ideal for merging objectFilter together.
+    """Recursively merges dct2 and dct1, ideal for merging objectFilter together.
 
-    :param dct1: dict onto which the merge is executed
-    :param dct2: dct merged into dct
-    :return: None
+    :param dct1: A dictionary
+    :param dct2: A dictionary
+    :return: dct1 + dct2
     """
 
+    dct = dct1.copy()
     for k, v in dct2.items():
         if (k in dct1 and isinstance(dct1[k], dict) and isinstance(dct2[k], collections.Mapping)):
-            dict_merge(dct1[k], dct2[k])
+            dct[k] = dict_merge(dct1[k], dct2[k])
         else:
-            dct1[k] = dct2[k]
+            dct[k] = dct2[k]
+    return dct
 
 
 def query_filter(query):

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -79,6 +79,16 @@ class TestUtils(testing.TestCase):
         self.assertEqual(datetime.timedelta(0), time.dst())
         self.assertEqual(datetime.timedelta(0), time.utcoffset())
 
+    def test_dict_merge(self):
+        filter1 = {"virtualGuests":{"hostname":{"operation":"etst"}}}
+        filter2 = {"virtualGuests":{"id":{"operation":"orderBy","options":[{"name":"sort","value":["DESC"]}]}}}
+        SoftLayer.utils.dict_merge(filter1, filter2)
+
+        self.assertEqual(filter1['virtualGuests']['id']['operation'], 'orderBy')
+        self.assertEqual(filter1['virtualGuests']['hostname']['operation'], 'etst')
+
+
+
 
 class TestNestedDict(testing.TestCase):
 

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -82,10 +82,11 @@ class TestUtils(testing.TestCase):
     def test_dict_merge(self):
         filter1 = {"virtualGuests":{"hostname":{"operation":"etst"}}}
         filter2 = {"virtualGuests":{"id":{"operation":"orderBy","options":[{"name":"sort","value":["DESC"]}]}}}
-        SoftLayer.utils.dict_merge(filter1, filter2)
+        result = SoftLayer.utils.dict_merge(filter1, filter2)
 
-        self.assertEqual(filter1['virtualGuests']['id']['operation'], 'orderBy')
-        self.assertEqual(filter1['virtualGuests']['hostname']['operation'], 'etst')
+        self.assertEqual(result['virtualGuests']['id']['operation'], 'orderBy')
+        self.assertNotIn('id', filter1['virtualGuests'])
+        self.assertEqual(result['virtualGuests']['hostname']['operation'], 'etst')
 
 
 

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -80,15 +80,13 @@ class TestUtils(testing.TestCase):
         self.assertEqual(datetime.timedelta(0), time.utcoffset())
 
     def test_dict_merge(self):
-        filter1 = {"virtualGuests":{"hostname":{"operation":"etst"}}}
-        filter2 = {"virtualGuests":{"id":{"operation":"orderBy","options":[{"name":"sort","value":["DESC"]}]}}}
+        filter1 = {"virtualGuests": {"hostname": {"operation": "etst"}}}
+        filter2 = {"virtualGuests": {"id": {"operation": "orderBy", "options": [{"name": "sort", "value": ["DESC"]}]}}}
         result = SoftLayer.utils.dict_merge(filter1, filter2)
 
         self.assertEqual(result['virtualGuests']['id']['operation'], 'orderBy')
         self.assertNotIn('id', filter1['virtualGuests'])
         self.assertEqual(result['virtualGuests']['hostname']['operation'], 'etst')
-
-
 
 
 class TestNestedDict(testing.TestCase):


### PR DESCRIPTION
Borrowed from https://gist.github.com/angstwad/bf22d1822c38a92ec0a9 mostly.

`SoftLayer.utils.dict_merge(filter1, filter2)` will now merge filter2 and filter1, returning a new filter

```python 
filter1 = {"virtualGuests":{"hostname":{"operation":"etst"}}}
filter2 = {"virtualGuests":{"id":{"operation":"orderBy","options":[{"name":"sort","value":["DESC"]}]}}}
result = SoftLayer.utils.dict_merge(filter1, filter2)
print(result) # will contain both filter1 and filter2
```

#1459
Fixes  #1461

