### PR TITLE
Fixed an issue with printing tables that contained empty items

### DIFF
--- a/SoftLayer/CLI/formatting.py
+++ b/SoftLayer/CLI/formatting.py
@@ -72,7 +72,12 @@ def format_prettytable(table, fmt='table'):
     """Converts SoftLayer.CLI.formatting.Table instance to a prettytable."""
     for i, row in enumerate(table.rows):
         for j, item in enumerate(row):
-            table.rows[i][j] = format_output(item)
+            # Issue when adding items that evaulate to None (like empty lists) for Rich Tables
+            # so we just cast those to a str
+            if item:
+                table.rows[i][j] = format_output(item)
+            else:
+                table.rows[i][j] = str(item)
     ptable = table.prettytable(fmt)
     return ptable
 

--- a/tests/CLI/helper_tests.py
+++ b/tests/CLI/helper_tests.py
@@ -484,3 +484,13 @@ class IterToTableTests(testing.TestCase):
 
         self.assertIsInstance(result, formatting.Table)
         self.assertEqual(result.columns, ['key'])
+
+    def test_format_api_list_with_empty_array(self):
+        result = formatting.iter_to_table([{'id': 130224450, 'activeTickets': []}])
+        self.assertIsInstance(result, formatting.Table)
+        self.assertIn('id', result.columns)
+        self.assertIn('activeTickets', result.columns)
+        formatted = formatting.format_output(result, "table")
+        # No good ways to test whats actually in a Rich.Table without going through the hassel of
+        # printing it out. As long as this didn't throw and exception it should be fine.
+        self.assertEqual(formatted.row_count, 1)


### PR DESCRIPTION
Fixed an issue where printing an empty list would cause Rich.Table to crash
Fixes #1658

## Before

![image](https://user-images.githubusercontent.com/7408017/179061977-c1b73543-dd0c-4f7d-9314-4be0b74f3ae6.png)


## After
![image](https://user-images.githubusercontent.com/7408017/179062066-d6d38dd6-958f-49f7-9c9e-94c0eeecedc9.png)


