### PR TITLE
Replace the use of ptable with prettytable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,7 +167,7 @@ If you cannot install python 3.6+ for some reason, you will need to use a versio
 
 Python Packages
 ---------------
-* ptable >= 0.9.2
+* prettytable >= 2.0.0
 * click >= 7
 * requests >= 2.20.0
 * prompt_toolkit >= 2

--- a/SoftLayer/CLI/formatting.py
+++ b/SoftLayer/CLI/formatting.py
@@ -11,11 +11,7 @@ import os
 
 import click
 
-# If both PTable and prettytable are installed, its impossible to use the new version
-try:
-    from prettytable import prettytable
-except ImportError:
-    import prettytable
+import prettytable
 
 from SoftLayer.CLI import exceptions
 from SoftLayer import utils

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     },
     python_requires='>=3.5',
     install_requires=[
-        'ptable >= 0.9.2',
+        'prettytable >= 2.0.0',
         'click >= 7',
         'requests >= 2.20.0',
         'prompt_toolkit >= 2',

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,4 @@
-ptable >= 0.9.2
+prettytable >= 2.0.0
 click >= 7
 requests >= 2.20.0
 prompt_toolkit >= 2

--- a/tools/test-requirements.txt
+++ b/tools/test-requirements.txt
@@ -4,7 +4,7 @@ pytest
 pytest-cov
 mock
 sphinx
-ptable >= 0.9.2
+prettytable >= 2.0.0
 click >= 7
 requests >= 2.20.0
 prompt_toolkit >= 2


### PR DESCRIPTION
{README.rst,tools/*}:
Replace ptable with prettytable >= 2.0.0.

SoftLayer/CLI/formatting.py:
Only import prettytable.

Fixes #1583 