### PR TITLE
slcli hardware reflash-firmware command does not display success message

### DIFF
--- a/SoftLayer/CLI/hardware/reflash_firmware.py
+++ b/SoftLayer/CLI/hardware/reflash_firmware.py
@@ -23,7 +23,5 @@ def cli(env, identifier):
                                'reflash device firmware. Continue?' % hw_id)):
         raise exceptions.CLIAbort('Aborted.')
 
-    success = mgr.reflash_firmware(hw_id)
-    if success:
-        message = 'Successfully device firmware reflashed'
-        click.echo(message)
+    if mgr.reflash_firmware(hw_id):
+        click.echo('Successfully device firmware reflashed')

--- a/SoftLayer/CLI/hardware/reflash_firmware.py
+++ b/SoftLayer/CLI/hardware/reflash_firmware.py
@@ -23,4 +23,7 @@ def cli(env, identifier):
                                'reflash device firmware. Continue?' % hw_id)):
         raise exceptions.CLIAbort('Aborted.')
 
-    mgr.reflash_firmware(hw_id)
+    success = mgr.reflash_firmware(hw_id)
+    if success:
+        message = 'Successfully device firmware reflashed'
+        click.echo(message)

--- a/tests/CLI/modules/server_tests.py
+++ b/tests/CLI/modules/server_tests.py
@@ -523,7 +523,7 @@ class ServerCLITests(testing.TestCase):
         result = self.run_command(['server', 'reflash-firmware', '1000'])
 
         self.assert_no_fail(result)
-        self.assertEqual(result.output, "")
+        self.assertEqual(result.output, 'Successfully device firmware reflashed\n')
         self.assert_called_with('SoftLayer_Hardware_Server',
                                 'createFirmwareReflashTransaction',
                                 args=((1, 1, 1)), identifier=1000)


### PR DESCRIPTION
Issue: https://github.com/softlayer/softlayer-python/issues/1723
Observations:  A success message was added
```
slcli hardware reflash-firmware 1532729
This will power off the server with id 1532729 and reflash device firmware. Continue? [y/N]: y
Successfully device firmware reflashed

```