### PR TITLE
Fixes firewall cancel so it can properly do multiVlan firewalls

### DIFF
--- a/SoftLayer/CLI/command.py
+++ b/SoftLayer/CLI/command.py
@@ -19,11 +19,15 @@ from SoftLayer.CLI import environment
 
 
 class OptionHighlighter(RegexHighlighter):
-    """Provides highlighter regex for the Command help"""
+    """Provides highlighter regex for the Command help.
+
+    Defined in SoftLayer\\utils.py console_color_themes()
+    """
     highlights = [
         r"(?P<switch>^\-\w)",  # single options like -v
         r"(?P<option>\-\-[\w\-]+)",  # long options like --verbose
         r"(?P<default_option>\[[^\]]+\])",  # anything between [], usually default options
+        r"(?P<option_choices>Choices: )",
     ]
 
 
@@ -222,6 +226,11 @@ class SLCommand(click.Command):
             help_message = ""
             if help_record:
                 help_message = param.get_help_record(ctx)[-1]
+
+            # Add Click choices to help message
+            if isinstance(param.type, click.Choice):
+                choices = ", ".join(param.type.choices)
+                help_message += f" Choices: {choices}"
 
             if param.metavar:
                 options += f" {param.metavar}"

--- a/SoftLayer/CLI/firewall/cancel.py
+++ b/SoftLayer/CLI/firewall/cancel.py
@@ -12,23 +12,22 @@ from SoftLayer.CLI import formatting
 
 @click.command(cls=SoftLayer.CLI.command.SLCommand, )
 @click.argument('identifier')
+@click.option('--firewall-type', required=True, show_default=True, default='vlan',
+              type=click.Choice(['vlan', 'server'], case_sensitive=False),
+              help='Firewall type.')
 @environment.pass_env
-def cli(env, identifier):
+def cli(env, identifier, firewall_type):
     """Cancels a firewall."""
 
     mgr = SoftLayer.FirewallManager(env.client)
-    firewall_type, firewall_id = firewall.parse_id(identifier)
 
     if not (env.skip_confirmations or
-            formatting.confirm("This action will cancel a firewall from your "
-                               "account. Continue?")):
+            formatting.confirm("This action will cancel a firewall from your account. Continue?")):
         raise exceptions.CLIAbort('Aborted.')
 
-    if firewall_type in ['vs', 'server']:
-        mgr.cancel_firewall(firewall_id, dedicated=False)
-    elif firewall_type == 'vlan':
-        mgr.cancel_firewall(firewall_id, dedicated=True)
+    if firewall_type == 'server':
+        mgr.cancel_firewall(identifier, dedicated=False)
     else:
-        raise exceptions.CLIAbort('Unknown firewall type: %s' % firewall_type)
+        mgr.cancel_firewall(identifier, dedicated=True)
 
     env.fout('Firewall with id %s is being cancelled!' % identifier)

--- a/SoftLayer/CLI/firewall/cancel.py
+++ b/SoftLayer/CLI/firewall/cancel.py
@@ -6,7 +6,6 @@ import click
 import SoftLayer
 from SoftLayer.CLI import environment
 from SoftLayer.CLI import exceptions
-from SoftLayer.CLI import firewall
 from SoftLayer.CLI import formatting
 
 

--- a/SoftLayer/managers/firewall.py
+++ b/SoftLayer/managers/firewall.py
@@ -157,11 +157,9 @@ class FirewallManager(utils.IdentifierMixin, object):
             firewall_service = self.client['Network_Component_Firewall']
         firewall = firewall_service.getObject(id=firewall_id, mask=mask)
         if firewall is None:
-            raise exceptions.SoftLayerError(
-                "Unable to find firewall %d" % firewall_id)
+            raise exceptions.SoftLayerError(f"Unable to find firewall {firewall_id}")
         if firewall.get('billingItem') is None:
-            raise exceptions.SoftLayerError(
-                "Unable to find billing item for firewall %d" % firewall_id)
+            raise exceptions.SoftLayerError(f"Unable to find billing item for firewall {firewall_id}")
 
         return firewall['billingItem']
 

--- a/SoftLayer/utils.py
+++ b/SoftLayer/utils.py
@@ -481,6 +481,7 @@ def console_color_themes(theme):
                 "default_option": "light_coral",
                 "option_keyword": "bold dark_cyan",
                 "args_keyword": "bold green4",
+                "option_choices": "gold3",
             })
         )
     return Console(theme=Theme(
@@ -497,6 +498,7 @@ def console_color_themes(theme):
             "default_option": "light_pink1",
             "option_keyword": "bold cyan",
             "args_keyword": "bold green",
+            "option_choices": "gold3",
         })
     )
 


### PR DESCRIPTION
Fixes #1768

`slcli firewall cancel` will now default to `vlan` firewalls, and have an option for server firewalls (which I haven't tested at the moment, but I assume works as it used to).

Also added output to the help for `click.Choices`
![image](https://user-images.githubusercontent.com/7408017/211685240-433fc737-e817-49c2-9a66-59c010ded983.png)


![image](https://user-images.githubusercontent.com/7408017/211685295-2871c838-bdf4-4d20-8727-f7df939991d4.png)


When we get around to #1820 well improve this further by not having to do the firewall type at all hopefully. But for now this should work.