### PR TITLE
Fix email commands

### DIFF
--- a/SoftLayer/CLI/email/detail.py
+++ b/SoftLayer/CLI/email/detail.py
@@ -4,7 +4,8 @@
 import click
 
 from SoftLayer.CLI.command import SLCommand as SLCommand
-from SoftLayer.CLI.email.list import build_statistics_table
+# Commented this line until we fix EmailManager.GetStatistics() method in golang plugin
+# from SoftLayer.CLI.email.list import build_statistics_table
 from SoftLayer.CLI import environment
 from SoftLayer.CLI import formatting
 from SoftLayer.managers.email import EmailManager
@@ -33,10 +34,9 @@ def cli(env, identifier):
     table.add_row(['type_description', utils.lookup(result, 'type', 'description')])
     table.add_row(['type', utils.lookup(result, 'type', 'keyName')])
     table.add_row(['vendor', utils.lookup(result, 'vendor', 'keyName')])
-
-    statistics = email_manager.get_statistics(identifier)
-
-    for statistic in statistics:
-        table.add_row(['statistics', build_statistics_table(statistic)])
-
+    # Commented these lines until we fix EmailManager.GetStatistics() method in golang plugin
+    # statistics = email_manager.get_statistics(identifier)
+    #
+    # for statistic in statistics:
+    #     table.add_row(['statistics', build_statistics_table(statistic)])
     env.fout(table)

--- a/SoftLayer/CLI/email/list.py
+++ b/SoftLayer/CLI/email/list.py
@@ -32,27 +32,28 @@ def cli(env):
                                    utils.lookup(email, 'vendor', 'keyName')])
 
         overview_table = _build_overview_table(email_manager.get_account_overview(email.get('id')))
-        statistics = email_manager.get_statistics(email.get('id'))
+        # Commented this line until we fix EmailManager.GetStatistics() method in golang plugin
+        # statistics = email_manager.get_statistics(email.get('id'))
 
         table.add_row(['email_information', table_information])
         table.add_row(['email_overview', overview_table])
-        for statistic in statistics:
-            table.add_row(['statistics', build_statistics_table(statistic)])
+        # Commented these lines until we fix EmailManager.GetStatistics() method in golang plugin
+        # for statistic in statistics:
+        #     table.add_row(['statistics', build_statistics_table(statistic)])
 
     env.fout(table)
 
 
 def _build_overview_table(email_overview):
     table = formatting.Table(
-        ['credit_allowed', 'credits_remain', 'credits_overage', 'credits_used',
-         'package', 'reputation', 'requests'])
+        ['package', 'reputation'])
     table.align['name'] = 'r'
     table.align['value'] = 'l'
 
-    table.add_row([email_overview.get('creditsAllowed'), email_overview.get('creditsRemain'),
-                   email_overview.get('creditsOverage'), email_overview.get('creditsUsed'),
-                   email_overview.get('package'), email_overview.get('reputation'),
-                   email_overview.get('requests')])
+    table.add_row([
+        utils.lookup(email_overview, 'profile', 'package'),
+        utils.lookup(email_overview, 'profile', 'reputation')
+    ])
 
     return table
 


### PR DESCRIPTION
Issue: https://github.com/softlayer/softlayer-python/issues/1857
Observations:  the `email list` and `email detail` commands were updated to not use SoftLayer_Network_Message_Delivery_Email_Sendgrid::getStatistics method and match with golang plugin 