### PR TITLE
Mishandling of domain and hostname data in `slcli account item-detail`

### DIFF
--- a/SoftLayer/CLI/account/item_detail.py
+++ b/SoftLayer/CLI/account/item_detail.py
@@ -28,7 +28,7 @@ def item_table(item):
     table.add_row(['cancellationDate', utils.clean_time(item.get('cancellationDate'), date_format, date_format)])
     table.add_row(['description', item.get('description')])
     table.align = 'l'
-    fqdn = "{}.{}".format(item.get('hostName'), item.get('domain'))
+    fqdn = "{}.{}".format(item.get('hostName', ''), item.get('domainName', ''))
     if fqdn != ".":
         table.add_row(['FQDN', fqdn])
 


### PR DESCRIPTION
Issue link: #1620 

```
softlayer-python/ (issue1620) $ slcli account item-detail 123
:...................................................................................:
:                             1 x 2.0 GHz or higher Core                            :
:.....................:.............................................................:
: Key                 : Value                                                       :
:.....................:.............................................................:
: createDate          : 2022-01-04                                                  :
: cycleStartDate      : 2022-04-03                                                  :
: cancellationDate    :                                                             :
: description         : 1 x 2.0 GHz or higher Core                                  :
: FQDN                : hostName.domainName.com                                           :
: hourlyRecurringFee  : 0                                                           :
: hoursUsed           : 442                                                         :
: currentHourlyCharge : 0                                                           :
: Ordered By          : User (Active)                                             :
: Notes               : None                                                        :
: Location            : dal10                                                       :
: ram                 : 2 GB                                                        :
: remote_management   : Reboot / Remote Console                                     :
: port_speed          : 100 Mbps Public & Private Network Uplinks                   :
: public_port         : 100 Mbps Public Uplink                                      :
: service_port        : 100 Mbps Private Uplink                                     :
: bandwidth           : 0 GB Bandwidth Allotment                                    :
: response            : Automated Reboot from Monitoring                            :
: vpn_management      : Unlimited SSL VPN Users                                     :
:.....................:.............................................................:
```
```
softlayer-python/ (issue1620) $ slcli account item-detail 1234
:.................................................................:
:           Citrix NetScaler VPX 12.1 10Mbps - Standard           :
:..................:..............................................:
: Key              : Value                                        :
:..................:..............................................:
: createDate       : 2022-02-11                                   :
: cycleStartDate   : 2022-04-03                                   :
: cancellationDate :                                              :
: description      : Citrix NetScaler VPX 12.1 10Mbps - Standard  :
: recurringFee     : 0                                            :
: Ordered By       : User (Active)                        :
: Notes            : SLADC307608-jt48                             :
: Location         : wdc07                                        :
:..................:..............................................:
```