### PR TITLE
Incorrect table title is displayed when an Auto Scale Group is scaled to reduce members

### DIFF
--- a/SoftLayer/CLI/autoscale/scale.py
+++ b/SoftLayer/CLI/autoscale/scale.py
@@ -37,14 +37,14 @@ def cli(env, identifier, scale_up, scale_by, amount):
 
     try:
         # Check if the first guest has a cancellation date, assume we are removing guests if it is.
-        cancel_date = result[0]['virtualGuest']['billingItem']['cancellationDate'] or False
+        status = result[0]['virtualGuest']['status']['keyName'] or False
     except (IndexError, KeyError, TypeError):
-        cancel_date = False
+        status = False
 
-    if cancel_date:
-        member_table = formatting.Table(['Id', 'Hostname', 'Created'], title="Cancelled Guests")
-    else:
+    if status == 'ACTIVE':
         member_table = formatting.Table(['Id', 'Hostname', 'Created'], title="Added Guests")
+    else:
+        member_table = formatting.Table(['Id', 'Hostname', 'Created'], title="Cancelled Guests")
 
     for guest in result:
         real_guest = guest.get('virtualGuest')


### PR DESCRIPTION
Issue: https://github.com/softlayer/softlayer-python/issues/1624
Observations: the title table was fixed to `--by -- down` and `--to` options to remove menbers

![image](https://user-images.githubusercontent.com/78806346/166067390-382094cb-1f64-4f90-bfe9-af998f2e296a.png)

![image](https://user-images.githubusercontent.com/78806346/166067421-2247b4c7-b5dd-4c39-acb5-0a8662f35ef2.png)
