### PR TITLE
Updates to the Release workflow for publishing to test pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Snapcraft and PyPi (Testing)
 
 on:
   release:
@@ -20,4 +20,32 @@ jobs:
           VERSION=`snapcraft list-revisions slcli --arch ${{ matrix.arch }} | grep "edge\*" | awk '{print $1}'`
           echo Publishing $VERSION on ${{ matrix.arch }}
           snapcraft release slcli $VERSION stable
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.CGALLO_TEST_PYPI }}
+        repository_url: https://test.pypi.org/legacy/
 

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -4,16 +4,16 @@ name: Publish 📦 to TestPyPI
 
 on:
   push:
-    branches: [ master, test-pypi ]
+    branches: [test-pypi ]
 
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install pypa/build

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -4,7 +4,7 @@ name: Publish 📦 to TestPyPI
 
 on:
   push:
-    branches: [ test-pypi ]
+    branches: [ master ]
 
 jobs:
   build-n-publish:
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install pypa/build
       run: >-
         python -m

--- a/.github/workflows/test_pypi_release.yml
+++ b/.github/workflows/test_pypi_release.yml
@@ -4,7 +4,7 @@ name: Publish 📦 to TestPyPI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, test-pypi ]
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
This updates the `release` Job to also publish the package to test-pypi repo, and if that works for the next few versions, I'll update it to do the official one as well.

I was going to try to get a way to auto-publish a package every update to master, but I think that will end up being too much trouble for now.

Any dev releases we do can be easily done by just adding a -devX suffix to the version string I think and push that to the test-pypi branch.