### PR TITLE
`slcli vs notifications` is displaying a hardware description

### DIFF
--- a/SoftLayer/CLI/virt/notifications.py
+++ b/SoftLayer/CLI/virt/notifications.py
@@ -12,7 +12,7 @@ from SoftLayer.CLI import formatting
 @click.argument('identifier')
 @environment.pass_env
 def cli(env, identifier):
-    """Get all hardware notifications."""
+    """Get all VS notifications."""
 
     virtual = SoftLayer.VSManager(env.client)
 


### PR DESCRIPTION
Issue: https://github.com/softlayer/softlayer-python/issues/1813
Observations: The command description was updated
```
slcli vs notifications -h
Usage: slcli vs notifications [OPTIONS] IDENTIFIER

        Get all VS notifications.

┌────┬────────────┬─────────────────────────────┐
│    │ identifier │                             │
│ -h │ --help     │ Show this message and exit. │
└────┴────────────┴─────────────────────────────┘
```