### PR TITLE
Fix Incomplete notes field for file and block

### DIFF
--- a/SoftLayer/CLI/environment.py
+++ b/SoftLayer/CLI/environment.py
@@ -52,6 +52,10 @@ class Environment(object):
             fmt = self.format
         return formatting.format_output(output, fmt)
 
+    def format_output_is_json(self):
+        """Return True if format output is json or jsonraw"""
+        return 'json' in self.format
+
     def fout(self, output, newline=True):
         """Format the input and output to the console (stdout)."""
         if output is not None:

--- a/SoftLayer/CLI/file/list.py
+++ b/SoftLayer/CLI/file/list.py
@@ -5,7 +5,7 @@ import click
 import SoftLayer
 from SoftLayer.CLI import columns as column_helper
 from SoftLayer.CLI import environment
-from SoftLayer.CLI import formatting
+from SoftLayer.CLI import storage_utils
 
 COLUMNS = [
     column_helper.Column('id', ('id',), mask="id"),
@@ -76,24 +76,5 @@ def cli(env, sortby, columns, datacenter, username, storage_type, order):
                                                   order=order,
                                                   mask=columns.mask())
 
-    table = formatting.Table(columns.columns)
-    table.sortby = sortby
-
-    _reduce_notes(file_volumes)
-
-    for file_volume in file_volumes:
-        table.add_row([value or formatting.blank()
-                       for value in columns.row(file_volume)])
-
+    table = storage_utils.build_output_table(env, file_volumes, columns, sortby)
     env.fout(table)
-
-
-def _reduce_notes(file_volumes):
-    """Reduces the size of the notes in a volume list.
-
-    :param file_volumes: An list of file volumes
-    """
-    for file_volume in file_volumes:
-        if len(file_volume.get('notes', '')) > DEFAULT_NOTES_SIZE:
-            shortened_notes = file_volume['notes'][:DEFAULT_NOTES_SIZE]
-            file_volume['notes'] = shortened_notes

--- a/SoftLayer/CLI/storage_utils.py
+++ b/SoftLayer/CLI/storage_utils.py
@@ -2,6 +2,43 @@
 # :license: MIT, see LICENSE for more details.
 
 from SoftLayer.CLI import columns as column_helper
+from SoftLayer.CLI import formatting
+
+DEFAULT_NOTES_SIZE = 20
+
+
+def reduce_notes(volumes, env):
+    """Reduces all long notes found in the volumes list just if the format output is different from a JSON format.
+
+    :param list volumes: An list of storage volumes
+    :param env :A environment console.
+    """
+    if env.format_output_is_json():
+        return
+
+    for volume in volumes:
+        if len(volume.get('notes', '')) > DEFAULT_NOTES_SIZE:
+            shortened_notes = volume['notes'][:DEFAULT_NOTES_SIZE]
+            volume['notes'] = shortened_notes
+
+
+def build_output_table(env, volumes, columns, sortby):
+    """Builds a formatting table for a list of volumes.
+
+        :param env :A Environment console.
+        :param list volumes: An list of storage volumes
+        :param columns :A ColumnFormatter for column names
+        :param str sortby :A string to sort by.
+        """
+    table = formatting.Table(columns.columns)
+    if sortby in table.columns:
+        table.sortby = sortby
+
+    reduce_notes(volumes, env)
+    for volume in volumes:
+        table.add_row([value or formatting.blank()
+                       for value in columns.row(volume)])
+    return table
 
 
 def _format_name(obj):
@@ -95,7 +132,6 @@ allowedSubnets.allowedHost.id
 allowedIpAddresses.allowedHost.id
 """),
 ]
-
 
 DEFAULT_COLUMNS = [
     'id',

--- a/tests/CLI/environment_tests.py
+++ b/tests/CLI/environment_tests.py
@@ -81,3 +81,7 @@ class EnvironmentTests(testing.TestCase):
         ]
         self.env.fout(output)
         self.assertEqual(2, echo.call_count)
+
+    def test_format_output_is_json(self):
+        self.env.format = 'jsonraw'
+        self.assertTrue(self.env.format_output_is_json())

--- a/tests/CLI/modules/file_tests.py
+++ b/tests/CLI/modules/file_tests.py
@@ -5,6 +5,7 @@
     :license: MIT, see LICENSE for more details.
 """
 from SoftLayer.CLI import exceptions
+from SoftLayer.CLI import formatting
 from SoftLayer import SoftLayerError
 from SoftLayer import testing
 
@@ -62,6 +63,37 @@ class FileTests(testing.TestCase):
         self.assert_no_fail(result)
         json_result = json.loads(result.output)
         self.assertEqual(json_result[0]['id'], 1)
+
+    @mock.patch('SoftLayer.FileStorageManager.list_file_volumes')
+    def test_volume_list_notes_format_output_json(self, list_mock):
+        note_mock = 'test ' * 5
+        list_mock.return_value = [
+            {'notes': note_mock}
+        ]
+
+        result = self.run_command(['--format', 'json', 'file', 'volume-list', '--columns', 'notes'])
+
+        self.assert_no_fail(result)
+        self.assertEqual(
+            [{
+                'notes': note_mock,
+            }],
+            json.loads(result.output))
+
+    @mock.patch('SoftLayer.FileStorageManager.list_file_volumes')
+    def test_volume_list_reduced_notes_format_output_table(self, list_mock):
+        note_mock = 'test ' * 10
+        expected_reduced_note = 'test ' * 4
+        list_mock.return_value = [
+            {'notes': note_mock}
+        ]
+        expected_table = formatting.Table(['notes'])
+        expected_table.add_row([expected_reduced_note])
+        expected_output = formatting.format_output(expected_table) + '\n'
+        result = self.run_command(['--format', 'table', 'file', 'volume-list', '--columns', 'notes'])
+
+        self.assert_no_fail(result)
+        self.assertEqual(expected_output, result.output)
 
     @mock.patch('SoftLayer.FileStorageManager.list_file_volumes')
     def test_volume_count(self, list_mock):


### PR DESCRIPTION
Fixes #1481 
### Tesing 
#### trim notes
- ✔️ slcli file volume-list 
- ✔️ slcli --format=table file volume-list --columns "notes"
- ✔️ slcli --format=raw file volume-list --columns "notes"

- ✔️ slcli block volume-list
- ✔️ slcli --format=table block volume-list --columns "notes"
- ✔️ slcli --format=raw block volume-list --columns "notes"
#### no trim 
- ✔️ slcli --format=jsonraw file volume-list --columns "notes"
- ✔️slcli --format=json file volume-list --columns "notes"

- ✔️ slcli --format=jsonraw block volume-list --columns "notes"
- ✔️ slcli --format=json block volume-list --columns "notes"
