### PR TITLE
Command slcli vlan create - displaying an error message

### DIFF
--- a/SoftLayer/CLI/vlan/create.py
+++ b/SoftLayer/CLI/vlan/create.py
@@ -28,7 +28,7 @@ def cli(env, name, datacenter, pod, network, billing):
     """
 
     if not (datacenter or pod):
-        raise exceptions.CLIAbort("Is required Datacenter or Pod")
+        raise exceptions.CLIAbort("--datacenter or --pod is required to create a VLAN")
 
     item_package = ['PUBLIC_NETWORK_VLAN']
     complex_type = 'SoftLayer_Container_Product_Order_Network_Vlan'

--- a/SoftLayer/CLI/vlan/create.py
+++ b/SoftLayer/CLI/vlan/create.py
@@ -19,7 +19,16 @@ from SoftLayer.CLI import formatting
               help="Billing rate")
 @environment.pass_env
 def cli(env, name, datacenter, pod, network, billing):
-    """Order/create a VLAN instance."""
+    """Order/create a VLAN instance.
+
+    Example:
+        slcli vlan create --name myvlan --datacenter dal13
+        or
+        slcli vlan create --name myvlan --pod dal10.pod01
+    """
+
+    if not (datacenter or pod):
+        raise exceptions.CLIAbort("Is required Datacenter or Pod")
 
     item_package = ['PUBLIC_NETWORK_VLAN']
     complex_type = 'SoftLayer_Container_Product_Order_Network_Vlan'


### PR DESCRIPTION
Issue link: #1706 
```
softlayer-python/ (issue1706 *) $ slcli vlan create -h
Usage: slcli vlan create [OPTIONS]

        Order/create a VLAN instance.

Example:
    slcli vlan create --name myvlan --datacenter dal13
    or
    slcli vlan create --name myvlan --pod dal10.pod01

┌────┬──────────────┬──────────────────────────────────────┐
│    │ --name       │ Vlan name                            │
│ -d │ --datacenter │ Datacenter shortname                 │
│ -p │ --pod        │ Pod name. E.g dal05.pod01            │
│    │ --network    │ Network vlan type  [default: public] │
│    │ --billing    │ Billing rate  [default: hourly]      │
│ -h │ --help       │ Show this message and exit.          │
└────┴──────────────┴──────────────────────────────────────┘
```