### PR TITLE
`user remove-access` is not displaying all removed device access and its help command displaying error message

### DIFF
--- a/SoftLayer/CLI/user/remove_access.py
+++ b/SoftLayer/CLI/user/remove_access.py
@@ -9,12 +9,9 @@ from SoftLayer.CLI import environment
 
 @click.command(cls=SoftLayer.CLI.command.SLCommand, )
 @click.argument('identifier')
-@click.option('--hardware', '-h',
-              help="Display hardware this user has access to.")
-@click.option('--virtual', '-v',
-              help="Display virtual guests this user has access to.")
-@click.option('--dedicated', '-l',
-              help="dedicated host ID ")
+@click.option('--hardware', help="Hardware ID")
+@click.option('--virtual', help="Virtual Guest ID")
+@click.option('--dedicated', help="Dedicated host ID ")
 @environment.pass_env
 def cli(env, identifier, hardware, virtual, dedicated):
     """Remove access from a user to an specific device.
@@ -23,24 +20,24 @@ def cli(env, identifier, hardware, virtual, dedicated):
     """
 
     mgr = SoftLayer.UserManager(env.client)
-    device = ''
     result = False
     if hardware:
-        device = hardware
         result = mgr.remove_hardware_access(identifier, hardware)
+        if result:
+            click.secho("Remove to access to hardware: %s" % hardware, fg='green')
 
     if virtual:
-        device = virtual
         result = mgr.remove_virtual_access(identifier, virtual)
+        if result:
+            click.secho("Remove to access to virtual guest: %s" % virtual, fg='green')
 
     if dedicated:
-        device = dedicated
         result = mgr.remove_dedicated_access(identifier, dedicated)
+        if result:
+            click.secho("Remove to access to dedicated host: %s" % dedicated, fg='green')
 
-    if result:
-        click.secho("Remove to access to device: %s" % device, fg='green')
-    else:
+    if not result:
         raise SoftLayer.exceptions.SoftLayerError('You need argument a hardware, virtual or dedicated identifier.\n'
-                                                  'E.g slcli user 123456 --hardware 91803794\n'
-                                                  '    slcli user 123456 --dedicated 91803793\n'
-                                                  '    slcli user 123456 --virtual 91803792')
+                                                  'E.g slcli user remove-access 123456 --hardware 91803794\n'
+                                                  '    slcli user remove-access 123456 --dedicated 91803793\n'
+                                                  '    slcli user remove-access 123456 --virtual 91803792')

--- a/SoftLayer/CLI/user/remove_access.py
+++ b/SoftLayer/CLI/user/remove_access.py
@@ -1,4 +1,4 @@
-"""User remove access to devices."""
+"""Removes a user access to a given device."""
 # :license: MIT, see LICENSE for more details.
 
 import click
@@ -15,7 +15,7 @@ from SoftLayer.CLI import exceptions
 @click.option('--dedicated', help="Dedicated host ID ")
 @environment.pass_env
 def cli(env, identifier, hardware, virtual, dedicated):
-    """Remove access from a user to an specific device.
+    """Removes a user access to a given device.
 
     Example: slcli user remove-access 123456 --hardware 123456789
     """

--- a/SoftLayer/CLI/user/remove_access.py
+++ b/SoftLayer/CLI/user/remove_access.py
@@ -5,6 +5,7 @@ import click
 
 import SoftLayer
 from SoftLayer.CLI import environment
+from SoftLayer.CLI import exceptions
 
 
 @click.command(cls=SoftLayer.CLI.command.SLCommand, )
@@ -24,20 +25,20 @@ def cli(env, identifier, hardware, virtual, dedicated):
     if hardware:
         result = mgr.remove_hardware_access(identifier, hardware)
         if result:
-            click.secho("Remove to access to hardware: %s" % hardware, fg='green')
+            click.secho(f"Removed access to hardware: {hardware}.", fg='green')
 
     if virtual:
         result = mgr.remove_virtual_access(identifier, virtual)
         if result:
-            click.secho("Remove to access to virtual guest: %s" % virtual, fg='green')
+            click.secho(f"Removed access to virtual guest: {virtual}", fg='green')
 
     if dedicated:
         result = mgr.remove_dedicated_access(identifier, dedicated)
         if result:
-            click.secho("Remove to access to dedicated host: %s" % dedicated, fg='green')
+            click.secho(f"Removed access to dedicated host: {dedicated}", fg='green')
 
     if not result:
-        raise SoftLayer.exceptions.SoftLayerError('You need argument a hardware, virtual or dedicated identifier.\n'
-                                                  'E.g slcli user remove-access 123456 --hardware 91803794\n'
-                                                  '    slcli user remove-access 123456 --dedicated 91803793\n'
-                                                  '    slcli user remove-access 123456 --virtual 91803792')
+        raise exceptions.CLIAbort('A device option is required.\n'
+                                  'E.g slcli user remove-access 123456 --hardware 91803794\n'
+                                  '    slcli user remove-access 123456 --dedicated 91803793\n'
+                                  '    slcli user remove-access 123456 --virtual 91803792')

--- a/tests/CLI/modules/user_tests.py
+++ b/tests/CLI/modules/user_tests.py
@@ -356,3 +356,8 @@ class UserCLITests(testing.TestCase):
     def test_remove_access_dedicated(self):
         result = self.run_command(['user', 'remove-access', '123456', '--dedicated', '369852'])
         self.assert_no_fail(result)
+
+    def test_remove_without_device(self):
+        result = self.run_command(['user', 'remove-access', '123456'])
+        self.assertEqual(2, result.exit_code)
+        self.assertIn('A device option is required.', result.exception.message)


### PR DESCRIPTION
Issue: https://github.com/softlayer/softlayer-python/issues/1823
Observations: The command was updated to print an message of each removed device access, the short flags were removed to can use short help flag and the help flags were updated to match with golang plugin
```
slcli user remove-access 8344222 --hardware 1532729 --virtual 132364928
Remove to access to hardware: 1532729
Remove to access to virtual guest: 132364928
```
```
slcli user remove-access -h
Usage: slcli user remove-access [OPTIONS] IDENTIFIER

        Remove access from a user to an specific device.

Example: slcli user remove-access 123456 --hardware 123456789

┌────┬─────────────┬─────────────────────────────┐
│    │ identifier  │                             │
│    │ --hardware  │ Hardware ID                 │
│    │ --virtual   │ Virtual Guest ID            │
│    │ --dedicated │ Dedicated host ID           │
│ -h │ --help      │ Show this message and exit. │
└────┴─────────────┴─────────────────────────────┘
```