### PR TITLE
`slcli block subnets-list` command display an error message

### DIFF
--- a/SoftLayer/CLI/block/subnets/list.py
+++ b/SoftLayer/CLI/block/subnets/list.py
@@ -10,7 +10,6 @@ from SoftLayer.CLI import helpers
 
 COLUMNS = [
     'id',
-    'createDate',
     'networkIdentifier',
     'cidr'
 ]
@@ -33,7 +32,6 @@ def cli(env, access_id):
         table = formatting.Table(COLUMNS)
         for subnet in subnets:
             row = ["{0}".format(subnet['id']),
-                   "{0}".format(subnet['createDate']),
                    "{0}".format(subnet['networkIdentifier']),
                    "{0}".format(subnet['cidr'])]
             table.add_row(row)


### PR DESCRIPTION
Issue: https://github.com/softlayer/softlayer-python/issues/1715
Observations: `create date` column was removed because the attribute does not exist in the API response 
```
slcli block subnets-list 2509552
┌────────┬───────────────────┬──────┐
│   id   │ networkIdentifier │ cidr │
├────────┼───────────────────┼──────┤
│ 834737 │  10.114.150.192   │  26  │
└────────┴───────────────────┴──────┘

```