### PR TITLE
Improved successful response to command - slcli vlan cancel

### DIFF
--- a/SoftLayer/CLI/account/cancel_item.py
+++ b/SoftLayer/CLI/account/cancel_item.py
@@ -15,4 +15,5 @@ def cli(env, identifier):
     manager = AccountManager(env.client)
     item = manager.cancel_item(identifier)
 
-    env.fout(item)
+    if item:
+        env.fout("Item: {} was cancelled.".format(identifier))

--- a/SoftLayer/CLI/virt/edit.py
+++ b/SoftLayer/CLI/virt/edit.py
@@ -54,11 +54,16 @@ def cli(env, identifier, domain, userfile, tag, hostname, userdata,
 
     vsi = SoftLayer.VSManager(env.client)
     vs_id = helpers.resolve_id(vsi.resolve_ids, identifier, 'VS')
-    if not vsi.edit(vs_id, **data):
-        raise exceptions.CLIAbort("Failed to update virtual server")
+
+    if vsi.edit(vs_id, **data):
+        for key, value in data.items():
+            if value is not None:
+                env.fout("The {} of virtual server instance: {} was updated.".format(key, vs_id))
 
     if public_speed is not None:
-        vsi.change_port_speed(vs_id, True, int(public_speed))
+        if vsi.change_port_speed(vs_id, True, int(public_speed)):
+            env.fout("The public speed of virtual server instance: {} was updated.".format(vs_id))
 
     if private_speed is not None:
-        vsi.change_port_speed(vs_id, False, int(private_speed))
+        if vsi.change_port_speed(vs_id, False, int(private_speed)):
+            env.fout("The private speed of virtual server instance: {} was updated.".format(vs_id))

--- a/SoftLayer/CLI/vlan/cancel.py
+++ b/SoftLayer/CLI/vlan/cancel.py
@@ -25,10 +25,11 @@ def cli(env, identifier):
         raise exceptions.CLIAbort(reasons)
     item = mgr.get_vlan(identifier).get('billingItem')
     if item:
-        mgr.cancel_item(item.get('id'),
-                        True,
-                        'Cancel by cli command',
-                        'Cancel by cli command')
+        if mgr.cancel_item(item.get('id'),
+                           True,
+                           'Cancel by cli command',
+                           'Cancel by cli command'):
+            env.fout("VLAN {} was cancelled.".format(identifier))
     else:
         raise exceptions.CLIAbort(
             "VLAN is an automatically assigned and free of charge VLAN,"

--- a/tests/CLI/modules/vs/vs_tests.py
+++ b/tests/CLI/modules/vs/vs_tests.py
@@ -609,7 +609,13 @@ class VirtTests(testing.TestCase):
                                    '100'])
 
         self.assert_no_fail(result)
-        self.assertEqual(result.output, '')
+        expected_output = '"The userdata of virtual server instance: 100 was updated."\n' \
+                          + '"The hostname of virtual server instance: 100 was updated."\n' \
+                          + '"The domain of virtual server instance: 100 was updated."\n' \
+                          + '"The tags of virtual server instance: 100 was updated."\n' \
+                          + '"The public speed of virtual server instance: 100 was updated."\n' \
+                          + '"The private speed of virtual server instance: 100 was updated."\n'
+        self.assertEqual(result.output, expected_output)
 
         self.assert_called_with(
             'SoftLayer_Virtual_Guest', 'editObject',


### PR DESCRIPTION
Main Issue: #1616 
```
softlayer-python/ (issue1616-vlan) $ slcli vlan cancel 123
This action cannot be undone! Type "123" or press Enter to abort: 123
VLAN 123 was cancelled.
```