### PR TITLE
Fix hw billing reports 0 items

### DIFF
--- a/SoftLayer/fixtures/SoftLayer_Hardware.py
+++ b/SoftLayer/fixtures/SoftLayer_Hardware.py
@@ -7,7 +7,7 @@ getObject = {
         'id': 6327,
         'recurringFee': 1.54,
         'nextInvoiceTotalRecurringAmount': 16.08,
-        'nextInvoiceChildren': [
+        'children': [
             {'description': 'test', 'nextInvoiceTotalRecurringAmount': 1},
         ],
         'orderItem': {

--- a/tests/CLI/modules/server_tests.py
+++ b/tests/CLI/modules/server_tests.py
@@ -868,19 +868,25 @@ class ServerCLITests(testing.TestCase):
 
     def test_billing(self):
         result = self.run_command(['hw', 'billing', '123456'])
-        billing_json = {
+        hardware_server_billing = {
             'Billing Item Id': 6327,
             'Id': '123456',
             'Provision Date': None,
             'Recurring Fee': 1.54,
             'Total': 16.08,
-            'prices': [{
-                'Item': 'test',
-                'Recurring Price': 1
-            }]
+            'prices': [
+                {
+                    'Item': 'test',
+                    'Recurring Price': 1
+                },
+                {
+                    'Item': 'test2',
+                    'Recurring Price': 2
+                },
+            ]
         }
         self.assert_no_fail(result)
-        self.assertEqual(json.loads(result.output), billing_json)
+        self.assertEqual(json.loads(result.output), hardware_server_billing)
 
     @mock.patch('SoftLayer.CLI.formatting.confirm')
     def test_create_hw_no_confirm(self, confirm_mock):


### PR DESCRIPTION
Fixes #1555 

- Changed to look for nextInvoiceChildren


### Testing
- ✔️ slcli hw billing 3128496
```bash
$slcli hw billing 3128496
:.................:................................................................................:
:            name : value                                                                          :
:.................:................................................................................:
:              Id : 3128496                                                                        :
: Billing Item Id : 774327352                                                                      :
:   Recurring Fee : None                                                                           :
:           Total : 0                                                                              :
:  Provision Date : None                                                                           :
:          prices : :..........................................................:.................: :
:                 : :                           Item                           : Recurring Price : :
:                 : :..........................................................:.................: :
:                 : :       Intel Xeon Platinum 8260 (48 Cores, 2.4 GHz)       :        0        : :
:                 : :        VMware Server Virtualization 6.5 Update 3         :        0        : :
:                 : :                           RAID                           :        0        : :
:                 : :                       4.00 TB SATA                       :        0        : :
:                 : :                       4.00 TB SATA                       :        0        : :
:                 : :               20000 GB Bandwidth Allotment               :        0        : :
:                 : : 10 Gbps Dual Public & Private Network Uplinks (Unbonded) :        0        : :
:                 : :         10 Gbps Dual Private Uplinks (Unbonded)          :        0        : :
:                 : :          10 Gbps Dual Public Uplinks (Unbonded)          :        0        : :
:                 : :                   Reboot / KVM over IP                   :        0        : :
:                 : :                       1 IP Address                       :        0        : :
:                 : :                        Host Ping                         :        0        : :
:                 : :                     Email and Ticket                     :        0        : :
:                 : :                  Automated Notification                  :        0        : :
:                 : :                 Unlimited SSL VPN Users                  :        0        : :
:                 : :                        384 GB RAM                        :        0        : :
:                 : :..........................................................:.................: :
:.................:................................................................................:
```