### PR TITLE
Add Devices with Trunks to vlan detail

### DIFF
--- a/SoftLayer/CLI/vlan/detail.py
+++ b/SoftLayer/CLI/vlan/detail.py
@@ -60,7 +60,7 @@ def cli(env, identifier, no_vs, no_hardware, no_trunks):
         # subnets.append(subnet_table)
         table.add_row(['subnets', subnet_table])
     else:
-        table.add_row(['subnets', 'none'])
+        table.add_row(['subnets', '-'])
 
     server_columns = ['hostname', 'domain', 'public_ip', 'private_ip']
 
@@ -74,7 +74,7 @@ def cli(env, identifier, no_vs, no_hardware, no_trunks):
                                   vsi.get('primaryBackendIpAddress')])
             table.add_row(['vs', vs_table])
         else:
-            table.add_row(['vs', 'none'])
+            table.add_row(['vs', '-'])
 
     if not no_hardware:
         if vlan.get('hardware'):
@@ -86,7 +86,7 @@ def cli(env, identifier, no_vs, no_hardware, no_trunks):
                                   hardware.get('primaryBackendIpAddress')])
             table.add_row(['hardware', hw_table])
         else:
-            table.add_row(['hardware', 'none'])
+            table.add_row(['hardware', '-'])
 
     if not no_trunks:
         if vlan.get('networkComponentTrunks'):
@@ -101,7 +101,7 @@ def cli(env, identifier, no_vs, no_hardware, no_trunks):
                                                                    'hardware', 'tagReferences'))])
             table.add_row(['trunks', trunks_table])
         else:
-            table.add_row(['trunks', 'none'])
+            table.add_row(['trunks', '-'])
 
     env.fout(table)
 

--- a/SoftLayer/managers/network.py
+++ b/SoftLayer/managers/network.py
@@ -438,7 +438,6 @@ class NetworkManager(object):
                   the specified VLAN.
         """
 
-        _mask = None
         if mask:
             _mask = mask
         else:

--- a/SoftLayer/managers/network.py
+++ b/SoftLayer/managers/network.py
@@ -429,15 +429,22 @@ class NetworkManager(object):
 
         return self.subnet.getObject(id=subnet_id, **kwargs)
 
-    def get_vlan(self, vlan_id):
+    def get_vlan(self, vlan_id, mask=None):
         """Returns information about a single VLAN.
 
-        :param int id: The unique identifier for the VLAN
+        :param int vlan_id: The unique identifier for the VLAN
+        :param string mask: mask for request
         :returns: A dictionary containing a large amount of information about
                   the specified VLAN.
-
         """
-        return self.vlan.getObject(id=vlan_id, mask=DEFAULT_GET_VLAN_MASK)
+
+        _mask = None
+        if mask:
+            _mask = mask
+        else:
+            _mask = DEFAULT_GET_VLAN_MASK
+
+        return self.vlan.getObject(id=vlan_id, mask=_mask)
 
     def list_global_ips(self, version=None, identifier=None, **kwargs):
         """Returns a list of all global IP address records on the account.


### PR DESCRIPTION
Issue link #1718
```
softlayer-python/ () $ slcli vlan detail -h
Usage: slcli vlan detail [OPTIONS] IDENTIFIER

        Get details about a VLAN.

┌────┬───────────────┬─────────────────────────────┐
│    │ identifier    │                             │
│    │ --no-vs       │ Hide virtual server listing │
│    │ --no-hardware │ Hide hardware listing       │
│    │ --no-trunks   │ Hide devices with trunks    │
│ -h │ --help        │ Show this message and exit. │
└────┴───────────────┴─────────────────────────────┘

softlayer-python/ () $ slcli vlan detail 1404269
┌──────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────┐
│             name │ value                                                                                                │
├──────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────┤
│               id │ 1404269                                                                                              │
│           number │ 1632                                                                                                 │
│       datacenter │ Dallas 10                                                                                            │
│   primary_router │ bcr01a.dal10.softlayer.com                                                                           │
│ Gateway/Firewall │ -                                                                                                    │
│          subnets │ ┌─────────┬───────────────┬─────────────────┬───────────────┬────────────────────┬────────────┐      │
│                  │ │   id    │  identifier   │     netmask     │    gateway    │        type        │ usable ips │      │
│                  │ ├─────────┼───────────────┼─────────────────┼───────────────┼────────────────────┼────────────┤      │
│                  │ │ 2290190 │ 10.176.39.128 │ 255.255.255.192 │ 10.176.39.129 │ ADDITIONAL_PRIMARY │     61     │      │
│                  │ └─────────┴───────────────┴─────────────────┴───────────────┴────────────────────┴────────────┘      │
│               vs │ none                                                                                                 │
│         hardware │ none                                                                                                 │
│           trunks │ ┌──────────────────────────┬────────┬──────────────────────────────────────────────────────────────┐ │
│                  │ │          device          │  port  │                             tags                             │ │
│                  │ ├──────────────────────────┼────────┼──────────────────────────────────────────────────────────────┤ │
│                  │ │ host17.vmware.chechu.com │ eth0/2 │ tape tool: vmware-demo-lab-chechu, tape tool: chechu-testing │ │
│                  │ │ host16.vmware.chechu.com │ eth0/2 │ tape tool: vmware-demo-lab-chechu, tape tool: chechu-testing │ │
│                  │ │ host15.vmware.chechu.com │ eth0/2 │ tape tool: vmware-demo-lab-chechu, tape tool: chechu-testing │ │
│                  │ └──────────────────────────┴────────┴──────────────────────────────────────────────────────────────┘ │
└──────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────┘
```