### PR TITLE
Mapping is now in collections.abc

### DIFF
--- a/SoftLayer/utils.py
+++ b/SoftLayer/utils.py
@@ -68,7 +68,7 @@ def dict_merge(dct1, dct2):
 
     dct = dct1.copy()
     for k, _ in dct2.items():
-        if (k in dct1 and isinstance(dct1[k], dict) and isinstance(dct2[k], collections.Mapping)):
+        if (k in dct1 and isinstance(dct1[k], dict) and isinstance(dct2[k], collections.abc.Mapping)):
             dct[k] = dict_merge(dct1[k], dct2[k])
         else:
             dct[k] = dct2[k]


### PR DESCRIPTION
this fixes an error running tests:

```
__________________________ TestUtils.test_dict_merge ___________________________

self = <tests.basic_tests.TestUtils testMethod=test_dict_merge>

    def test_dict_merge(self):
        filter1 = {"virtualGuests": {"hostname": {"operation": "etst"}}}
        filter2 = {"virtualGuests": {"id": {"operation": "orderBy", "options": [{"name": "sort", "value": ["DESC"]}]}}}
>       result = SoftLayer.utils.dict_merge(filter1, filter2)

tests/basic_tests.py:85: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

dct1 = {'virtualGuests': {'hostname': {'operation': 'etst'}}}
dct2 = {'virtualGuests': {'id': {'operation': 'orderBy', 'options': [{'name': 'sort', 'value': ['DESC']}]}}}

    def dict_merge(dct1, dct2):
        """Recursively merges dct2 and dct1, ideal for merging objectFilter together.
    
        :param dct1: A dictionary
        :param dct2: A dictionary
        :return: dct1 + dct2
        """
    
        dct = dct1.copy()
        for k, _ in dct2.items():
>           if (k in dct1 and isinstance(dct1[k], dict) and isinstance(dct2[k], collections.Mapping)):
E           AttributeError: module 'collections' has no attribute 'Mapping'

SoftLayer/utils.py:71: AttributeError
```