### PR TITLE
Updated command slcli block replica-order

### DIFF
--- a/SoftLayer/CLI/block/replication/disaster_recovery_failover.py
+++ b/SoftLayer/CLI/block/replication/disaster_recovery_failover.py
@@ -15,7 +15,7 @@ failover to an available replica in another location. This method does not allow
 After using this method, to failback to the original volume, please open a support ticket.
 If you wish to test failover, please use replica-failover.""")
 @click.argument('volume-id')
-@click.option('--replicant-id', help="ID of the replicant volume")
+@click.option('--replicant-id', help="ID of the replicant volume.")
 @environment.pass_env
 def cli(env, volume_id, replicant_id):
     """Failover an inaccessible block volume to its available replicant volume."""

--- a/SoftLayer/CLI/block/replication/failback.py
+++ b/SoftLayer/CLI/block/replication/failback.py
@@ -10,7 +10,7 @@ from SoftLayer.CLI import environment
 @click.argument('volume-id')
 @environment.pass_env
 def cli(env, volume_id):
-    """Failback a block volume from the given replicant volume."""
+    """Failback a block volume from the given replica volume."""
     block_storage_manager = SoftLayer.BlockStorageManager(env.client)
 
     success = block_storage_manager.failback_from_replicant(volume_id)

--- a/SoftLayer/CLI/block/replication/failover.py
+++ b/SoftLayer/CLI/block/replication/failover.py
@@ -8,10 +8,10 @@ from SoftLayer.CLI import environment
 
 @click.command(cls=SoftLayer.CLI.command.SLCommand, )
 @click.argument('volume-id')
-@click.option('--replicant-id', help="ID of the replicant volume")
+@click.option('--replicant-id', help="ID of the replicant volume.")
 @environment.pass_env
 def cli(env, volume_id, replicant_id):
-    """Failover a block volume to the given replicant volume."""
+    """Failover a block volume to the given replica volume."""
     block_storage_manager = SoftLayer.BlockStorageManager(env.client)
 
     success = block_storage_manager.failover_to_replicant(

--- a/SoftLayer/CLI/block/replication/locations.py
+++ b/SoftLayer/CLI/block/replication/locations.py
@@ -22,12 +22,12 @@ DEFAULT_COLUMNS = [
 
 @click.command(cls=SoftLayer.CLI.command.SLCommand, )
 @click.argument('volume-id')
-@click.option('--sortby', help='Column to sort by', default='Long Name')
 @click.option('--columns',
               callback=column_helper.get_formatter(COLUMNS),
               help='Columns to display. Options: {0}'.format(
                   ', '.join(column.name for column in COLUMNS)),
               default=','.join(DEFAULT_COLUMNS))
+@click.option('--sortby', help='Column to sort by', default='Long Name')
 @environment.pass_env
 def cli(env, columns, sortby, volume_id):
     """List suitable replication datacenters for the given volume."""

--- a/SoftLayer/CLI/block/replication/partners.py
+++ b/SoftLayer/CLI/block/replication/partners.py
@@ -14,15 +14,15 @@ DEFAULT_COLUMNS = storage_utils.REPLICATION_PARTNER_DEFAULT
 
 @click.command(cls=SoftLayer.CLI.command.SLCommand, )
 @click.argument('volume-id')
-@click.option('--sortby', help='Column to sort by', default='Username')
 @click.option('--columns',
               callback=column_helper.get_formatter(COLUMNS),
               help='Columns to display. Options: {0}'.format(
                   ', '.join(column.name for column in COLUMNS)),
               default=','.join(DEFAULT_COLUMNS))
+@click.option('--sortby', help='Column to sort by', default='Username')
 @environment.pass_env
 def cli(env, columns, sortby, volume_id):
-    """List existing replicant volumes for a block volume."""
+    """List existing replica volumes for a block volume."""
     block_storage_manager = SoftLayer.BlockStorageManager(env.client)
 
     legal_volumes = block_storage_manager.get_replication_partners(

--- a/SoftLayer/managers/storage.py
+++ b/SoftLayer/managers/storage.py
@@ -217,7 +217,8 @@ class StorageManager(utils.IdentifierMixin, object):
                                snapshot_schedule,
                                location,
                                tier=None,
-                               os_type=None):
+                               os_type=None,
+                               iops=None):
         """Places an order for a replicant volume.
 
         :param volume_id: The ID of the primary volume to be replicated
@@ -239,9 +240,12 @@ class StorageManager(utils.IdentifierMixin, object):
         storage_class = storage_utils.block_or_file(
             block_volume['storageType']['keyName'])
 
+        if iops is None:
+            iops = int(block_volume['provisionedIops'])
+
         order = storage_utils.prepare_replicant_order_object(
             self, snapshot_schedule, location, tier, block_volume,
-            storage_class)
+            storage_class, iops)
 
         if storage_class == 'block':
             if os_type is None:

--- a/SoftLayer/managers/storage_utils.py
+++ b/SoftLayer/managers/storage_utils.py
@@ -645,7 +645,7 @@ def _get_order_type_and_category(service_offering, storage_type, volume_type):
 
 
 def prepare_replicant_order_object(manager, snapshot_schedule, location,
-                                   tier, volume, volume_type):
+                                   tier, volume, volume_type, iops):
     """Prepare the order object which is submitted to the placeOrder() method
 
     :param manager: The File or Block manager calling this function
@@ -730,7 +730,7 @@ def prepare_replicant_order_object(manager, snapshot_schedule, location,
                     "A replica volume cannot be ordered for this performance "
                     "volume since it does not support Encryption at Rest.")
             volume_is_performance = True
-            iops = int(volume['provisionedIops'])
+
             prices = [
                 find_price_by_category(package, billing_item_category_code),
                 find_price_by_category(package, 'storage_' + volume_type),

--- a/tests/CLI/modules/block_tests.py
+++ b/tests/CLI/modules/block_tests.py
@@ -625,7 +625,8 @@ class BlockTests(testing.TestCase):
 
         result = self.run_command(['block', 'replica-order', '100',
                                    '--snapshot-schedule=DAILY',
-                                   '--location=dal05'])
+                                   '--datacenter=dal05',
+                                   '--iops=100'])
 
         self.assert_no_fail(result)
         self.assertEqual(result.output,
@@ -650,7 +651,8 @@ class BlockTests(testing.TestCase):
 
         result = self.run_command(['block', 'replica-order', '100',
                                    '--snapshot-schedule=DAILY',
-                                   '--location=dal05', '--tier=2'])
+                                   '--datacenter=dal05', '--tier=2',
+                                   '--iops=100'])
 
         self.assert_no_fail(result)
         self.assertEqual(result.output,

--- a/tests/managers/storage_utils_tests.py
+++ b/tests/managers/storage_utils_tests.py
@@ -3259,7 +3259,7 @@ class StorageUtilsTests(testing.TestCase):
         exception = self.assertRaises(
             exceptions.SoftLayerError,
             storage_utils.prepare_replicant_order_object,
-            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block'
+            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block', 100
         )
 
         self.assertEqual(
@@ -3275,7 +3275,7 @@ class StorageUtilsTests(testing.TestCase):
         exception = self.assertRaises(
             exceptions.SoftLayerError,
             storage_utils.prepare_replicant_order_object,
-            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block'
+            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block', 100
         )
 
         self.assertEqual(
@@ -3292,7 +3292,7 @@ class StorageUtilsTests(testing.TestCase):
         exception = self.assertRaises(
             exceptions.SoftLayerError,
             storage_utils.prepare_replicant_order_object,
-            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block'
+            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block', 100
         )
 
         self.assertEqual(
@@ -3310,7 +3310,7 @@ class StorageUtilsTests(testing.TestCase):
         exception = self.assertRaises(
             exceptions.SoftLayerError,
             storage_utils.prepare_replicant_order_object,
-            self.block, 'WEEKLY', 'hoth02', None, mock_volume, 'block'
+            self.block, 'WEEKLY', 'hoth02', None, mock_volume, 'block', 100
         )
 
         self.assertEqual(
@@ -3329,7 +3329,7 @@ class StorageUtilsTests(testing.TestCase):
         exception = self.assertRaises(
             exceptions.SoftLayerError,
             storage_utils.prepare_replicant_order_object,
-            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block'
+            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block', 100
         )
 
         self.assertEqual(
@@ -3348,7 +3348,7 @@ class StorageUtilsTests(testing.TestCase):
         exception = self.assertRaises(
             exceptions.SoftLayerError,
             storage_utils.prepare_replicant_order_object,
-            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block'
+            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block', 100
         )
 
         self.assertEqual(
@@ -3385,7 +3385,7 @@ class StorageUtilsTests(testing.TestCase):
         }
 
         result = storage_utils.prepare_replicant_order_object(
-            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block'
+            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block', 100
         )
 
         self.assertEqual(expected_object, result)
@@ -3419,7 +3419,7 @@ class StorageUtilsTests(testing.TestCase):
         }
 
         result = storage_utils.prepare_replicant_order_object(
-            self.block, 'WEEKLY', 'wdc04', 2, mock_volume, 'block'
+            self.block, 'WEEKLY', 'wdc04', 2, mock_volume, 'block', 100
         )
 
         self.assertEqual(expected_object, result)
@@ -3437,7 +3437,7 @@ class StorageUtilsTests(testing.TestCase):
         exception = self.assertRaises(
             exceptions.SoftLayerError,
             storage_utils.prepare_replicant_order_object,
-            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block'
+            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block', 100
         )
 
         self.assertEqual(
@@ -3472,12 +3472,12 @@ class StorageUtilsTests(testing.TestCase):
             'originVolumeId': 102,
             'originVolumeScheduleId': 978,
             'volumeSize': 500,
-            'iops': 1000,
+            'iops': 100,
             'useHourlyPricing': False
         }
 
         result = storage_utils.prepare_replicant_order_object(
-            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block'
+            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block', 100
         )
 
         self.assertEqual(expected_object, result)
@@ -3494,7 +3494,7 @@ class StorageUtilsTests(testing.TestCase):
         exception = self.assertRaises(
             exceptions.SoftLayerError,
             storage_utils.prepare_replicant_order_object,
-            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block'
+            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block', 100
         )
 
         self.assertEqual(
@@ -3534,7 +3534,7 @@ class StorageUtilsTests(testing.TestCase):
         }
 
         result = storage_utils.prepare_replicant_order_object(
-            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block'
+            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block', 100
         )
 
         self.assertEqual(expected_object, result)
@@ -3569,7 +3569,7 @@ class StorageUtilsTests(testing.TestCase):
         }
 
         result = storage_utils.prepare_replicant_order_object(
-            self.block, 'WEEKLY', 'wdc04', 2, mock_volume, 'block'
+            self.block, 'WEEKLY', 'wdc04', 2, mock_volume, 'block', 100
         )
 
         self.assertEqual(expected_object, result)
@@ -3604,7 +3604,7 @@ class StorageUtilsTests(testing.TestCase):
         }
 
         result = storage_utils.prepare_replicant_order_object(
-            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block'
+            self.block, 'WEEKLY', 'wdc04', None, mock_volume, 'block', 100
         )
 
         self.assertEqual(expected_object, result)


### PR DESCRIPTION
Issue link: #1845 
Note: Updated some descriptions in group command `slcli block replica`

```
softlayer-python/ (issue1845) $ slcli block replica-order -h
Usage: slcli block replica-order [OPTIONS] VOLUME_ID

        Order a block storage replica volume.

┌────┬─────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────┐
│    │ volume_id           │                                                                                                  │
│ -d │ --datacenter        │ Short name of the datacenter for the replica (e.g.: dal09)  [required]                           │
│ -i │ --iops              │ Performance Storage IOPs, between 100 and 6000 in multiples of 100. If no IOPS value is          │
│    │                     │ specified, the IOPS value of the original volume will be used.                                   │
│ -o │ --os-type           │ Operating System Type (eg. LINUX) of the primary volume for which a replica is ordered           │
│    │                     │ [optional]. Choices: HYPER_V, LINUX, VMWARE, WINDOWS_2008, WINDOWS_GPT, WINDOWS, XEN             │
│ -s │ --snapshot-schedule │ Snapshot schedule to use for replication. Options are: HOURLY, DAILY, WEEKLY  [required]         │
│    │                     │ Choices: HOURLY, DAILY, WEEKLY                                                                   │
│ -t │ --tier              │ Endurance Storage Tier (IOPS per GB) of the primary volume for which a replica is ordered        │
│    │                     │ [optional]. If no tier is specified, the tier of the original volume will be used Choices: 0.25, │
│    │                     │ 2, 4, 10                                                                                         │
│ -h │ --help              │ Show this message and exit.                                                                      │
└────┴─────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────┘
```