### PR TITLE
Issues/1541 loadbal details

### DIFF
--- a/SoftLayer/fixtures/SoftLayer_Network_LBaaS_LoadBalancer.py
+++ b/SoftLayer/fixtures/SoftLayer_Network_LBaaS_LoadBalancer.py
@@ -58,6 +58,17 @@ getObject = {
                 'uuid': 'ab1a1abc-0e83-4690-b5d4-1359625dba8f',
             }
         },
+        {
+            'clientTimeout': 15,
+            'defaultPool': {
+                'healthMonitor': {
+                    'uuid': '222222ab-bbcc-4f32-9b31-1b6d3a1959c0'
+                },
+                'protocol': 'HTTP',
+                'protocolPort': 256,
+                'uuid': 'ab1a1abc-0e83-4690-b5d4-1359625dba8x',
+            }
+        },
         {'connectionLimit': None,
          'createDate': '2019-08-21T17:19:25-04:00',
          'defaultPool': {'createDate': '2019-08-21T17:19:25-04:00',

--- a/SoftLayer/managers/load_balancer.py
+++ b/SoftLayer/managers/load_balancer.py
@@ -18,6 +18,11 @@ class LoadBalancerManager(utils.IdentifierMixin, object):
     :param SoftLayer.API.BaseClient client: the client instance
 
     """
+    TYPE = {
+        1: "Public to Private",
+        0: "Private to Private",
+        2: "Public to Public",
+    }
 
     def __init__(self, client):
         self.client = client

--- a/tests/CLI/modules/loadbal_tests.py
+++ b/tests/CLI/modules/loadbal_tests.py
@@ -215,6 +215,9 @@ class LoadBalancerTests(testing.TestCase):
     def test_lb_detail(self):
         result = self.run_command(['lb', 'detail', '1111111'])
         self.assert_no_fail(result)
+        self.assertIn('Id', result.output)
+        self.assertIn('UUI', result.output)
+        self.assertIn('Address', result.output)
 
     def test_lb_detail_by_name(self):
         name = SoftLayer_Network_LBaaS_LoadBalancer.getObject.get('name')


### PR DESCRIPTION
Fixes #1541 

- added Type at the output, as `ibmcloud sl loadbal detail` shows
- some fields were reordered too in the same order as UI and `ibmcloud`
- Listeners field was renamed to Protocols, as UI and `ibmcloud` show.
- to fix duplicated column errors a prefix as `P0 ->` was added.
![image](https://user-images.githubusercontent.com/30413337/133866536-76d49bb5-c708-46da-ab6b-1e9d156ed089.png)

### Testing 
- ✔️slcli lb detail 928098
![image](https://user-images.githubusercontent.com/30413337/133866738-6f91c744-a4bd-4ad3-a9ac-0cbd12c57ba6.png)
