### PR TITLE
Add status, create date and domain columns in `slcli vs list command`

### DIFF
--- a/SoftLayer/CLI/virt/list.py
+++ b/SoftLayer/CLI/virt/list.py
@@ -36,9 +36,12 @@ COLUMNS = [
 DEFAULT_COLUMNS = [
     'id',
     'hostname',
+    'domain',
+    'deviceStatus.name',
+    'datacenter',
     'primary_ip',
     'backend_ip',
-    'datacenter',
+    'createDate',
     'action',
 ]
 


### PR DESCRIPTION
Issue: https://github.com/softlayer/softlayer-python/issues/1727
Observations:  status, create date and domain columns were added 
```
softlayer-python> slcli vs list
┌───────────┬─────────────────────────┬────────────────────────────────────────────────┬───────────────────┬────────────┬────────────────┬────────────────┬───────────────────────────┬──────────────────────────────────────────────────┐
│    id     │        hostname         │                     domain                     │ deviceStatus.name │ datacenter │   primary_ip   │   backend_ip   │        createDate         │                      action                      │
├───────────┼─────────────────────────┼────────────────────────────────────────────────┼───────────────────┼────────────┼────────────────┼────────────────┼───────────────────────────┼──────────────────────────────────────────────────┤
│ 121401696 │        KVM-Test         │                   cgallo.com                   │      Running      │   dal13    │  169.48.96.27  │  10.208.73.53  │ 2021-06-09T14:49:28-06:00 │                        -                         │
│ 112238162 │      SuspendVsTest      │                 softlayer.test                 │      Running      │   dal12    │       -        │  10.74.54.76   │ 2020-11-16T09:01:57-06:00 │                        -                         │
│ 107879710 │     VSItesttcreate1     │                   test.local                   │      Running      │   dal05    │ 75.126.18.179  │  10.86.20.151  │ 2020-08-24T09:00:38-06:00 │                        -                         │
│ 107879712 │     VSItesttcreate2     │                   test.local                   │      Running      │   dal05    │ 75.126.18.182  │  10.86.20.142  │ 2020-08-24T09:00:38-06:00 │                        -                         │
│ 100317048 │     activedirectory     │                   chechu.com                   │      Running      │   dal13    │       -        │  10.208.73.55  │ 2020-04-07T04:01:49-06:00 │                        -                         │
│ 100250634 │          adns           │               vmware.chechu.com                │      Running      │   dal10    │ 169.46.48.110  │ 10.177.122.174 │ 2020-04-06T05:28:15-06:00 │                        -                         │
│ 116114480 │       cloudbase01       │                   cgallo.com                   │      Running      │   dal13    │  52.116.23.73  │  10.73.116.49  │ 2021-02-09T14:42:03-06:00 │                        -                         │
│ 121450334 │      dcbtestscript      │                 dcbtest.local                  │      Running      │   sjc04    │       -        │  10.87.19.120  │ 2021-06-10T12:29:35-06:00 │                        -                         │
│ 105751868 │        dcdctest         │    SoftLayer-tesch-support-Community.cloud     │      Running      │   dal13    │  169.48.96.30  │  10.208.73.7   │ 2020-07-14T08:03:07-06:00 │                        -                         │
│ 131791446 │         delete          │                   cgallo.com                   │      Running      │   dal13    │  52.116.23.71  │  10.73.116.8   │ 2022-07-06T14:35:08-06:00 │                        -                         │
│ 127671714 │      dhGuestTest2       │                   cgallo.com                   │      Running      │   dal13    │  52.116.23.68  │  10.73.116.6   │ 2022-01-31T07:29:02-06:00 │                        -                         │
│ 132364928 │        easerverh        │                easerverd.cloud                 │      Running      │   dal13    │ 67.228.227.82  │ 10.37.211.196  │ 2022-08-11T10:52:46-06:00 │                        -                         │
│ 120487918 │         fotest          │                   test.local                   │      Running      │   dal05    │ 108.168.148.28 │  10.82.12.198  │ 2021-05-19T12:29:55-06:00 │                        -                         │
│ 127270182 │        imageTest        │                   cgallo.com                   │      Running      │   mex01    │  169.57.37.42  │ 10.131.14.188  │ 2022-01-13T17:34:43-06:00 │                        -                         │
│ 127890078 │         lab-web         │                    test.com                    │      Running      │   dal05    │ 108.168.148.27 │  10.82.12.203  │ 2022-02-08T08:31:46-06:00 │                        -                         │
│ 127890106 │         lab-web         │                    test.com                    │      Running      │   dal05    │ 108.168.148.26 │  10.82.12.220  │ 2022-02-08T08:33:12-06:00 │                        -                         │
│ 60971505  │        openldap1        │                   chechu.com                   │      Running      │   ams03    │       -        │ 10.175.106.141 │ 2018-09-05T13:10:55-06:00 │                        -                         │
│ 102396266 │        reserved         │                  example.com                   │      Stopped      │   dal13    │       -        │       -        │ 2020-05-12T14:10:22-06:00 │                        -                         │
│ 114583216 │  slcli-reserved-test1   │                 testslcli.com                  │      Running      │   dal13    │  52.116.23.76  │  10.73.116.54  │ 2021-01-06T14:12:23-06:00 │                        -                         │
│ 129300354 │ spectrum-virtualize-vsi │                   chechu.com                   │      Running      │   tor01    │ 169.53.167.198 │ 10.114.140.225 │ 2022-03-29T09:14:19-06:00 │                        -                         │
│ 127854700 │       sv-install        │                   chechu.com                   │      Running      │   tor01    │ 169.53.167.203 │ 10.114.140.218 │ 2022-02-07T06:04:02-06:00 │                        -                         │
│ 129168000 │     sv-install-par      │                   chechu.com                   │      Running      │   par01    │  159.8.110.89  │ 10.126.118.26  │ 2022-03-24T08:05:55-06:00 │                        -                         │
│ 109648788 │       techsupport       │ SoftLayer-Internal-Development-Community.cloud │      Running      │   sao01    │ 169.57.227.67  │ 10.151.109.245 │ 2020-09-25T09:34:12-06:00 │                        -                         │
│ 119825818 │          test           │                   chechu.com                   │      Running      │   ams03    │ 169.50.188.50  │ 10.175.106.173 │ 2021-05-04T02:38:15-06:00 │                        -                         │
│ 120531054 │          test           │                 softlayer.com                  │      Running      │   dal13    │  169.48.96.18  │  10.208.73.4   │ 2021-05-20T08:11:02-06:00 │                        -                         │
│ 102381798 │        testMssql        │ SoftLayer-Internal-Development-Community.cloud │      Stopped      │   dal13    │  52.116.23.75  │  10.73.116.12  │ 2020-05-12T09:08:26-06:00 │                        -                         │
│ 127747404 │        testORder        │                   cgallo.com                   │      Running      │   fra05    │ 149.81.77.151  │ 10.123.97.203  │ 2022-02-02T17:57:38-06:00 │                        -                         │
│ 113317688 │        testTor01        │                   cgallo.com                   │      Running      │   tor01    │  169.55.163.4  │  10.167.88.19  │ 2020-12-08T20:14:20-06:00 │                        -                         │
│ 113520242 │        testTor01        │                   cgallo.com                   │      Running      │   tor01    │ 169.55.163.10  │  10.167.88.22  │ 2020-12-12T10:04:58-06:00 │                        -                         │
│ 106291032 │       testingEdit       │                  deleteme.com                  │      Running      │   mex01    │  169.57.37.38  │ 10.131.14.169  │ 2020-07-24T12:34:04-06:00 │                        -                         │
│ 113821290 │        testname         │          Development-Community.cloud           │      Running      │   dal13    │  52.116.23.72  │  10.73.116.31  │ 2020-12-18T13:46:30-06:00 │                        -                         │
│ 127889958 │        testslack        │                    test.com                    │      Running      │   mex01    │  169.57.37.40  │ 10.131.14.144  │ 2022-02-08T08:25:48-06:00 │                        -                         │
│ 106893716 │     testttbootmode      │               softlayer.ibm.com                │      Running      │   ams01    │ 159.122.26.60  │  10.71.53.26   │ 2020-08-05T16:36:20-06:00 │                        -                         │
│ 130274066 │       testvs-171d       │                    test.com                    │      Running      │   hkg02    │ 119.81.231.20  │ 10.111.177.149 │ 2022-05-09T08:41:16-06:00 │                        -                         │
│ 130180924 │       testvs-17b9       │                    test.com                    │      Running      │   hkg02    │ 119.81.231.25  │ 10.111.177.181 │ 2022-05-04T15:56:08-06:00 │                        -                         │
│ 130180820 │       testvs-1c30       │                    test.com                    │      Running      │   hkg02    │ 119.81.157.172 │ 10.111.177.182 │ 2022-05-04T15:31:11-06:00 │                        -                         │
│ 130180822 │       testvs-256f       │                    test.com                    │      Running      │   hkg02    │ 119.81.157.171 │ 10.111.177.173 │ 2022-05-04T15:31:11-06:00 │                        -                         │
│ 130224452 │       testvs-34c5       │                    test.com                    │      Running      │   hkg02    │ 119.81.231.24  │ 10.111.177.147 │ 2022-05-06T08:10:24-06:00 │                        -                         │
│ 129904788 │       testvs-3e6a       │                    test.com                    │      Running      │   hkg02    │ 169.56.136.59  │ 10.174.81.135  │ 2022-04-22T08:09:00-06:00 │                        -                         │
│ 129886746 │       testvs-4085       │                    test.com                    │      Running      │   sjc04    │  169.62.95.28  │  10.87.19.72   │ 2022-04-21T15:45:14-06:00 │                        -                         │
│ 130180824 │       testvs-4518       │                    test.com                    │      Running      │   hkg02    │ 119.81.157.170 │ 10.111.177.170 │ 2022-05-04T15:31:11-06:00 │                        -                         │
│ 129906398 │       testvs-6d7a       │                    test.com                    │      Running      │   hkg02    │ 169.56.136.57  │ 10.174.81.153  │ 2022-04-22T09:07:26-06:00 │                        -                         │
│ 129906774 │       testvs-7bc9       │                    test.com                    │      Running      │   hkg02    │ 169.56.136.56  │ 10.174.81.160  │ 2022-04-22T09:30:53-06:00 │                        -                         │
│ 130180888 │       testvs-7dd0       │                    test.com                    │      Running      │   hkg02    │ 119.81.157.173 │ 10.111.177.132 │ 2022-05-04T15:52:51-06:00 │                        -                         │
│ 130199968 │       testvs-9052       │                    test.com                    │      Running      │   hkg02    │ 119.81.231.19  │ 10.111.177.136 │ 2022-05-05T09:44:04-06:00 │                        -                         │
│ 129911702 │       testvs-97e7       │                    test.com                    │      Running      │   sjc04    │  169.62.95.18  │  10.87.19.75   │ 2022-04-22T13:45:28-06:00 │                        -                         │
│ 129906358 │       testvs-9dca       │                    test.com                    │      Running      │   hkg02    │ 169.56.136.62  │ 10.174.81.146  │ 2022-04-22T09:03:42-06:00 │                        -                         │
│ 130180892 │       testvs-a47a       │                    test.com                    │      Running      │   hkg02    │ 119.81.231.26  │ 10.111.177.154 │ 2022-05-04T15:52:51-06:00 │                        -                         │
│ 130224454 │       testvs-a5ef       │                    test.com                    │      Running      │   hkg02    │ 119.81.231.27  │ 10.111.177.158 │ 2022-05-06T08:10:24-06:00 │                        -                         │
│ 130180926 │       testvs-a7ad       │                    test.com                    │      Running      │   hkg02    │ 119.81.231.30  │ 10.111.177.160 │ 2022-05-04T15:56:08-06:00 │                        -                         │
│ 130200056 │       testvs-aef3       │                    test.com                    │      Running      │   hkg02    │ 119.81.231.28  │ 10.111.177.141 │ 2022-05-05T09:52:48-06:00 │                        -                         │
│ 130180890 │       testvs-af7a       │                    test.com                    │      Running      │   hkg02    │ 119.81.157.174 │ 10.111.177.140 │ 2022-05-04T15:52:51-06:00 │                        -                         │
│ 130224450 │       testvs-b454       │                    test.com                    │      Running      │   hkg02    │ 119.81.231.23  │ 10.111.177.155 │ 2022-05-06T08:10:24-06:00 │                        -                         │
│ 130180928 │       testvs-fbf6       │                    test.com                    │      Running      │   hkg02    │ 119.81.231.21  │ 10.111.177.156 │ 2022-05-04T15:56:08-06:00 │                        -                         │
│ 129198876 │       thinkerbell       │                   chechu.com                   │    Reclaiming     │   par01    │  159.8.110.82  │ 10.126.118.60  │ 2022-03-25T04:30:36-06:00 │ This is a buffer time in which the customer may  │
│           │                         │                                                │                   │            │                │                │                           │                cancel the server                 │
│ 106875080 │       upbootmode        │ SoftLayer-Internal-Development-Community.cloud │      Running      │   tor01    │ 169.53.167.196 │ 10.114.140.198 │ 2020-08-05T09:21:36-06:00 │                        -                         │
│ 107002374 │     upbootmode2333      │                   test.local                   │      Running      │   dal05    │ 75.126.18.180  │  10.86.20.130  │ 2020-08-07T16:06:50-06:00 │                        -                         │
│ 106762910 │         upgrade         │ SoftLayer-Internal-Development-Community.cloud │      Running      │   dal13    │  52.116.23.78  │  10.73.116.18  │ 2020-08-03T10:03:11-06:00 │                        -                         │
│ 117718622 │     virtualserver01     │ SoftLayer-Internal-Development-Community.cloud │      Running      │   mil01    │ 159.122.145.71 │ 10.144.242.84  │ 2021-03-17T08:29:55-06:00 │                        -                         │
│ 126625632 │     virtualserver01     │ SoftLayer-Internal-Development-Community.cloud │      Running      │   dal13    │  169.48.96.29  │  10.208.73.18  │ 2021-12-10T15:49:29-06:00 │                        -                         │
│ 130086212 │  virtualserver01-9caa   │ SoftLayer-Internal-Development-Community.cloud │      Running      │   ams03    │  159.8.203.54  │  10.137.157.7  │ 2022-04-29T13:47:51-06:00 │                        -                         │
│ 118345654 │           vpn           │                   chechu.com                   │      Running      │   ams01    │ 159.122.26.62  │  10.71.53.27   │ 2021-03-30T11:08:05-06:00 │                        -                         │
│ 127557772 │         windows         │                   chechu.com                   │      Running      │   par01    │  159.8.110.83  │ 10.126.118.41  │ 2022-01-26T09:49:38-06:00 │                        -                         │
└───────────┴─────────────────────────┴────────────────────────────────────────────────┴───────────────────┴────────────┴────────────────┴────────────────┴───────────────────────────┴──────────────────────────────────────────────────┘
```