### PR TITLE
Improved successful response to command - slcli vs cancel

### DIFF
--- a/SoftLayer/CLI/virt/cancel.py
+++ b/SoftLayer/CLI/virt/cancel.py
@@ -21,4 +21,7 @@ def cli(env, identifier):
     if not (env.skip_confirmations or formatting.no_going_back(vs_id)):
         raise exceptions.CLIAbort('Aborted')
 
-    vsi.cancel_instance(vs_id)
+    vs = vsi.cancel_instance(vs_id)
+
+    if vs:
+        env.fout("The virtual server instance: {} was cancelled.".format(vs_id))

--- a/SoftLayer/CLI/virt/cancel.py
+++ b/SoftLayer/CLI/virt/cancel.py
@@ -21,7 +21,7 @@ def cli(env, identifier):
     if not (env.skip_confirmations or formatting.no_going_back(vs_id)):
         raise exceptions.CLIAbort('Aborted')
 
-    vs = vsi.cancel_instance(vs_id)
+    virtual_server = vsi.cancel_instance(vs_id)
 
-    if vs:
+    if virtual_server:
         env.fout("The virtual server instance: {} was cancelled.".format(vs_id))


### PR DESCRIPTION
Main Issue: #1616 
```
softlayer-python/ (issue1616-virtual-cancel) $ slcli vs cancel 123456
This action cannot be undone! Type "123456" or press Enter to abort: 123456
The virtual server instance: 123456 was cancelled.
```