### PR TITLE
Prevents SLCLI_VERSION environment variable from breaking things

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 jobs:
-  release:
+  snap-release:
     runs-on: ubuntu-18.04
     strategy:
       matrix:

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,26 @@ InsecurePlatformWarning Notice
 ------------------------------
 This library relies on the `requests <http://docs.python-requests.org/>`_ library to make HTTP requests. On Python versions below Python 2.7.9, requests has started emitting a security warning (InsecurePlatformWarning) due to insecurities with creating SSL connections. To resolve this, upgrade to Python 2.7.9+ or follow the instructions here: http://stackoverflow.com/a/29099439.
 
+Basic Usage
+-----------
+
+- `The Complete Command Directory <https://softlayer-python.readthedocs.io/en/latest/cli_directory/>`_
+
+Advanced Usage
+--------------
+
+You can automatically set some parameters via environment variables with by using the SLCLI prefix. For example
+
+.. code-block:: bash
+  $ export SLCLI_VERBOSE=3
+  $ export SLCLI_FORMAT=json
+  $ slcli vs list
+
+is equivalent to 
+
+.. code-block:: bash
+  $ slcli -vvv --format=json vs list
+
 Getting Help
 ------------
 Bugs and feature requests about this library should have a `GitHub issue <https://github.com/softlayer/softlayer-python/issues>`_ opened about them. 

--- a/SoftLayer/CLI/core.py
+++ b/SoftLayer/CLI/core.py
@@ -129,7 +129,7 @@ use: 'slcli setup'""",
               required=False,
               help="Use demo data instead of actually making API calls")
 @click.option('--version', is_flag=True, expose_value=False, is_eager=True, callback=get_version_message,
-              help="Show version information.")
+              help="Show version information.",  allow_from_autoenv=False,)
 @environment.pass_env
 def cli(env,
         format='table',


### PR DESCRIPTION
Fixes #1524 

Apparently Click has a neat feature that allows you to set parameters with environment variables, which I just learned about.
https://github.com/softlayer/softlayer-python/blame/master/SoftLayer/CLI/core.py#L103 is what actually controls that, but since its been active for 3 years, I don't really want to turn it off entirely, as it is a somewhat neat feature.

So I'll just turn it off for --version which I don't think anyone would want to have automatically be set.