### PR TITLE
Fix `slcli hardware create-credential` command

### DIFF
--- a/SoftLayer/CLI/hardware/create_credential.py
+++ b/SoftLayer/CLI/hardware/create_credential.py
@@ -14,44 +14,37 @@ from SoftLayer.CLI import formatting
 @click.option('--username', '-U', required=True, help="The username part of the username/password pair")
 @click.option('--password', '-P', required=True, help="The password part of the username/password pair.")
 @click.option('--notes', '-n', help="A note string stored for this username/password pair.")
-@click.option('--system', required=True, help="The name of this specific piece of software.")
+@click.option('--software', required=True, help="The name of this specific piece of software.")
 @environment.pass_env
-def cli(env, identifier, username, password, notes, system):
+def cli(env, identifier, username, password, notes, software):
     """Create a password for a software component."""
 
     mgr = SoftLayer.HardwareManager(env.client)
 
-    software = mgr.get_software_components(identifier)
-    sw_id = ''
+    software_components = mgr.get_software_components(identifier)
+    software_id = ''
     try:
-        for sw_instance in software:
-            if (sw_instance['softwareLicense']['softwareDescription']['name']).lower() == system:
-                sw_id = sw_instance['id']
+        for software_component in software_components:
+            if software_component['softwareLicense']['softwareDescription']['name'].lower() == software.lower():
+                software_id = software_component['id']
     except KeyError as ex:
-        raise exceptions.CLIAbort('System id not found') from ex
+        raise exceptions.CLIAbort('Software not found') from ex
 
     template = {
         "notes": notes,
         "password": password,
-        "softwareId": sw_id,
-        "username": username,
-        "software": {
-            "hardwareId": identifier,
-            "softwareLicense": {
-                "softwareDescription": {
-                    "name": system
-                }
-            }
-        }}
+        "softwareId": software_id,
+        "username": username
+    }
 
     result = mgr.create_credential(template)
 
     table = formatting.KeyValueTable(['name', 'value'])
-    table.align['name'] = 'r'
-    table.align['value'] = 'l'
-    table.add_row(['Software Id', result['id']])
+    table.align['Name'] = 'r'
+    table.align['Value'] = 'l'
+    table.add_row(['Software Credential Id', result['id']])
     table.add_row(['Created', result['createDate']])
     table.add_row(['Username', result['username']])
     table.add_row(['Password', result['password']])
-    table.add_row(['Notes', result['notes']])
+    table.add_row(['Notes', result.get('notes') or formatting.blank()])
     env.fout(table)

--- a/SoftLayer/CLI/hardware/create_credential.py
+++ b/SoftLayer/CLI/hardware/create_credential.py
@@ -39,7 +39,7 @@ def cli(env, identifier, username, password, notes, software):
 
     result = mgr.create_credential(template)
 
-    table = formatting.KeyValueTable(['name', 'value'])
+    table = formatting.KeyValueTable(['Name', 'Value'])
     table.align['Name'] = 'r'
     table.align['Value'] = 'l'
     table.add_row(['Software Credential Id', result['id']])

--- a/tests/CLI/modules/server_tests.py
+++ b/tests/CLI/modules/server_tests.py
@@ -1055,7 +1055,7 @@ class ServerCLITests(testing.TestCase):
     def test_create_credential(self):
         result = self.run_command(['hw', 'create-credential', '123456',
                                    '--username', 'testslcli', '--password', 'test-123456',
-                                   '--notes', 'test slcli', '--system', 'system'])
+                                   '--notes', 'test slcli', '--software', 'system'])
         self.assert_no_fail(result)
 
     def test_list_hw_search_noargs(self):


### PR DESCRIPTION
Issue: https://github.com/softlayer/softlayer-python/issues/1885
Observations: The command was updated to handle uppercase and lowercase OS and to not display error message without --note option and `--system` option was changed by `--software`
```
slcli hardware create-credential 1532729 --username userb --password 123456 --software "passmark Suite"
┌────────────────────────┬───────────────────────────┐
│                   Name │ Value                     │
├────────────────────────┼───────────────────────────┤
│ Software Credential Id │ 80991916                  │
│                Created │ 2023-03-23T13:47:33-06:00 │
│               Username │ userb                     │
│               Password │ 123456                    │
│                  Notes │ -                         │
└────────────────────────┴───────────────────────────┘
```