### PR TITLE
New command `slcli image share-deny`

### DIFF
--- a/SoftLayer/CLI/image/share_deny.py
+++ b/SoftLayer/CLI/image/share_deny.py
@@ -1,0 +1,23 @@
+"""Deny share an image template with another account."""
+# :license: MIT, see LICENSE for more details.
+
+import click
+
+import SoftLayer
+from SoftLayer.CLI import environment
+from SoftLayer.CLI import helpers
+
+
+@click.command(cls=SoftLayer.CLI.command.SLCommand, )
+@click.argument('identifier')
+@click.option('--account-id', help='Account Id for another account to deny share image template', required=True)
+@environment.pass_env
+def cli(env, identifier, account_id):
+    """Deny share an image template with another account."""
+
+    image_mgr = SoftLayer.ImageManager(env.client)
+    image_id = helpers.resolve_id(image_mgr.resolve_ids, identifier, 'image')
+    shared_image = image_mgr.deny_share_image(image_id, account_id)
+
+    if shared_image:
+        env.fout("Image template {} was deny shared to account {}.".format(identifier, account_id))

--- a/SoftLayer/CLI/routes.py
+++ b/SoftLayer/CLI/routes.py
@@ -208,6 +208,7 @@ ALL_ROUTES = [
     ('image:import', 'SoftLayer.CLI.image.import:cli'),
     ('image:export', 'SoftLayer.CLI.image.export:cli'),
     ('image:datacenter', 'SoftLayer.CLI.image.datacenter:cli'),
+    ('image:share-deny', 'SoftLayer.CLI.image.share_deny:cli'),
 
     ('ipsec', 'SoftLayer.CLI.vpn.ipsec'),
     ('ipsec:configure', 'SoftLayer.CLI.vpn.ipsec.configure:cli'),

--- a/SoftLayer/fixtures/SoftLayer_Virtual_Guest_Block_Device_Template_Group.py
+++ b/SoftLayer/fixtures/SoftLayer_Virtual_Guest_Block_Device_Template_Group.py
@@ -53,3 +53,4 @@ getStorageLocations = [
     {'id': 265592, 'longName': 'Amsterdam 1', 'name': 'ams01', 'statusId': 2},
     {'id': 814994, 'longName': 'Amsterdam 3', 'name': 'ams03', 'statusId': 2},
 ]
+denySharingAccess = True

--- a/SoftLayer/managers/image.py
+++ b/SoftLayer/managers/image.py
@@ -237,3 +237,12 @@ class ImageManager(utils.IdentifierMixin, object):
             locations_ids.append(matching_location)
 
         return locations_ids
+
+    def deny_share_image(self, image_id, account_id):
+        """Deny sharing image template with another account.
+
+        :param int image_id: The ID of the image.
+        :param int account_id: The ID of the another account to deny share the image.
+        """
+
+        return self.vgbdtg.denySharingAccess(account_id, id=image_id)

--- a/docs/cli/image.rst
+++ b/docs/cli/image.rst
@@ -30,3 +30,7 @@ Disk Image Commands
 .. click:: SoftLayer.CLI.image.datacenter:cli
     :prog: image datacenter
     :show-nested:
+
+.. click:: SoftLayer.CLI.image.share_deny:cli
+    :prog: image share-deny
+    :show-nested:

--- a/tests/CLI/modules/image_tests.py
+++ b/tests/CLI/modules/image_tests.py
@@ -53,3 +53,15 @@ class ImageTests(testing.TestCase):
     def test_datacenter_remove_fails(self):
         result = self.run_command(['image', 'datacenter', '100', '--remove'])
         self.assertEqual(2, result.exit_code)
+
+    def test_deny_share(self):
+        result = self.run_command(['image', 'share-deny', '123456', '--account-id', '654321'])
+        self.assert_no_fail(result)
+
+    def test_deny_share_without_id(self):
+        result = self.run_command(['image', 'share-deny'])
+        self.assertEqual(2, result.exit_code)
+
+    def test_deny_share_without_id_account(self):
+        result = self.run_command(['image', 'share-deny', "123456"])
+        self.assertEqual(2, result.exit_code)


### PR DESCRIPTION
Issue link: #1873
```
softlayer-python/ () $ slcli image share-deny 5706 --account-id 46
Image template 5706 was deny shared to account 46.
```
