### PR TITLE
Update `slcli report bandwidth` command

### DIFF
--- a/tests/CLI/modules/report_tests.py
+++ b/tests/CLI/modules/report_tests.py
@@ -183,7 +183,7 @@ class ReportTests(testing.TestCase):
         stripped_output = '[' + result.output.split('[', 1)[1]
         json_output = json.loads(stripped_output)
         self.assertEqual(json_output[0]['hostname'], 'pool1')
-        self.assertEqual(json_output[1]['private_in'], 0)
+        self.assertEqual(json_output[1]['private_out'], 40)
         self.assertEqual(json_output[2]['private_in'], 30)
         self.assertEqual(json_output[3]['type'], 'virtual')
 
@@ -266,7 +266,7 @@ class ReportTests(testing.TestCase):
         stripped_output = '[' + result.output.split('[', 1)[1]
         json_output = json.loads(stripped_output)
         self.assertEqual(json_output[0]['hostname'], 'pool1')
-        self.assertEqual(json_output[1]['private_in'], 0)
+        self.assertEqual(json_output[1]['private_out'], 40)
         self.assertEqual(json_output[2]['private_in'], 30)
         self.assertEqual(json_output[3]['type'], 'hardware')
 


### PR DESCRIPTION
Issue: https://github.com/softlayer/softlayer-python/issues/1663
Observations: the command was updated to only display pools with metric summary data and display pool name of hardware and virtual servers if they have instead pool id

```
slcli report bandwidth --start 2022-06-07 --end 2022-06-08
Generating bandwidth report for 2022-06-07 00:00:00 to 2022-06-08 00:00:00
Calculating for bandwidth pools  [####################################]  100%
Calculating for hardware  [####################################]  100%
Calculating for virtual  [####################################]  100%
┌──────────┬───────────────────────────┬───────────┬────────────┬────────────┬─────────────┬───────────┐
│   type   │         hostname          │ public_in │ public_out │ private_in │ private_out │   pool    │
├──────────┼───────────────────────────┼───────────┼────────────┼────────────┼─────────────┼───────────┤
│ virtual  │         KVM-Test          │   0.02G   │   0.02G    │   0.02G    │    0.00G    │     -     │
│   pool   │         MexRegion         │   0.05G   │   0.03G    │   0.02G    │    0.00G    │     -     │
│ virtual  │      VSItesttcreate1      │   0.02G   │   0.02G    │   0.02G    │    0.00G    │     -     │
│ virtual  │      VSItesttcreate2      │   0.04G   │   0.05G    │   0.01G    │    0.00G    │     -     │
│ virtual  │      activedirectory      │   0.00G   │   0.00G    │   0.02G    │    0.00G    │     -     │
│ virtual  │           adns            │   0.01G   │   0.00G    │   0.01G    │    0.00G    │     -     │
│ hardware │        bardcabero         │   0.04G   │   0.02G    │   0.03G    │    0.01G    │     -     │
│ hardware │          baredcb          │   0.04G   │   0.02G    │   0.03G    │    0.01G    │     -     │
│ hardware │        baremetal01        │   0.07G   │   0.03G    │   0.02G    │    0.00G    │     -     │
│ hardware │    baremetalwithgpu01     │   0.04G   │   0.02G    │   0.02G    │    0.00G    │     -     │
│ virtual  │        cloudbase01        │   0.05G   │   0.05G    │   0.00G    │    0.00G    │     -     │
│ virtual  │         dcdctest          │   0.00G   │   0.00G    │   0.02G    │    0.00G    │     -     │
│ virtual  │       dhGuestTest2        │   0.02G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ virtual  │          earios2          │   0.00G   │   0.00G    │   0.01G    │    0.00G    │     -     │
│ virtual  │          fotest           │   0.01G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ hardware │      fotestbaremetal      │   0.24G   │   0.24G    │   0.03G    │    0.01G    │     -     │
│ hardware │        gpu.vmware         │   0.02G   │   0.00G    │  2656.96G  │  6211.16G   │     -     │
│ hardware │       host11.vmware       │   0.05G   │   0.00G    │   0.09G    │    0.10G    │     -     │
│ hardware │       host12.vmware       │   0.03G   │   0.00G    │  161.95G   │   224.16G   │     -     │
│ hardware │       host13.vmware       │   0.03G   │   0.00G    │  2927.61G  │  1215.62G   │     -     │
│ hardware │          host14           │   0.03G   │   6.14G    │   0.09G    │    6.14G    │     -     │
│ hardware │          host15           │   0.03G   │   0.00G    │  917.65G   │  2374.25G   │     -     │
│ hardware │       host16.vmware       │  48.23G   │   15.10G   │  1518.57G  │  2624.43G   │     -     │
│ hardware │       host17.vmware       │   0.03G   │   0.00G    │  1574.43G  │  1935.94G   │     -     │
│ virtual  │      hostnameEdited       │   0.06G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ virtual  │         imageTest         │   0.02G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ virtual  │          lab-web          │   0.01G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ virtual  │          lab-web          │   0.01G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ virtual  │         openldap1         │   0.00G   │   0.00G    │   0.00G    │    0.00G    │     -     │
│ hardware │     phptesthostnameb      │   0.03G   │   0.03G    │   0.01G    │    0.00G    │     -     │
│ virtual  │   slcli-reserved-test1    │   0.02G   │   0.01G    │   0.01G    │    0.00G    │     -     │
│ hardware │ spectrum-virtualize-par-1 │   0.02G   │   0.00G    │   0.02G    │    0.00G    │     -     │
│ hardware │ spectrum-virtualize-par-2 │   0.04G   │   0.03G    │   0.02G    │    0.00G    │     -     │
│ hardware │ spectrum-virtualize-par-3 │   0.04G   │   0.03G    │   0.02G    │    0.00G    │     -     │
│ hardware │ spectrum-virtualize-tor-1 │   0.04G   │   0.03G    │   0.02G    │    0.00G    │     -     │
│ hardware │ spectrum-virtualize-tor-2 │   0.04G   │   0.03G    │   0.02G    │    0.00G    │     -     │
│ virtual  │  spectrum-virtualize-vsi  │   0.00G   │   0.00G    │   0.84G    │    0.00G    │     -     │
│ virtual  │        sv-install         │   0.02G   │   0.02G    │   0.75G    │    0.00G    │     -     │
│ virtual  │      sv-install-par       │   0.03G   │   0.03G    │   0.37G    │    0.00G    │     -     │
│ virtual  │        techsupport        │   0.00G   │   0.00G    │   0.00G    │    0.00G    │     -     │
│ virtual  │           test            │   0.02G   │   0.02G    │   0.02G    │    0.00G    │     -     │
│ virtual  │           test            │   0.02G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ virtual  │           test            │   0.04G   │   0.02G    │   0.02G    │    0.00G    │     -     │
│ virtual  │         testMssql         │   0.00G   │   0.00G    │   0.00G    │    0.00G    │     -     │
│ virtual  │         testORder         │   0.00G   │   0.00G    │   0.00G    │    0.00G    │     -     │
│ virtual  │         testTor01         │   0.05G   │   0.04G    │   0.00G    │    0.00G    │     -     │
│ virtual  │         testTor01         │   0.02G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ hardware │          testibm          │   0.08G   │   0.08G    │   0.02G    │    0.09G    │     -     │
│ virtual  │         testname          │   0.03G   │   0.03G    │   0.00G    │    0.00G    │     -     │
│ hardware │       testpooling2        │   0.05G   │   0.03G    │   0.02G    │    0.00G    │ MexRegion │
│ virtual  │         testslack         │   0.02G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ virtual  │      testttbootmode       │   0.02G   │   0.03G    │   0.00G    │    0.00G    │     -     │
│ hardware │        testuislcli        │   0.03G   │   0.00G    │   0.02G    │    0.00G    │     -     │
│ virtual  │        testvs-171d        │   0.01G   │   0.00G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-17b9        │   0.01G   │   0.01G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-1c30        │   0.01G   │   0.01G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-256f        │   0.01G   │   0.01G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-34c5        │   0.02G   │   0.03G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-3e6a        │   0.02G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-4085        │   0.02G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-4518        │   0.01G   │   0.01G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-6d7a        │   0.01G   │   0.01G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-7bc9        │   0.02G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-7dd0        │   0.01G   │   0.01G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-9052        │   0.01G   │   0.01G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-97e7        │   0.02G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-9dca        │   0.04G   │   0.04G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-a47a        │   0.01G   │   0.01G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-a5ef        │   0.01G   │   0.01G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-a7ad        │   0.01G   │   0.01G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-aef3        │   0.02G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-af7a        │   0.01G   │   0.01G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-b454        │   0.01G   │   0.01G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        testvs-fbf6        │   0.00G   │   0.00G    │   0.00G    │    0.00G    │     -     │
│ virtual  │        thinkerbell        │   0.03G   │   0.03G    │   0.02G    │    0.00G    │     -     │
│ virtual  │        upbootmode         │   0.00G   │   0.00G    │   0.00G    │    0.00G    │     -     │
│ virtual  │      upbootmode2333       │   0.02G   │   0.02G    │   0.01G    │    0.00G    │     -     │
│ virtual  │          upgrade          │   0.02G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ virtual  │      virtualserver01      │   0.02G   │   0.02G    │   0.00G    │    0.00G    │     -     │
│ virtual  │      virtualserver01      │   0.02G   │   0.02G    │   0.02G    │    0.00G    │     -     │
│ virtual  │   virtualserver01-9caa    │   0.03G   │   0.03G    │   0.00G    │    0.00G    │     -     │
│ virtual  │ virtualserverwithfirewall │   0.04G   │   0.01G    │   0.00G    │    0.00G    │     -     │
│ virtual  │            vpn            │   0.02G   │   0.03G    │   0.00G    │    0.00G    │     -     │
│ virtual  │          windows          │   0.16G   │   0.14G    │   0.00G    │    0.00G    │     -     │
└──────────┴───────────────────────────┴───────────┴────────────┴────────────┴─────────────┴───────────┘

```