### PR TITLE
`slcli vs upgrade --resize-disk` is resizing another disk and not the selected one

### DIFF
--- a/SoftLayer/fixtures/SoftLayer_Product_Package.py
+++ b/SoftLayer/fixtures/SoftLayer_Product_Package.py
@@ -2216,3 +2216,63 @@ getItems_IPSEC = [{
         }
     ]
 }]
+
+getVSDiskItemPrices = [
+    {
+        "id": 2255,
+        "locationGroupId": None,
+        "categories": [
+            {
+                "categoryCode": "guest_disk1",
+                "id": 82,
+                "name": "Second Disk",
+                "quantityLimit": 0,
+                "sortOrder": None
+            },
+            {
+                "categoryCode": "guest_disk2",
+                "id": 92,
+                "name": "Third Disk",
+                "quantityLimit": 0,
+                "sortOrder": None
+            },
+            {
+                "categoryCode": "guest_disk3",
+                "id": 93,
+                "name": "Fourth Disk",
+                "quantityLimit": 0,
+                "sortOrder": None
+            },
+            {
+                "categoryCode": "guest_disk4",
+                "id": 116,
+                "name": "Fifth Disk",
+                "quantityLimit": 0,
+                "sortOrder": None
+            }
+        ],
+        "item": {
+            "capacity": "10",
+            "description": "10 GB (SAN)",
+            "keyName": "GUEST_DISK_10_GB_SAN"
+        }
+    },
+    {
+        "id": 1639,
+        "locationGroupId": None,
+        "categories": [
+            {
+                "categoryCode": "guest_disk0",
+                "id": 81,
+                "name": "First Disk",
+                "quantityLimit": 0,
+                "sortOrder": None
+            }
+        ],
+        "item": {
+            "capacity": "10",
+            "description": "10 GB (SAN)",
+            "keyName": "GUEST_DISK_10_GB_SAN"
+        }
+    }
+]

--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -1105,7 +1105,10 @@ class VSManager(utils.IdentifierMixin, object):
         return False
 
     def get_disk_category_id_by_disk_number(self, capacity, disk_number):
-        """Uses Product_Package::getItemPrices to get all disk items with its categories."""
+        """Uses Product_Package::getItemPrices to get all disk items with its categories and
+
+        disk_key_names dictionary to convert disk numbers (int) to ordinal numbers (string)
+        """
         disk_key_names = {
             1: "First Disk",
             2: "Second Disk",

--- a/tests/CLI/modules/vs/vs_tests.py
+++ b/tests/CLI/modules/vs/vs_tests.py
@@ -10,6 +10,7 @@ import sys
 from unittest import mock as mock
 
 from SoftLayer.CLI import exceptions
+from SoftLayer.fixtures import SoftLayer_Product_Package
 from SoftLayer.fixtures import SoftLayer_Virtual_Guest as SoftLayer_Virtual_Guest
 from SoftLayer import SoftLayerAPIError
 from SoftLayer import SoftLayerError
@@ -565,6 +566,8 @@ class VirtTests(testing.TestCase):
     @mock.patch('SoftLayer.CLI.formatting.confirm')
     def test_upgrade_disk(self, confirm_mock):
         confirm_mock.return_value = True
+        mock = self.set_mock('SoftLayer_Product_Package', 'getItemPrices')
+        mock.return_value = SoftLayer_Product_Package.getVSDiskItemPrices
         result = self.run_command(['vs', 'upgrade', '100', '--flavor=M1_64X512X100',
                                    '--resize-disk=10', '1', '--resize-disk=10', '2'])
         self.assert_no_fail(result)
@@ -598,6 +601,8 @@ class VirtTests(testing.TestCase):
     @mock.patch('SoftLayer.CLI.formatting.confirm')
     def test_upgrade_with_add_disk(self, confirm_mock):
         confirm_mock.return_value = True
+        mock = self.set_mock('SoftLayer_Product_Package', 'getItemPrices')
+        mock.return_value = SoftLayer_Product_Package.getVSDiskItemPrices
         result = self.run_command(['vs', 'upgrade', '100', '--add-disk=10', '--add-disk=10'])
         self.assert_no_fail(result)
         self.assert_called_with('SoftLayer_Product_Order', 'placeOrder')


### PR DESCRIPTION
Issue: https://github.com/softlayer/softlayer-python/issues/1802
Observations: The command was updated to resize disk using category id instead category code
```
slcli vs upgrade 134499384 --resize-disk 10 4
This action will incur charges on your account. Continue? [y/N]: y
```
![image](https://user-images.githubusercontent.com/78806346/206031529-f5d192f6-5946-474b-85e5-f5a2bd799502.png)
