### PR TITLE
New Command: `slcli virtual host-create`

### DIFF
--- a/SoftLayer/CLI/routes.py
+++ b/SoftLayer/CLI/routes.py
@@ -58,6 +58,7 @@ ALL_ROUTES = [
     ('virtual:notification-add', 'SoftLayer.CLI.virt.notification_add:cli'),
     ('virtual:notification-delete', 'SoftLayer.CLI.virt.notification_delete:cli'),
     ('virtual:host-list', 'SoftLayer.CLI.dedicatedhost.list:cli'),
+    ('virtual:host-create', 'SoftLayer.CLI.dedicatedhost.create:cli'),
 
     ('dedicatedhost', 'SoftLayer.CLI.dedicatedhost'),
     ('dedicatedhost:list', 'SoftLayer.CLI.dedicatedhost.list:cli'),

--- a/docs/cli/dedicated.rst
+++ b/docs/cli/dedicated.rst
@@ -35,3 +35,7 @@ Dedicated Host Commands
 .. click:: SoftLayer.CLI.dedicatedhost.list:cli
     :prog: virtual host-list
     :show-nested:
+
+.. click:: SoftLayer.CLI.dedicatedhost.create:cli
+    :prog: virtual host-create
+    :show-nested:

--- a/docs/cli/vs.rst
+++ b/docs/cli/vs.rst
@@ -296,6 +296,11 @@ If no timezone is specified, IMS local time (CST) will be assumed, which might n
     :prog: virtual host-list
     :show-nested:
 
+.. click:: SoftLayer.CLI.virt.create:cli
+    This command is an alias for `slcli dedicatedhost create`
+   :prog: virtual host-create
+   :show-nested:
+
 Manages the migration of virutal guests. Supports migrating virtual guests on Dedicated Hosts as well.
 
 Reserved Capacity


### PR DESCRIPTION
Issue: https://github.com/softlayer/softlayer-python/issues/1836
Observations: Added `vs host-create` as alias of `dedicatedhost create`
```
slcli vs host-create --billing hourly -d dal13 -D mydomain.com --hostname myhostanme -f 56_CORES_X_242_RAM_X_1_4_TB
This action will incur charges on your account. Continue? [y/N]: y
┌───────────────────┬──────┐
│              Item │ cost │
├───────────────────┼──────┤
│ Total hourly cost │ 0.00 │
└───────────────────┴──────┘
 -- ! Prices reflected here are retail and do not take account level discounts and are not guaranteed.
┌─────────┬───────────────────────────┐
│    name │ value                     │
├─────────┼───────────────────────────┤
│      id │ 102235062                 │
│ created │ 2023-02-02T14:18:35-06:00 │
└─────────┴───────────────────────────┘
```