### PR TITLE
Updated snap to core20 and edited README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,12 @@ To install the slcli snap:
 
 .. code-block:: bash
 
-	$ sudo snap install slcli
+	$ sudo snap install slcli 
+	
+	(or to get the latest release)
+	
+	$ sudo snap install slcli --edge
+	
 	
 
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,7 +12,7 @@ confinement: strict
 
 apps:
   slcli:
-    command: slcli
+    command: bin/slcli
     environment: 
       LC_ALL: C.UTF-8
     plugs:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
 
 license: MIT
 
-base: core18
+base: core20
 grade: stable 
 confinement: strict
 
@@ -25,7 +25,6 @@ parts:
     source: https://github.com/softlayer/softlayer-python
     source-type: git
     plugin: python
-    python-version: python3
     override-pull: |
       snapcraftctl pull
       snapcraftctl set-version "$(git describe --tags | sed 's/^v//')"


### PR DESCRIPTION
Updated the snap to `core20` for newer base and edited README to point users to the `edge` channel to get the latest releases based on the GH repo (`master`). This should mitigate complaints that the "snap is out of date". 

Build is successful and testing was limited, as I don't have an SL account. 