### PR TITLE
Add columns to `image list`

### DIFF
--- a/SoftLayer/CLI/image/__init__.py
+++ b/SoftLayer/CLI/image/__init__.py
@@ -3,8 +3,8 @@
 from SoftLayer.CLI import formatting
 
 
-MASK = ('id,accountId,name,globalIdentifier,parentId,publicFlag,flexImageFlag,'
-        'imageType')
+MASK = ('id,createDate,note,accountId,name,globalIdentifier,parentId,publicFlag,flexImageFlag,'
+        'imageType,children[blockDevices[diskImage[softwareReferences[softwareDescription]]]]')
 DETAIL_MASK = MASK + (',firstChild,children[id,blockDevicesDiskSpaceTotal,datacenter,'
                       'transaction[transactionGroup,transactionStatus]],'
                       'note,createDate,status,transaction')

--- a/SoftLayer/CLI/image/list.py
+++ b/SoftLayer/CLI/image/list.py
@@ -29,11 +29,18 @@ def cli(env, name, public):
         for image in image_mgr.list_public_images(name=name, mask=image_mod.MASK):
             images.append(image)
 
-    table = formatting.Table(['id', 'name', 'type', 'visibility', 'account'])
+    table = formatting.Table(['id', 'name', 'type', 'visibility', 'account', 'os', 'created', 'notes'])
 
     images = [image for image in images if not image['parentId']]
     for image in images:
-
+        operative_system = '-'
+        if image.get('children') and len(image.get('children')) != 0:
+            if image.get('children')[0].get('blockDevices') and len(image.get('children')[0].get('blockDevices')) != 0:
+                for block_device in image.get('children')[0].get('blockDevices'):
+                    if block_device.get('diskImage').get('softwareReferences') and \
+                            len(block_device.get('diskImage').get('softwareReferences')) != 0:
+                        operative_system = block_device.get('diskImage').get('softwareReferences')[0].\
+                            get('softwareDescription').get('longDescription')
         visibility = (image_mod.PUBLIC_TYPE if image['publicFlag'] else image_mod.PRIVATE_TYPE)
         table.add_row([
             image.get('id', formatting.blank()),
@@ -43,6 +50,9 @@ def cli(env, name, public):
                 utils.lookup(image, 'imageType', 'name')),
             visibility,
             image.get('accountId', formatting.blank()),
+            operative_system,
+            image.get('createDate', formatting.blank()),
+            image.get('note', formatting.blank()),
         ])
 
     env.fout(table)


### PR DESCRIPTION
Issue: https://github.com/softlayer/softlayer-python/issues/1871
Observations: OS, created date and notes columns were added in the command output
```
slcli image list --private
┌──────────┬───────────────────────────────────────┬───────────┬────────────┬─────────┬──────────────────────────────────────────────────────────┬───────────────────────────┬───────────────────────────────────────────────────────────┐
│    id    │                 name                  │   type    │ visibility │ account │                            os                            │          created          │                           notes                           │
├──────────┼───────────────────────────────────────┼───────────┼────────────┼─────────┼──────────────────────────────────────────────────────────┼───────────────────────────┼───────────────────────────────────────────────────────────┤
│ 5706582  │ Backup template for disk migration of │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2020-08-07T12:12:14-07:00 │    This is a backup template for the disk migration of    │
│          │  'testttbootmode.softlayer.ibm.com'.  │           │            │         │                                                          │                           │  'testttbootmode.softlayer.ibm.com' and is not required.  │
│          │                                       │           │            │         │                                                          │                           │          This image may be removed at any time.           │
│ 11829352 │               apr8cnt7                │  System   │  Private   │ 307608  │             Ubuntu 20.04-64 Minimal for VSI              │ 2022-04-08T08:58:37-07:00 │                             -                             │
│ 8730058  │        cgallo-test-transaction        │  System   │  Private   │ 307608  │              CentOS 8.0-64 Minimal for VSI               │ 2021-04-06T06:37:56-07:00 │                             -                             │
│ 12666290 │          cgalloTestImage001           │  System   │  Private   │ 307608  │             Ubuntu 20.04-64 Minimal for VSI              │ 2023-02-21T16:41:26-06:00 │                       My test image                       │
│ 12666294 │          cgalloTestImage002           │  System   │  Private   │ 307608  │             Ubuntu 20.04-64 Minimal for VSI              │ 2023-02-21T16:42:27-06:00 │                   Another My test image                   │
│ 11921678 │               ecapture                │  System   │  Private   │ 307608  │             Ubuntu 20.04-64 Minimal for VSI              │ 2022-04-20T14:17:14-07:00 │                       enoteCapture                        │
│ 2022239  │            fmirCentOsSwift            │  System   │  Private   │ 307608  │                 Other Unix / Linux 1.0.0                 │ 2018-08-31T10:16:16-07:00 │                   fmirTestRESTfromCurl                    │
│ 2024549  │              fmirChechu2              │ ISO Image │  Private   │ 307608  │                            -                             │ 2018-09-04T09:07:20-07:00 │                            Win                            │
│ 2023559  │             fmirChechu_1              │  System   │  Private   │ 307608  │                 Other Unix / Linux 1.0.0                 │ 2018-09-03T06:55:42-07:00 │                     fmirTestRESTVhd1                      │
│ 2023579  │             fmirChechu_3              │  System   │  Private   │ 307608  │  Microsoft Windows 2008 FULL STD 64 bit R2 SP1 2008 R2   │ 2018-09-03T07:12:18-07:00 │                     fmirTestRESTVhd3                      │
│          │                                       │           │            │         │                     FULL STD x64 SP1                     │                           │                                                           │
│ 1985169  │      fmirFlavHourVgpuImgTemplate      │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2018-07-17T12:04:43-07:00 │         imageTemplate with 25 gb hdd hard drive 0         │
│          │                                       │           │            │         │                                                          │                           │                       vsi 54054565                        │
│ 1929279  │           fmirFlavhourVgpu            │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2018-05-14T13:18:18-07:00 │   This is an image created from an VSI hourly with vGpu   │
│          │                                       │           │            │         │                                                          │                           │                          flavour                          │
│ 1796409  │        fmirGroupImageTemplate         │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2017-11-21T12:49:42-06:00 │                   an optional fmir note                   │
│ 1827235  │            fmirImageVsiWin            │  System   │  Private   │ 307608  │ Microsoft Windows 2016 FULL STD 64 bit 2016 FULL STD x64 │ 2018-01-03T07:27:20-06:00 │ This is an image template test to verify time until it is │
│          │                                       │           │            │         │                                                          │                           │                ready to use setBoot method                │
│ 9238386  │            fmirImageVsiWin            │  System   │  Private   │ 307608  │              CentOS 8.0-64 Minimal for VSI               │ 2021-05-19T11:11:08-07:00 │                             -                             │
│ 2023687  │            fmirLinuxChechu            │ ISO Image │  Private   │ 307608  │                            -                             │ 2018-09-03T12:07:27-07:00 │                      fmirTestRESTiso                      │
│ 1797793  │       fmirTestByolRhel7Minimal        │  System   │  Private   │ 307608  │             Redhat EL 7.0-64 Minimal for VSI             │ 2017-11-23T09:22:18-06:00 │   This image template was created to test Byol property   │
│          │                                       │           │            │         │                                                          │                           │              using Vsi with RHEL 7.x Minimal              │
│ 2057659  │             fmirTestTime              │ ISO Image │  Private   │ 307608  │                            -                             │ 2018-10-09T06:25:05-07:00 │                             -                             │
│ 2057663  │             fmirTestTime2             │ ISO Image │  Private   │ 307608  │                            -                             │ 2018-10-09T06:31:04-07:00 │                             -                             │
│ 2057667  │             fmirTestTime3             │  System   │  Private   │ 307608  │              CentOS 6.0-32 Minimal for VSI               │ 2018-10-09T06:38:26-07:00 │                             -                             │
│ 2057671  │             fmirTestTime4             │  System   │  Private   │ 307608  │        Microsoft Windows 2003 STD 64 bit SP2 w/R2        │ 2018-10-09T06:45:33-07:00 │                             -                             │
│          │                                       │           │            │         │                      STD-SRV-SP2-64                      │                           │                                                           │
│ 1796405  │        fmirUIstandardTemplate         │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2017-11-21T12:45:02-06:00 │                        fmirNotes3                         │
│ 2020575  │     fmirVsiWin-ps1-imateTemplate      │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2018-08-29T10:08:16-07:00 │ https://control.softlayer.com/devices/details/52473787/v… │
│          │                                       │           │            │         │                                                          │                           │                  (Disk) (25 GB) (System)                  │
│          │                                       │           │            │         │                                                          │                           │                   (Disk) (2 GB) (Swap)                    │
│          │                                       │           │            │         │                                                          │                           │                 (Disk) (100 GB) (System)                  │
│          │                                       │           │            │         │                                                          │                           │                  (Disk) (64 MB) (System)                  │
│          │                                       │           │            │         │                                                          │                           │                                                           │
│ 1793027  │             fmirWithoutCI             │  System   │  Private   │ 307608  │             Ubuntu 16.04-64 Minimal for VSI              │ 2017-11-16T15:07:24-06:00 │  This image should not be created with cloud init as it   │
│          │                                       │           │            │         │                                                          │                           │      has been ordered selecting additional software,      │
│          │                                       │           │            │         │                                                          │                           │    post-provisioning scripts, or advanced monitoring.     │
│ 4799312  │            fotestTemplate             │  System   │  Private   │ 307608  │             Ubuntu 16.04-64 Minimal for VSI              │ 2020-05-07T16:00:02-07:00 │                       test template                       │
│ 4798282  │             gq-image-test             │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2020-05-07T13:49:51-07:00 │                     tech-support-img                      │
│ 12623686 │            hsproxyocpvirt             │  System   │  Private   │ 307608  │             Redhat EL 8.0-64 Minimal for VSI             │ 2022-11-28T10:36:11-06:00 │                             -                             │
│ 1770563  │      image-factory-rpms-20171024      │  System   │  Private   │ 729557  │             Redhat EL 7.0-64 Minimal for VSI             │ 2017-10-24T10:58:34-07:00 │                             -                             │
│ 2167987  │     image-factory-rpms.chechu.com     │  System   │  Private   │ 307608  │             Redhat EL 7.0-64 Minimal for VSI             │ 2019-02-23T05:33:13-06:00 │                             -                             │
│ 12621008 │           migration-fabric            │  System   │  Private   │ 307608  │             Redhat EL 8.0-64 Minimal for VSI             │ 2022-11-22T10:59:37-06:00 │                             -                             │
│ 1906463  │          multi-disk-template          │  System   │  Private   │ 307608  │             Ubuntu 16.04-64 Minimal for VSI              │ 2018-04-12T13:23:13-07:00 │                    testing this thing                     │
│ 1370915  │     newdeploymenttool- 21-10-2016     │  System   │  Private   │ 307608  │             Ubuntu 14.04-64 Minimal for VSI              │ 2016-10-21T11:24:08-07:00 │                             -                             │
│ 1370919  │            odoo 21-10-2016            │  System   │  Private   │ 307608  │             Ubuntu 14.04-64 Minimal for VSI              │ 2016-10-21T11:25:29-07:00 │                             -                             │
│ 2167983  │        provisioner.chechu.com         │  System   │  Private   │ 307608  │             Redhat EL 7.0-64 Minimal for VSI             │ 2019-02-23T05:31:17-06:00 │                             -                             │
│ 12604232 │                  pxe                  │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2022-10-26T12:46:41-07:00 │                             -                             │
│ 1047761  │              pxe working              │  System   │  Private   │ 307608  │             Ubuntu 14.04-64 Minimal for VSI              │ 2016-04-27T12:06:11-07:00 │                             -                             │
│ 1445193  │             pxeencryption             │  System   │  Private   │ 307608  │             Redhat EL 7.0-64 Minimal for VSI             │ 2016-12-22T19:08:37-06:00 │                             -                             │
│ 2167979  │             rabbit_chechu             │  System   │  Private   │ 307608  │             Redhat EL 7.0-64 Minimal for VSI             │ 2019-02-23T05:29:18-06:00 │                             -                             │
│ 1897617  │                rcvgpu                 │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2018-04-02T08:45:21-07:00 │                           test                            │
│ 1498665  │            redhat_openvpn             │  System   │  Private   │ 307608  │             Redhat EL 7.0-64 Minimal for VSI             │ 2017-02-12T17:34:03-06:00 │                             -                             │
│ 11829254 │                 test                  │  System   │  Private   │ 307608  │                CentOS 7.0-64 LAMP for VSI                │ 2022-04-08T08:19:03-07:00 │                             -                             │
│ 4811244  │            test-image-gq03            │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2020-05-08T16:07:02-07:00 │                 Only for testing purposes                 │
│ 4799296  │        testGroupImageTemplate         │  System   │  Private   │ 307608  │             Ubuntu 16.04-64 Minimal for VSI              │ 2020-05-07T15:54:47-07:00 │                   an optional fmir note                   │
│ 12650596 │               testimage               │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2023-01-25T22:40:57-06:00 │                          test 1                           │
│ 12651610 │               testimage               │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2023-01-26T14:59:34-06:00 │                             -                             │
│ 12651324 │               testimage               │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2023-01-26T11:42:56-06:00 │                             -                             │
│ 12651396 │               testimage               │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2023-01-26T14:18:43-06:00 │                             -                             │
│ 12650608 │               testimage               │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2023-01-25T22:45:37-06:00 │                             -                             │
│ 12651368 │               testimage               │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2023-01-26T13:22:08-06:00 │                             -                             │
│ 12651244 │               testimage               │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2023-01-26T09:42:56-06:00 │                             -                             │
│ 12651392 │               testimage               │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2023-01-26T14:16:34-06:00 │                             -                             │
│ 12651364 │               testimage               │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2023-01-26T13:19:16-06:00 │                             -                             │
│ 12651264 │               testimage               │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2023-01-26T10:47:58-06:00 │                             -                             │
│ 12650600 │               testimage               │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2023-01-25T22:43:09-06:00 │                             -                             │
│ 12651320 │               testimage               │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2023-01-26T11:41:17-06:00 │                             -                             │
│ 12651328 │               testimage               │  System   │  Private   │ 307608  │              CentOS 7.0-64 Minimal for VSI               │ 2023-01-26T11:44:36-06:00 │                             -                             │
└──────────┴───────────────────────────────────────┴───────────┴────────────┴─────────┴──────────────────────────────────────────────────────────┴───────────────────────────┴───────────────────────────────────────────────────────────┘
```