### PR TITLE
Forces specific endoing on XMLRPC requests

### DIFF
--- a/SoftLayer/CLI/autoscale/__init__.py
+++ b/SoftLayer/CLI/autoscale/__init__.py
@@ -1,0 +1,1 @@
+"""Autoscale"""

--- a/SoftLayer/CLI/autoscale/edit.py
+++ b/SoftLayer/CLI/autoscale/edit.py
@@ -32,7 +32,7 @@ def cli(env, identifier, name, minimum, maximum, userdata, userfile, cpu, memory
     if userdata:
         virt_template['userData'] = [{"value": userdata}]
     elif userfile:
-        with open(userfile, 'r') as userfile_obj:
+        with open(userfile, 'r', encoding="utf-8") as userfile_obj:
             virt_template['userData'] = [{"value": userfile_obj.read()}]
     virt_template['startCpus'] = cpu
     virt_template['maxMemory'] = memory

--- a/SoftLayer/CLI/block/count.py
+++ b/SoftLayer/CLI/block/count.py
@@ -25,7 +25,7 @@ def cli(env, sortby, datacenter):
                                                      mask=mask)
 
     # cycle through all block volumes and count datacenter occurences.
-    datacenters = dict()
+    datacenters = {}
     for volume in block_volumes:
         service_resource = volume['serviceResource']
         if 'datacenter' in service_resource:

--- a/SoftLayer/CLI/block/replication/partners.py
+++ b/SoftLayer/CLI/block/replication/partners.py
@@ -6,26 +6,10 @@ import SoftLayer
 from SoftLayer.CLI import columns as column_helper
 from SoftLayer.CLI import environment
 from SoftLayer.CLI import formatting
+from SoftLayer.CLI import storage_utils
 
-COLUMNS = [
-    column_helper.Column('ID', ('id',)),
-    column_helper.Column('Username', ('username',), mask="username"),
-    column_helper.Column('Account ID', ('accountId',), mask="accountId"),
-    column_helper.Column('Capacity (GB)', ('capacityGb',), mask="capacityGb"),
-    column_helper.Column('Hardware ID', ('hardwareId',), mask="hardwareId"),
-    column_helper.Column('Guest ID', ('guestId',), mask="guestId"),
-    column_helper.Column('Host ID', ('hostId',), mask="hostId"),
-]
-
-DEFAULT_COLUMNS = [
-    'ID',
-    'Username',
-    'Account ID',
-    'Capacity (GB)',
-    'Hardware ID',
-    'Guest ID',
-    'Host ID'
-]
+COLUMNS = storage_utils.REPLICATION_PARTNER_COLUMNS
+DEFAULT_COLUMNS = storage_utils.REPLICATION_PARTNER_DEFAULT
 
 
 @click.command()

--- a/SoftLayer/CLI/dns/zone_import.py
+++ b/SoftLayer/CLI/dns/zone_import.py
@@ -26,7 +26,7 @@ def cli(env, zonefile, dry_run):
     """Import zone based off a BIND zone file."""
 
     manager = SoftLayer.DNSManager(env.client)
-    with open(zonefile) as zone_f:
+    with open(zonefile, encoding="utf-8") as zone_f:
         zone_contents = zone_f.read()
 
     zone, records, bad_lines = parse_zone_details(zone_contents)

--- a/SoftLayer/CLI/file/count.py
+++ b/SoftLayer/CLI/file/count.py
@@ -24,7 +24,7 @@ def cli(env, sortby, datacenter):
     file_volumes = file_manager.list_file_volumes(datacenter=datacenter,
                                                   mask=mask)
 
-    datacenters = dict()
+    datacenters = {}
     for volume in file_volumes:
         service_resource = volume['serviceResource']
         if 'datacenter' in service_resource:

--- a/SoftLayer/CLI/file/replication/partners.py
+++ b/SoftLayer/CLI/file/replication/partners.py
@@ -6,28 +6,10 @@ import SoftLayer
 from SoftLayer.CLI import columns as column_helper
 from SoftLayer.CLI import environment
 from SoftLayer.CLI import formatting
+from SoftLayer.CLI import storage_utils
 
-COLUMNS = [
-    column_helper.Column('ID', ('id',)),
-    column_helper.Column('Username', ('username',), mask="username"),
-    column_helper.Column('Account ID', ('accountId',), mask="accountId"),
-    column_helper.Column('Capacity (GB)', ('capacityGb',), mask="capacityGb"),
-    column_helper.Column('Hardware ID', ('hardwareId',), mask="hardwareId"),
-    column_helper.Column('Guest ID', ('guestId',), mask="guestId"),
-    column_helper.Column('Host ID', ('hostId',), mask="hostId"),
-]
-
-# In-line comment to avoid similarity flag with block version
-
-DEFAULT_COLUMNS = [
-    'ID',
-    'Username',
-    'Account ID',
-    'Capacity (GB)',
-    'Hardware ID',
-    'Guest ID',
-    'Host ID'
-]
+COLUMNS = storage_utils.REPLICATION_PARTNER_COLUMNS
+DEFAULT_COLUMNS = storage_utils.REPLICATION_PARTNER_DEFAULT
 
 
 @click.command()

--- a/SoftLayer/CLI/firewall/edit.py
+++ b/SoftLayer/CLI/firewall/edit.py
@@ -23,7 +23,7 @@ def parse_rules(content=None):
     :returns: a list of rules
     """
     rules = content.split(DELIMITER)
-    parsed_rules = list()
+    parsed_rules = []
     order = 1
     for rule in rules:
         if rule.strip() == '':

--- a/SoftLayer/CLI/hardware/edit.py
+++ b/SoftLayer/CLI/hardware/edit.py
@@ -40,7 +40,7 @@ def cli(env, identifier, domain, userfile, tag, hostname, userdata, public_speed
     if userdata:
         data['userdata'] = userdata
     elif userfile:
-        with open(userfile, 'r') as userfile_obj:
+        with open(userfile, 'r', encoding="utf-8") as userfile_obj:
             data['userdata'] = userfile_obj.read()
 
     if tag:

--- a/SoftLayer/CLI/hardware/upgrade.py
+++ b/SoftLayer/CLI/hardware/upgrade.py
@@ -51,7 +51,7 @@ def cli(env, identifier, memory, network, drive_controller, public_bandwidth, ad
                 "This action will incur charges on your account. Continue?")):
             raise exceptions.CLIAbort('Aborted')
 
-    disk_list = list()
+    disk_list = []
     if add_disk:
         for guest_disk in add_disk:
             disks = {'description': 'add_disk', 'capacity': guest_disk[0], 'number': guest_disk[1]}

--- a/SoftLayer/CLI/order/quote.py
+++ b/SoftLayer/CLI/order/quote.py
@@ -43,7 +43,7 @@ def _parse_create_args(client, args):
     if args.get('userdata'):
         userdata = args['userdata']
     elif args.get('userfile'):
-        with open(args['userfile'], 'r') as userfile:
+        with open(args['userfile'], 'r', encoding="utf-8") as userfile:
             userdata = userfile.read()
     if userdata:
         for hardware in data['hardware']:

--- a/SoftLayer/CLI/sshkey/add.py
+++ b/SoftLayer/CLI/sshkey/add.py
@@ -33,7 +33,7 @@ def cli(env, label, in_file, key, note):
     if key:
         key_text = key
     else:
-        with open(path.expanduser(in_file), 'rU') as key_file:
+        with open(path.expanduser(in_file), 'rU', encoding="utf-8") as key_file:
             key_text = key_file.read().strip()
             key_file.close()
 

--- a/SoftLayer/CLI/sshkey/print.py
+++ b/SoftLayer/CLI/sshkey/print.py
@@ -26,7 +26,7 @@ def cli(env, identifier, out_file):
     key = mgr.get_key(key_id)
 
     if out_file:
-        with open(path.expanduser(out_file), 'w') as pub_file:
+        with open(path.expanduser(out_file), 'w', encoding="utf-8") as pub_file:
             pub_file.write(key['key'])
 
     table = formatting.KeyValueTable(['name', 'value'])

--- a/SoftLayer/CLI/ssl/add.py
+++ b/SoftLayer/CLI/ssl/add.py
@@ -28,16 +28,16 @@ def cli(env, crt, csr, icc, key, notes):
         'certificateSigningRequest': '',
         'notes': notes,
     }
-    with open(crt) as file_crt:
+    with open(crt, encoding="utf-8") as file_crt:
         template['certificate'] = file_crt.read()
-    with open(key) as file_key:
+    with open(key, encoding="utf-8") as file_key:
         template['privateKey'] = file_key.read()
-    with open(csr) as file_csr:
+    with open(csr, encoding="utf-8") as file_csr:
         if csr:
             body = file_csr.read()
             template['certificateSigningRequest'] = body
 
-    with open(icc) as file_icc:
+    with open(icc, encoding="utf-8") as file_icc:
         if icc:
             body = file_icc.read()
             template['intermediateCertificate'] = body

--- a/SoftLayer/CLI/ssl/download.py
+++ b/SoftLayer/CLI/ssl/download.py
@@ -30,5 +30,5 @@ def cli(env, identifier):
 
 def write_cert(filename, content):
     """Writes certificate body to the given file path."""
-    with open(filename, 'w') as cert_file:
+    with open(filename, 'w', encoding="utf-8") as cert_file:
         cert_file.write(content)

--- a/SoftLayer/CLI/ssl/edit.py
+++ b/SoftLayer/CLI/ssl/edit.py
@@ -24,16 +24,16 @@ from SoftLayer.CLI import environment
 def cli(env, identifier, crt, csr, icc, key, notes):
     """Edit SSL certificate."""
     template = {'id': identifier}
-    with open(crt) as file_crt:
+    with open(crt, encoding="utf-8") as file_crt:
         if crt:
             template['certificate'] = file_crt.read()
-    with open(key) as file_key:
+    with open(key, encoding="utf-8") as file_key:
         if key:
             template['privateKey'] = file_key.read()
-    with open(csr) as file_csr:
+    with open(csr, encoding="utf-8") as file_csr:
         if csr:
             template['certificateSigningRequest'] = file_csr.read()
-    with open(icc) as file_icc:
+    with open(icc, encoding="utf-8") as file_icc:
         if icc:
             template['intermediateCertificate'] = file_icc.read()
     if notes:

--- a/SoftLayer/CLI/storage_utils.py
+++ b/SoftLayer/CLI/storage_utils.py
@@ -144,3 +144,24 @@ DEFAULT_COLUMNS = [
     'password',
     'allowed_host_id',
 ]
+
+
+REPLICATION_PARTNER_COLUMNS = [
+    column_helper.Column('ID', ('id',)),
+    column_helper.Column('Username', ('username',), mask="username"),
+    column_helper.Column('Account ID', ('accountId',), mask="accountId"),
+    column_helper.Column('Capacity (GB)', ('capacityGb',), mask="capacityGb"),
+    column_helper.Column('Hardware ID', ('hardwareId',), mask="hardwareId"),
+    column_helper.Column('Guest ID', ('guestId',), mask="guestId"),
+    column_helper.Column('Host ID', ('hostId',), mask="hostId"),
+]
+
+REPLICATION_PARTNER_DEFAULT = [
+    'ID',
+    'Username',
+    'Account ID',
+    'Capacity (GB)',
+    'Hardware ID',
+    'Guest ID',
+    'Host ID'
+]

--- a/SoftLayer/CLI/template.py
+++ b/SoftLayer/CLI/template.py
@@ -24,7 +24,7 @@ class TemplateCallback(object):
         if value is None:
             return
 
-        with open(os.path.expanduser(value), 'r') as file_handle:
+        with open(os.path.expanduser(value), 'r', encoding="utf-8") as file_handle:
             config = configparser.ConfigParser()
             ini_str = '[settings]\n' + file_handle.read()
             ini_fp = io.StringIO(ini_str)
@@ -58,7 +58,7 @@ def export_to_template(filename, args, exclude=None):
     exclude.append('format')
     exclude.append('debug')
 
-    with open(filename, "w") as template_file:
+    with open(filename, "w", encoding="utf-8") as template_file:
         for k, val in args.items():
             if val and k not in exclude:
                 if isinstance(val, tuple):

--- a/SoftLayer/CLI/virt/create.py
+++ b/SoftLayer/CLI/virt/create.py
@@ -118,7 +118,7 @@ def _parse_create_args(client, args):
     if args.get('userdata'):
         data['userdata'] = args['userdata']
     elif args.get('userfile'):
-        with open(args['userfile'], 'r') as userfile:
+        with open(args['userfile'], 'r', encoding="utf-8") as userfile:
             data['userdata'] = userfile.read()
 
     # Get the SSH keys

--- a/SoftLayer/CLI/virt/edit.py
+++ b/SoftLayer/CLI/virt/edit.py
@@ -43,7 +43,7 @@ def cli(env, identifier, domain, userfile, tag, hostname, userdata,
     if userdata:
         data['userdata'] = userdata
     elif userfile:
-        with open(userfile, 'r') as userfile_obj:
+        with open(userfile, 'r', encoding="utf-8") as userfile_obj:
             data['userdata'] = userfile_obj.read()
 
     data['hostname'] = hostname

--- a/SoftLayer/CLI/virt/upgrade.py
+++ b/SoftLayer/CLI/virt/upgrade.py
@@ -42,7 +42,7 @@ def cli(env, identifier, cpu, private, memory, network, flavor, add_disk, resize
     if not (env.skip_confirmations or formatting.confirm("This action will incur charges on your account. Continue?")):
         raise exceptions.CLIAbort('Aborted')
 
-    disk_json = list()
+    disk_json = []
     if memory:
         memory = int(memory / 1024)
     if resize_disk:

--- a/SoftLayer/config.py
+++ b/SoftLayer/config.py
@@ -118,5 +118,5 @@ def write_config(configuration, config_file=None):
     if config_file is None:
         config_file = '~/.softlayer'
     config_file = os.path.expanduser(config_file)
-    with open(config_file, 'w') as file:
+    with open(config_file, 'w', encoding="utf-8") as file:
         configuration.write(file)

--- a/SoftLayer/fixtures/SoftLayer_Account.py
+++ b/SoftLayer/fixtures/SoftLayer_Account.py
@@ -14,7 +14,7 @@ getPrivateBlockDeviceTemplateGroups = [{
     'globalIdentifier': 'F9329795-4220-4B0A-B970-C86B950667FA',
     'id': 201,
     # 'name': 'private_image2',
-    'name': u'a¬ሴ€耀',
+    'name': 'a¬ሴ€耀',
     'parentId': '',
     'publicFlag': False,
 }]

--- a/SoftLayer/managers/vs_capacity.py
+++ b/SoftLayer/managers/vs_capacity.py
@@ -89,7 +89,7 @@ instances[id, billingItem[description, hourlyRecurringFee]], instanceCount, back
         for region in regions:
             routers[region['keyname']] = []
             for location in region['locations']:
-                location['location']['pods'] = list()
+                location['location']['pods'] = []
                 for pod in pods:
                     if pod['datacenterName'] == location['location']['name']:
                         location['location']['pods'].append(pod)

--- a/SoftLayer/transports.py
+++ b/SoftLayer/transports.py
@@ -205,7 +205,8 @@ class XmlRpcTransport(object):
         request.url = '/'.join([self.endpoint_url, request.service])
         request.payload = xmlrpc.client.dumps(tuple(largs),
                                               methodname=request.method,
-                                              allow_none=True)
+                                              allow_none=True,
+                                              encoding="iso-8859-1")
 
         # Prefer the request setting, if it's not None
         verify = request.verify
@@ -214,7 +215,7 @@ class XmlRpcTransport(object):
 
         try:
             resp = self.client.request('POST', request.url,
-                                       data=request.payload,
+                                       data=request.payload.encode(),
                                        auth=auth,
                                        headers=request.transport_headers,
                                        timeout=self.timeout,
@@ -273,7 +274,7 @@ client.mount('https://', adapter)
 #auth=HTTPBasicAuth('apikey', YOUR_CLOUD_API_KEY)
 auth=None
 url = '$url'
-payload = """$payload"""
+payload = $payload
 transport_headers = $transport_headers
 timeout = $timeout
 verify = $verify
@@ -287,6 +288,7 @@ ElementTree.dump(xml)
 
         safe_payload = re.sub(r'<string>[a-z0-9]{64}</string>', r'<string>API_KEY_GOES_HERE</string>', request.payload)
         safe_payload = re.sub(r'(\s+)', r' ', safe_payload)
+        safe_payload = safe_payload.encode()
         substitutions = dict(url=request.url, payload=safe_payload, transport_headers=request.transport_headers,
                              timeout=self.timeout, verify=request.verify, cert=request.cert,
                              proxy=_proxies_dict(self.proxy))


### PR DESCRIPTION
Fixes #1540 

Most important change here is to SoftLayer\transports.py where I'm now forcibly encoding the payload, along with setting the encoding type for XML to `encoding="iso-8859-1"`

Other files being changed are for tox reasons