### PR TITLE
slcli vs capture uses a deprecated API

### DIFF
--- a/SoftLayer/CLI/virt/capture.py
+++ b/SoftLayer/CLI/virt/capture.py
@@ -24,7 +24,6 @@ def cli(env, identifier, name, all, note):
     vs_id = helpers.resolve_id(vsi.resolve_ids, identifier, 'VS')
 
     capture = vsi.capture(vs_id, name, all, note)
-    
 
     table = formatting.KeyValueTable(['name', 'value'])
     table.align['name'] = 'r'

--- a/SoftLayer/CLI/virt/capture.py
+++ b/SoftLayer/CLI/virt/capture.py
@@ -24,8 +24,7 @@ def cli(env, identifier, name, all, note):
     vs_id = helpers.resolve_id(vsi.resolve_ids, identifier, 'VS')
 
     capture = vsi.capture(vs_id, name, all, note)
-
-    print(capture)
+    
 
     table = formatting.KeyValueTable(['name', 'value'])
     table.align['name'] = 'r'

--- a/SoftLayer/CLI/virt/capture.py
+++ b/SoftLayer/CLI/virt/capture.py
@@ -25,11 +25,13 @@ def cli(env, identifier, name, all, note):
 
     capture = vsi.capture(vs_id, name, all, note)
 
+    print(capture)
+
     table = formatting.KeyValueTable(['name', 'value'])
     table.align['name'] = 'r'
     table.align['value'] = 'l'
 
-    table.add_row(['vs_id', capture['guestId']])
+    table.add_row(['globalIdentifier', capture['globalIdentifier']])
     table.add_row(['date', capture['createDate'][:10]])
     table.add_row(['time', capture['createDate'][11:19]])
     table.add_row(['transaction', formatting.transaction_status(capture)])

--- a/SoftLayer/fixtures/SoftLayer_Virtual_Guest.py
+++ b/SoftLayer/fixtures/SoftLayer_Virtual_Guest.py
@@ -716,14 +716,15 @@ generateOrderTemplate = {
 setUserMetadata = ['meta']
 reloadOperatingSystem = 'OK'
 setTags = True
-createArchiveTransaction = {
+createArchiveTemplate = {
     'createDate': '2018-12-10T17:29:18-06:00',
     'elapsedSeconds': 0,
     'guestId': 12345678,
     'hardwareId': None,
     'id': 12345,
     'modifyDate': '2018-12-10T17:29:18-06:00',
-    'statusChangeDate': '2018-12-10T17:29:18-06:00'
+    'statusChangeDate': '2018-12-10T17:29:18-06:00',
+    'globalIdentifier': '495c47c2-80af-4fef-87a9-97faf132345678'
 }
 
 executeRescueLayer = True

--- a/SoftLayer/managers/vs.py
+++ b/SoftLayer/managers/vs.py
@@ -996,7 +996,7 @@ class VSManager(utils.IdentifierMixin, object):
 
             disks_to_capture.append(block_device)
 
-        return self.guest.createArchiveTransaction(
+        return self.guest.createArchiveTemplate(
             name, disks_to_capture, notes, id=instance_id)
 
     def upgrade(self, instance_id, cpus=None, memory=None, nic_speed=None, public=True, preset=None, disk=None):

--- a/tests/CLI/modules/vs/vs_tests.py
+++ b/tests/CLI/modules/vs/vs_tests.py
@@ -743,7 +743,7 @@ class VirtTests(testing.TestCase):
 
         result = self.run_command(['vs', 'capture', '100', '--name', 'TestName'])
         self.assert_no_fail(result)
-        self.assert_called_with('SoftLayer_Virtual_Guest', 'createArchiveTransaction', identifier=100)
+        self.assert_called_with('SoftLayer_Virtual_Guest', 'createArchiveTemplate', identifier=100)
 
     @mock.patch('SoftLayer.CLI.formatting.no_going_back')
     def test_usage_no_confirm(self, confirm_mock):

--- a/tests/managers/vs/vs_tests.py
+++ b/tests/managers/vs/vs_tests.py
@@ -968,11 +968,11 @@ class VSTests(testing.TestCase):
         # capture only the OS disk
         result = self.vs.capture(1, 'a')
 
-        expected = fixtures.SoftLayer_Virtual_Guest.createArchiveTransaction
+        expected = fixtures.SoftLayer_Virtual_Guest.createArchiveTemplate
         self.assertEqual(result, expected)
         args = ('a', [{'device': 0, 'uuid': 1, 'mountType': 'Disk'}], None)
         self.assert_called_with('SoftLayer_Virtual_Guest',
-                                'createArchiveTransaction',
+                                'createArchiveTemplate',
                                 args=args,
                                 identifier=1)
 
@@ -981,12 +981,12 @@ class VSTests(testing.TestCase):
         # make sure the data is carried along with it
         result = self.vs.capture(1, 'a', additional_disks=True)
 
-        expected = fixtures.SoftLayer_Virtual_Guest.createArchiveTransaction
+        expected = fixtures.SoftLayer_Virtual_Guest.createArchiveTemplate
         self.assertEqual(result, expected)
         args = ('a', [{'device': 0, 'mountType': 'Disk', 'uuid': 1},
                       {'device': 3, 'mountType': 'Disk', 'uuid': 3}], None)
         self.assert_called_with('SoftLayer_Virtual_Guest',
-                                'createArchiveTransaction',
+                                'createArchiveTemplate',
                                 args=args,
                                 identifier=1)
 


### PR DESCRIPTION
[#issue1842](https://github.com/softlayer/softlayer-python/issues/1842)

![image](https://user-images.githubusercontent.com/22535437/214949363-0cbbee21-984f-4586-864a-a8f06d3d4ff4.png)
