### PR TITLE
Added example to slcli call-api

### DIFF
--- a/SoftLayer/CLI/call_api.py
+++ b/SoftLayer/CLI/call_api.py
@@ -150,6 +150,9 @@ def cli(env, service, method, parameters, _id, _filters, mask, limit, offset, or
             '[{"keyName": "NETWORK_MESSAGE_DELIVERY_MANAGE"}]'
         slcli call-api Account getVirtualGuests \\
             --orderBy virttualguests.id=ASC
+        slcli call-api SoftLayer_Notification_Occurrence_Event getAllObjects \\
+            --json-filter='{"endDate": {"operation": "greaterThanDate", \\
+            "options": [{"name":"date", "value": ["10/14/2022"]}]}}' --limit=50
     """
 
     if _filters and json_filter:


### PR DESCRIPTION
Issue link: #1770

Using to another form, its possible use the filter using dates, like that:
`slcli -vvv call-api SoftLayer_Notification_Occurrence_Event getAllObjects --mask="mask[id, subject, startDate, endDate]" --json-filter='{"notificationOccurrenceEventType": {"keyName": {"operation": "PLANNED"}}, "endDate": {"operation": "greaterThanDate", "options": [{"name":"date", "value": ["10/14/2022"]}]}, "startDate": {"operation": "orderBy", "options": [{"name": "sort", "value": ["DESC"]}]}}' --limit=50`

Its neccesary use the date the follow form:
`["10/14/2022"]`

I added an example to how use this type of dates

Result of the request:
```
┌───────────────────────────┬────────┬───────────────────────────┬─────────────────────────────────────────────────────────────────────────────────────┐
│          endDate          │   id   │         startDate         │                                       subject                                       │
├───────────────────────────┼────────┼───────────────────────────┼─────────────────────────────────────────────────────────────────────────────────────┤
│ 2023-02-04T09:30:00-06:00 │ 358644 │ 2023-02-03T23:30:00-06:00 │                           VPC DAL AZ2 Network Maintenance                           │
│ 2023-02-02T03:00:00-06:00 │ 358564 │ 2023-02-01T21:00:00-06:00 │                           VPC SAO AZ3 Network Maintenance                           │
│ 2023-02-01T03:00:00-06:00 │ 358342 │ 2023-01-31T21:00:00-06:00 │                           VPC SAO AZ2 Network Maintenance                           │
│ 2023-01-30T01:00:00-06:00 │ 358336 │ 2023-01-29T17:00:00-06:00 │                           VPC LON AZ3 Network Maintenance                           │
│ 2023-01-28T17:30:00-06:00 │ 358340 │ 2023-01-28T07:30:00-06:00 │                           VPC WDC AZ2 Network Maintenance                           │
│ 2023-01-28T07:00:00-06:00 │ 358528 │ 2023-01-27T21:00:00-06:00 │                           VPC DAL AZ1 Network Maintenance                           │
│ 2023-01-25T21:00:00-06:00 │ 358420 │ 2023-01-25T15:00:00-06:00 │                           VPC FRA AZ3 Network Maintenance                           │
│ 2023-01-24T21:00:00-06:00 │ 358406 │ 2023-01-24T15:00:00-06:00 │                           VPC FRA AZ2 Network Maintenance                           │
│ 2023-01-22T21:00:00-06:00 │ 358328 │ 2023-01-22T15:00:00-06:00 │                           VPC FRA AZ1 Network Maintenance                           │
│ 2023-01-21T08:00:00-06:00 │ 358326 │ 2023-01-20T22:00:00-06:00 │                           VPC WDC AZ1 Network Maintenance                           │
│ 2023-01-20T02:00:00-06:00 │ 358014 │ 2023-01-19T18:00:00-06:00 │                           VPC LON AZ1 Network Maintenance                           │
│ 2023-01-19T02:00:00-06:00 │ 358092 │ 2023-01-18T20:00:00-06:00 │                           VPC TOR AZ2 Network Maintenance                           │
│ 2023-01-18T02:00:00-06:00 │ 358284 │ 2023-01-17T20:00:00-06:00 │                           VPC TOR AZ1 Network Maintenance                           │
│ 2023-01-16T13:00:00-06:00 │ 357976 │ 2023-01-16T07:00:00-06:00 │                           VPC SYD AZ3 Network Maintenance                           │
│ 2023-01-14T14:30:00-06:00 │ 357968 │ 2023-01-14T08:30:00-06:00 │                           VPC SYD AZ2 Network Maintenance                           │
│ 2023-01-13T21:00:00-06:00 │ 358164 │ 2023-01-13T13:00:00-06:00 │          Planned Maintenance for Red Hat Satellites/Capsules on 01-13-2023          │
│ 2023-01-13T02:00:00-06:00 │ 357894 │ 2023-01-12T18:00:00-06:00 │          Planned Maintenance for Red Hat Satellites/Capsules on 01-13-2023          │
│ 2023-01-09T03:00:00-06:00 │ 357806 │ 2023-01-08T21:00:00-06:00 │                        VPC Sao Paulo AZ 1 Network Maintenance                       │
│ 2023-01-07T15:30:00-06:00 │ 357768 │ 2023-01-07T08:30:00-06:00 │                         VPC Sydney AZ 1 Network Maintenance                         │
│ 2023-01-05T23:00:00-06:00 │ 357500 │ 2023-01-05T17:00:00-06:00 │                        Hardware Maintenance on bcr01b.wdc07                         │
│ 2022-12-18T01:00:00-06:00 │ 357456 │ 2022-12-17T13:00:00-06:00 │ Performance/Endurance File and Block Storage Services (PAR01) 17-Dec-2022 19:00 UTC │
│ 2022-12-18T01:00:00-06:00 │ 357414 │ 2022-12-17T13:00:00-06:00 │ Performance/Endurance File and Block Storage Services (PAR01) 17-Dec-2022 19:00 UTC │
│ 2022-12-17T01:00:00-06:00 │ 357568 │ 2022-12-16T13:00:00-06:00 │     Performance/Endurance Block Storage Services (FRA05) 16-Dec-2022 19:00 UTC      │
│ 2022-12-11T01:00:00-06:00 │ 357492 │ 2022-12-10T13:00:00-06:00 │ Performance/Endurance File and Block Storage Services (PAR01) 10-Dec-2022 19:00 UTC │
│ 2022-12-09T20:30:00-06:00 │ 356086 │ 2022-12-09T08:30:00-06:00 │ Performance/Endurance File and Block Storage Services (CHE01) 9-Dec-2022 14:30 UTC  │
│ 2022-12-04T01:00:00-06:00 │ 356934 │ 2022-12-03T13:00:00-06:00 │ Performance/Endurance File and Block Storage Services (PAR01) 3-Dec-2022 19:00 UTC  │
│ 2022-11-29T10:01:00-06:00 │ 354774 │ 2022-11-29T10:00:00-06:00 │                            VPC TLS Cipher Suite Removal                             │
│ 2022-11-07T01:00:00-06:00 │ 354812 │ 2022-11-06T13:00:00-06:00 │ Performance/Endurance File and Block Storage Services (PAR01) 6-Nov-2022 19:00 UTC  │
│ 2022-11-04T13:30:00-07:00 │ 355124 │ 2022-11-04T07:30:00-07:00 │                          VPC SYD AZ 2 Network Maintenance                           │
│ 2022-11-04T15:00:00-07:00 │ 354378 │ 2022-11-04T06:00:00-07:00 │      Performance/Endurance Block Storage Services (SYD01) 4-Nov-2022 13:00 UTC      │
│ 2022-11-02T13:30:00-07:00 │ 354804 │ 2022-11-02T07:30:00-07:00 │                          VPC SYD AZ 2 Network Maintenance                           │
│ 2022-10-26T00:00:00-07:00 │ 353705 │ 2022-10-25T20:00:00-07:00 │                 PTASK0047879 | Maintenance of fcr03.dal05 Slot 2/1                  │
│ 2022-10-23T23:00:00-07:00 │ 354301 │ 2022-10-23T11:00:00-07:00 │ Performance/Endurance File and Block Storage Services (PAR01) 23-Oct-2022 18:00 UTC │
│ 2022-10-23T23:00:00-07:00 │ 354139 │ 2022-10-23T11:00:00-07:00 │ Performance/Endurance File and Block Storage Services (PAR01) 23-Oct-2022 18:00 UTC │
│ 2022-10-22T23:00:00-07:00 │ 354221 │ 2022-10-22T11:00:00-07:00 │     Performance/Endurance Block Storage Services (FRA05) 22-Oct-2022 18:00 UTC      │
│ 2022-10-22T07:00:00-07:00 │ 353279 │ 2022-10-22T04:00:00-07:00 │        Planned Commercial Infrastructure Management System (IMS) Maintenance        │
│ 2022-10-20T22:00:00-07:00 │ 353035 │ 2022-10-20T12:00:00-07:00 │                      Emergency:Replace chassis on bcr01b.lon06                      │
└───────────────────────────┴────────┴───────────────────────────┴─────────────────────────────────────────────────────────────────────────────────────┘
```

```
softlayer-python/ (master *) $ slcli -vvv call-api --help
Usage: slcli call-api [OPTIONS] SERVICE METHOD [PARAMETERS]...

        Call arbitrary API endpoints with the given SERVICE and METHOD.

For parameters that require a datatype, use a JSON string for that parameter.
Example::

    slcli call-api Account getObject
    slcli call-api Account getVirtualGuests --limit=10 --mask=id,hostname
    slcli call-api Virtual_Guest getObject --id=12345
    slcli call-api Metric_Tracking_Object getBandwidthData --id=1234 \
        "2015-01-01 00:00:00" "2015-01-1 12:00:00" public
    slcli call-api Account getVirtualGuests \
        -f 'virtualGuests.datacenter.name=dal05' \
        -f 'virtualGuests.maxCpu=4' \
        --mask=id,hostname,datacenter.name,maxCpu
    slcli call-api Account getVirtualGuests \
        -f 'virtualGuests.datacenter.name IN dal05,sng01'
    slcli call-api Account getVirtualGuests \
        --json-filter  '{"virtualGuests":{"hostname":{"operation":"^= test"}}}' --limit=10
    slcli -v call-api SoftLayer_User_Customer addBulkPortalPermission --id=1234567 \
        '[{"keyName": "NETWORK_MESSAGE_DELIVERY_MANAGE"}]'
    slcli call-api Account getVirtualGuests \
        --orderBy virttualguests.id=ASC
    slcli call-api SoftLayer_Notification_Occurrence_Event getAllObjects \
        --json-filter='{"endDate": {"operation": "greaterThanDate", "options": [{"name":"date", "value": ["10/14/2022"]}]}}' --limit=50

┌────┬─────────────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│    │ service         │                                                                                                                                                                                                                                        │
│    │ method          │                                                                                                                                                                                                                                        │
│    │ parameters      │                                                                                                                                                                                                                                        │
│    │ --id            │ Init parameter                                                                                                                                                                                                                         │
│ -f │ --filter        │ Object filters. This should be of the form: 'property=value' or 'nested.property=value'.Complex filters should use --json-filter. (multiple occurrence permitted)                                                                      │
│    │ --mask          │ String-based object mask                                                                                                                                                                                                               │
│    │ --limit         │ Result limit                                                                                                                                                                                                                           │
│    │ --offset        │ Result offset                                                                                                                                                                                                                          │
│    │ --orderBy       │ To set the sort direction, ASC or DESC can be provided.This should be of the form: '--orderBy nested.property' default DESC or '--orderBy nested.property=ASC', e.g.  --orderBy subnets.id default DESC --orderBy subnets.id=ASC       │
│    │ --output-python │ Show python example code instead of executing the call                                                                                                                                                                                 │
│    │ --json-filter   │ A JSON string to be passed in as the object filter to the API call. Remember to use double quotes (") for variable names. Can NOT be used with --filter. Dont use whitespace outside of strings, or the slcli might have trouble       │
│    │                 │ parsing it.                                                                                                                                                                                                                            │
│ -h │ --help          │ Show this message and exit.                                                                                                                                                                                                            │
└────┴─────────────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

