### PR TITLE
Snapcraft: Updated to Core22 and  add homeishome-launch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
 
 license: MIT
 
-base: core20
+base: core22
 grade: stable 
 confinement: strict
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,9 +10,14 @@ base: core22
 grade: stable 
 confinement: strict
 
+assumes:
+  - command-chain
+
 apps:
   slcli:
     command: bin/slcli
+    command-chain: 
+      - bin/homeishome-launch        
     environment: 
       LC_ALL: C.UTF-8
     plugs:
@@ -34,3 +39,8 @@ parts:
       
     stage-packages:
       - python3
+
+  homeishome-launch:
+    plugin: nil
+    stage-snaps:
+      - homeishome-launch     


### PR DESCRIPTION
Propose upgrade to core22 and add homeishome-launch.

homeishome-launch is a "helper" to improve UX. 