### PR TITLE
Updated command slcli block snapshot-order, added flag iops 

### DIFF
--- a/SoftLayer/CLI/block/snapshot/cancel.py
+++ b/SoftLayer/CLI/block/snapshot/cancel.py
@@ -11,11 +11,11 @@ from SoftLayer.CLI import formatting
 
 @click.command(cls=SoftLayer.CLI.command.SLCommand, )
 @click.argument('volume-id')
-@click.option('--reason', help="An optional reason for cancellation")
+@click.option('--reason', help="An optional reason for cancellation.")
 @click.option('--immediate',
               is_flag=True,
               help="Cancels the snapshot space immediately instead "
-                   "of on the billing anniversary")
+                   "of on the billing anniversary.")
 @environment.pass_env
 def cli(env, volume_id, reason, immediate):
     """Cancel existing snapshot space for a given volume."""

--- a/SoftLayer/CLI/block/snapshot/create.py
+++ b/SoftLayer/CLI/block/snapshot/create.py
@@ -9,10 +9,10 @@ from SoftLayer.CLI import environment
 @click.command(cls=SoftLayer.CLI.command.SLCommand, )
 @click.argument('volume_id')
 @click.option('--notes', '-n',
-              help='Notes to set on the new snapshot')
+              help='Notes to set on the new snapshot.')
 @environment.pass_env
 def cli(env, volume_id, notes):
-    """Creates a snapshot on a given volume"""
+    """Creates a snapshot on a given volume."""
     block_manager = SoftLayer.BlockStorageManager(env.client)
     snapshot = block_manager.create_snapshot(volume_id, notes=notes)
 

--- a/SoftLayer/CLI/block/snapshot/delete.py
+++ b/SoftLayer/CLI/block/snapshot/delete.py
@@ -10,7 +10,7 @@ from SoftLayer.CLI import environment
 @click.argument('snapshot_id')
 @environment.pass_env
 def cli(env, snapshot_id):
-    """Deletes a snapshot on a given volume"""
+    """Deletes a snapshot on a given volume."""
     block_manager = SoftLayer.BlockStorageManager(env.client)
     deleted = block_manager.delete_snapshot(snapshot_id)
 

--- a/SoftLayer/CLI/block/snapshot/disable.py
+++ b/SoftLayer/CLI/block/snapshot/disable.py
@@ -10,11 +10,11 @@ from SoftLayer.CLI import exceptions
 @click.command(cls=SoftLayer.CLI.command.SLCommand, )
 @click.argument('volume_id')
 @click.option('--schedule-type',
-              help='Snapshot schedule [INTERVAL|HOURLY|DAILY|WEEKLY]',
+              help='Snapshot schedule [INTERVAL|HOURLY|DAILY|WEEKLY].',
               required=True)
 @environment.pass_env
 def cli(env, volume_id, schedule_type):
-    """Disables snapshots on the specified schedule for a given volume"""
+    """Disables snapshots on the specified schedule for a given volume."""
 
     if (schedule_type not in ['INTERVAL', 'HOURLY', 'DAILY', 'WEEKLY']):
         raise exceptions.CLIAbort(

--- a/SoftLayer/CLI/block/snapshot/enable.py
+++ b/SoftLayer/CLI/block/snapshot/enable.py
@@ -10,24 +10,24 @@ from SoftLayer.CLI import exceptions
 @click.command(cls=SoftLayer.CLI.command.SLCommand, )
 @click.argument('volume_id')
 @click.option('--schedule-type',
-              help='Snapshot schedule [INTERVAL|HOURLY|DAILY|WEEKLY]',
+              help='Snapshot schedule [INTERVAL|HOURLY|DAILY|WEEKLY].',
               required=True)
 @click.option('--retention-count',
-              help='Number of snapshots to retain',
+              help='Number of snapshots to retain.',
               required=True)
 @click.option('--minute',
-              help='Minute of the day when snapshots should be taken',
+              help='Minute of the day when snapshots should be taken.',
               default=0)
 @click.option('--hour',
-              help='Hour of the day when snapshots should be taken',
+              help='Hour of the day when snapshots should be taken.',
               default=0)
 @click.option('--day-of-week',
-              help='Day of the week when snapshots should be taken',
+              help='Day of the week when snapshots should be taken.',
               default='SUNDAY')
 @environment.pass_env
 def cli(env, volume_id, schedule_type, retention_count,
         minute, hour, day_of_week):
-    """Enables snapshots for a given volume on the specified schedule"""
+    """Enables snapshots for a given volume on the specified schedule."""
     block_manager = SoftLayer.BlockStorageManager(env.client)
 
     valid_schedule_types = {'INTERVAL', 'HOURLY', 'DAILY', 'WEEKLY'}

--- a/SoftLayer/CLI/block/snapshot/get_notify_status.py
+++ b/SoftLayer/CLI/block/snapshot/get_notify_status.py
@@ -10,7 +10,7 @@ from SoftLayer.CLI import environment
 @click.argument('volume_id')
 @environment.pass_env
 def cli(env, volume_id):
-    """Get snapshots space usage threshold warning flag setting for a given volume"""
+    """Get snapshots space usage threshold warning flag setting for a given volume."""
     block_manager = SoftLayer.BlockStorageManager(env.client)
     enabled = block_manager.get_volume_snapshot_notification_status(volume_id)
 

--- a/SoftLayer/CLI/block/snapshot/list.py
+++ b/SoftLayer/CLI/block/snapshot/list.py
@@ -28,7 +28,7 @@ DEFAULT_COLUMNS = [
 
 @click.command(cls=SoftLayer.CLI.command.SLCommand, )
 @click.argument('volume_id')
-@click.option('--sortby', help='Column to sort by',
+@click.option('--sortby', help='Column to sort by.',
               default='created')
 @click.option('--columns',
               callback=column_helper.get_formatter(COLUMNS),

--- a/SoftLayer/CLI/block/snapshot/order.py
+++ b/SoftLayer/CLI/block/snapshot/order.py
@@ -9,34 +9,45 @@ from SoftLayer.CLI import exceptions
 
 @click.command(cls=SoftLayer.CLI.command.SLCommand, )
 @click.argument('volume_id')
-@click.option('--capacity',
+@click.option('--iops',
               type=int,
-              help='Size of snapshot space to create in GB',
+              help='Performance Storage IOPs, between 100 and 6000 in multiples of 100.')
+@click.option('--size',
+              type=int,
+              help='Size of snapshot space to create in GB.',
               required=True)
 @click.option('--tier',
               help='Endurance Storage Tier (IOPS per GB) of the block'
               ' volume for which space is ordered [optional, and only'
-              ' valid for endurance storage volumes]',
+              ' valid for endurance storage volumes].',
               type=click.Choice(['0.25', '2', '4', '10']))
 @click.option('--upgrade',
               type=bool,
-              help='Flag to indicate that the order is an upgrade',
+              help='Flag to indicate that the order is an upgrade.',
               default=False,
               is_flag=True)
 @environment.pass_env
-def cli(env, volume_id, capacity, tier, upgrade):
+def cli(env, volume_id, size, tier, upgrade, iops):
     """Order snapshot space for a block storage volume."""
     block_manager = SoftLayer.BlockStorageManager(env.client)
 
     if tier is not None:
         tier = float(tier)
 
+    if iops is not None:
+        if iops < 100 or iops > 6000:
+            raise exceptions.ArgumentError(f"Invalid value for '--iops' / '-i': '{iops}' is not one "
+                                           "of between 100 and 6000.")
+        if iops % 100 != 0:
+            raise exceptions.ArgumentError(f"Invalid value for '--iops' / '-i': '{iops}' is not a multiple of 100.")
+
     try:
         order = block_manager.order_snapshot_space(
             volume_id,
-            capacity=capacity,
+            capacity=size,
             tier=tier,
-            upgrade=upgrade
+            upgrade=upgrade,
+            iops=iops
         )
     except ValueError as ex:
         raise exceptions.ArgumentError(str(ex))

--- a/SoftLayer/CLI/block/snapshot/restore.py
+++ b/SoftLayer/CLI/block/snapshot/restore.py
@@ -10,10 +10,10 @@ from SoftLayer.CLI import environment
 @click.argument('volume_id')
 @click.option('--snapshot-id', '-s',
               help='The id of the snapshot which will be used'
-              ' to restore the block volume')
+              ' to restore the block volume.')
 @environment.pass_env
 def cli(env, volume_id, snapshot_id):
-    """Restore block volume using a given snapshot"""
+    """Restore block volume using a given snapshot."""
     block_manager = SoftLayer.BlockStorageManager(env.client)
     success = block_manager.restore_from_snapshot(volume_id, snapshot_id)
 

--- a/SoftLayer/CLI/block/snapshot/schedule_list.py
+++ b/SoftLayer/CLI/block/snapshot/schedule_list.py
@@ -11,7 +11,7 @@ from SoftLayer.CLI import formatting
 @click.argument('volume_id')
 @environment.pass_env
 def cli(env, volume_id):
-    """Lists snapshot schedules for a given volume"""
+    """Lists snapshot schedules for a given volume."""
 
     block_manager = SoftLayer.BlockStorageManager(env.client)
 

--- a/SoftLayer/CLI/block/snapshot/set_notify_status.py
+++ b/SoftLayer/CLI/block/snapshot/set_notify_status.py
@@ -12,12 +12,12 @@ from SoftLayer.CLI import environment
     '--enable/--disable',
     default=True,
     help="""
-    Enable/Disable snapshot notification. Use `slcli block snapshot-set-notification volumeId --enable` to enable
+    Enable/Disable snapshot notification. Use `slcli block snapshot-set-notification volumeId --enable` to enable.
     """,
     required=True)
 @environment.pass_env
 def cli(env, volume_id, enable):
-    """Enables/Disables snapshot space usage threshold warning for a given volume"""
+    """Enables/Disables snapshot space usage threshold warning for a given volume."""
     block_manager = SoftLayer.BlockStorageManager(env.client)
 
     status = block_manager.set_volume_snapshot_notification(volume_id, enable)

--- a/SoftLayer/managers/storage.py
+++ b/SoftLayer/managers/storage.py
@@ -381,7 +381,7 @@ class StorageManager(utils.IdentifierMixin, object):
                                 **kwargs)
 
     def order_snapshot_space(self, volume_id, capacity, tier, upgrade,
-                             **kwargs):
+                             iops=None, **kwargs):
         """Orders snapshot space for the given block volume.
 
         :param integer volume_id: The id of the volume
@@ -395,8 +395,11 @@ class StorageManager(utils.IdentifierMixin, object):
                       'staasVersion,hasEncryptionAtRest'
         volume = self.get_volume_details(volume_id, mask=object_mask, **kwargs)
 
+        if iops is None:
+            iops = int(volume['provisionedIops'])
+
         order = storage_utils.prepare_snapshot_order_object(
-            self, volume, capacity, tier, upgrade)
+            self, volume, capacity, tier, upgrade, iops)
 
         return self.client.call('Product_Order', 'placeOrder', order)
 

--- a/SoftLayer/managers/storage_utils.py
+++ b/SoftLayer/managers/storage_utils.py
@@ -423,7 +423,7 @@ def find_snapshot_schedule_id(volume, snapshot_schedule_keyname):
                      "the given storage volume")
 
 
-def prepare_snapshot_order_object(manager, volume, capacity, tier, upgrade):
+def prepare_snapshot_order_object(manager, volume, capacity, tier, upgrade, iops):
     """Prepare the snapshot space order object for the placeOrder() method
 
     :param manager: The File or Block manager calling this function
@@ -466,7 +466,7 @@ def prepare_snapshot_order_object(manager, volume, capacity, tier, upgrade):
                 raise exceptions.SoftLayerError(
                     "Snapshot space cannot be ordered for this performance "
                     "volume since it does not support Encryption at Rest.")
-            iops = int(volume['provisionedIops'])
+
             prices = [find_saas_snapshot_space_price(
                 package, capacity, iops=iops)]
         else:

--- a/tests/CLI/modules/block_tests.py
+++ b/tests/CLI/modules/block_tests.py
@@ -446,7 +446,7 @@ class BlockTests(testing.TestCase):
         order_mock.return_value = {}
 
         result = self.run_command(['block', 'snapshot-order', '1234',
-                                   '--capacity=10', '--tier=0.25'])
+                                   '--size=10', '--tier=0.25', '--iops=100'])
 
         self.assert_no_fail(result)
         self.assertEqual(result.output,
@@ -458,7 +458,7 @@ class BlockTests(testing.TestCase):
         order_mock.side_effect = ValueError('failure!')
 
         result = self.run_command(['block', 'snapshot-order', '1234',
-                                   '--capacity=10', '--tier=0.25'])
+                                   '--size=10', '--tier=0.25', '--iops=100'])
 
         self.assertEqual(2, result.exit_code)
         self.assertEqual('Argument Error: failure!', result.exception.message)
@@ -475,7 +475,7 @@ class BlockTests(testing.TestCase):
         }
 
         result = self.run_command(['block', 'snapshot-order', '1234',
-                                   '--capacity=10', '--tier=0.25'])
+                                   '--size=10', '--tier=0.25', '--iops=100'])
 
         self.assert_no_fail(result)
         self.assertEqual(result.output,

--- a/tests/managers/storage_utils_tests.py
+++ b/tests/managers/storage_utils_tests.py
@@ -2688,7 +2688,7 @@ class StorageUtilsTests(testing.TestCase):
         exception = self.assertRaises(
             exceptions.SoftLayerError,
             storage_utils.prepare_snapshot_order_object,
-            self.block, mock_volume, 10, None, False
+            self.block, mock_volume, 10, None, False, 100
         )
 
         self.assertEqual(
@@ -2703,7 +2703,7 @@ class StorageUtilsTests(testing.TestCase):
         exception = self.assertRaises(
             exceptions.SoftLayerError,
             storage_utils.prepare_snapshot_order_object,
-            self.block, mock_volume, 10, None, False
+            self.block, mock_volume, 10, None, False, 100
         )
 
         self.assertEqual(
@@ -2730,7 +2730,7 @@ class StorageUtilsTests(testing.TestCase):
         }
 
         result = storage_utils.prepare_snapshot_order_object(
-            self.block, mock_volume, 10, 2, False
+            self.block, mock_volume, 10, 2, False, 100
         )
 
         self.assertEqual(expected_object, result)
@@ -2753,7 +2753,7 @@ class StorageUtilsTests(testing.TestCase):
         }
 
         result = storage_utils.prepare_snapshot_order_object(
-            self.block, mock_volume, 20, None, True
+            self.block, mock_volume, 20, None, True, 100
         )
 
         self.assertEqual(expected_object, result)
@@ -2769,7 +2769,7 @@ class StorageUtilsTests(testing.TestCase):
         exception = self.assertRaises(
             exceptions.SoftLayerError,
             storage_utils.prepare_snapshot_order_object,
-            self.block, mock_volume, 10, None, False
+            self.block, mock_volume, 10, None, False, 100
         )
 
         self.assertEqual(
@@ -2797,7 +2797,7 @@ class StorageUtilsTests(testing.TestCase):
         }
 
         result = storage_utils.prepare_snapshot_order_object(
-            self.block, mock_volume, 10, None, False
+            self.block, mock_volume, 10, None, False, 100
         )
 
         self.assertEqual(expected_object, result)
@@ -2812,7 +2812,7 @@ class StorageUtilsTests(testing.TestCase):
         exception = self.assertRaises(
             exceptions.SoftLayerError,
             storage_utils.prepare_snapshot_order_object,
-            self.block, mock_volume, 10, None, False
+            self.block, mock_volume, 10, None, False, 100
         )
 
         self.assertEqual(
@@ -2842,7 +2842,7 @@ class StorageUtilsTests(testing.TestCase):
         }
 
         result = storage_utils.prepare_snapshot_order_object(
-            self.block, mock_volume, 10, 2, False
+            self.block, mock_volume, 10, 2, False, 100
         )
 
         self.assertEqual(expected_object, result)
@@ -2867,7 +2867,7 @@ class StorageUtilsTests(testing.TestCase):
         }
 
         result = storage_utils.prepare_snapshot_order_object(
-            self.block, mock_volume, 20, None, False
+            self.block, mock_volume, 20, None, False, 100
         )
 
         self.assertEqual(expected_object, result)
@@ -2891,7 +2891,7 @@ class StorageUtilsTests(testing.TestCase):
         }
 
         result = storage_utils.prepare_snapshot_order_object(
-            self.block, mock_volume, 20, None, False
+            self.block, mock_volume, 20, None, False, 100
         )
 
         self.assertEqual(expected_object, result)


### PR DESCRIPTION
Issue link: #1856 
Note: additionally was updated some unit test and descriptions in snapshot group command
```
softlayer-python/ (issue1856) $ slcli block snapshot-order -h
Usage: slcli block snapshot-order [OPTIONS] VOLUME_ID

        Order snapshot space for a block storage volume.

┌────┬───────────┬────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│    │ volume_id │                                                                                                        │
│    │ --iops    │ Performance Storage IOPs, between 100 and 6000 in multiples of 100.                                    │
│    │ --size    │ Size of snapshot space to create in GB.  [required]                                                    │
│    │ --tier    │ Endurance Storage Tier (IOPS per GB) of the block volume for which space is ordered [optional, and     │
│    │           │ only valid for endurance storage volumes]. Choices: 0.25, 2, 4, 10                                     │
│    │ --upgrade │ Flag to indicate that the order is an upgrade.                                                         │
│ -h │ --help    │ Show this message and exit.                                                                            │
└────┴───────────┴────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```