### PR TITLE
New Command: `slcli user vpn-password`

### DIFF
--- a/SoftLayer/CLI/routes.py
+++ b/SoftLayer/CLI/routes.py
@@ -387,6 +387,7 @@ ALL_ROUTES = [
     ('user:vpn-subnet', 'SoftLayer.CLI.user.vpn_subnet:cli'),
     ('user:remove-access', 'SoftLayer.CLI.user.remove_access:cli'),
     ('user:grant-access', 'SoftLayer.CLI.user.grant_access:cli'),
+    ('user:vpn-password', 'SoftLayer.CLI.user.vpn_password:cli'),
 
     ('vlan', 'SoftLayer.CLI.vlan'),
     ('vlan:create', 'SoftLayer.CLI.vlan.create:cli'),

--- a/SoftLayer/CLI/user/vpn_password.py
+++ b/SoftLayer/CLI/user/vpn_password.py
@@ -1,0 +1,26 @@
+"""Set the user VPN password."""
+# :license: MIT, see LICENSE for more details.
+
+import click
+import SoftLayer
+
+from SoftLayer.CLI.command import SLCommand as SLCommand
+from SoftLayer.CLI import environment
+from SoftLayer.CLI import helpers
+
+
+@click.command(cls=SLCommand, )
+@click.argument('identifier')
+@click.option('--password', required=True, help="Your new VPN password")
+@environment.pass_env
+def cli(env, identifier, password):
+    """Set the user VPN password.
+
+    Example: slcli user vpn-password 123456 --password=Mypassword1.
+    """
+
+    mgr = SoftLayer.UserManager(env.client)
+    user_id = helpers.resolve_id(mgr.resolve_ids, identifier, 'username')
+    result = mgr.update_vpn_password(user_id, password)
+    if result:
+        click.secho("Successfully updated user VPN password.", fg='green')

--- a/SoftLayer/fixtures/SoftLayer_User_Customer.py
+++ b/SoftLayer/fixtures/SoftLayer_User_Customer.py
@@ -92,6 +92,7 @@ removeVirtualGuestAccess = True
 addDedicatedHostAccess = True
 addHardwareAccess = True
 addVirtualGuestAccess = True
+updateVpnPassword = True
 
 getHardware = [{
         "domain": "testedit.com",

--- a/SoftLayer/managers/user.py
+++ b/SoftLayer/managers/user.py
@@ -476,6 +476,16 @@ class UserManager(utils.IdentifierMixin, object):
         """
         return self.user_service.getVirtualGuests(id=user_id)
 
+    def update_vpn_password(self, user_id, password):
+        """Update a user's VPN password.
+
+        :param int user_id:
+        :param string password:
+
+        :returns: true
+        """
+        return self.user_service.updateVpnPassword(password, id=user_id)
+
 
 def _keyname_search(haystack, needle):
     for item in haystack:

--- a/docs/cli/users.rst
+++ b/docs/cli/users.rst
@@ -60,4 +60,7 @@ Version 5.6.0 introduces the ability to interact with user accounts from the cli
     :prog: user grant-access
     :show-nested:
 
+.. click:: SoftLayer.CLI.user.vpn_password:cli
+    :prog: user vpn-password
+    :show-nested:
 

--- a/tests/CLI/modules/user_tests.py
+++ b/tests/CLI/modules/user_tests.py
@@ -378,3 +378,12 @@ class UserCLITests(testing.TestCase):
         result = self.run_command(['user', 'remove-access', '123456'])
         self.assertEqual(2, result.exit_code)
         self.assertIn('A device option is required.', result.exception.message)
+
+    def test_update_vpn_password(self):
+        result = self.run_command(['user', 'vpn-password', '123456', '--password', 'Mypassword1.'])
+        self.assert_no_fail(result)
+
+    def test_remove_without_password(self):
+        result = self.run_command(['user', 'vpn-password', '123456'])
+        self.assertEqual(2, result.exit_code)
+        self.assertIn("Missing option '--password'", result.output)

--- a/tests/managers/user_tests.py
+++ b/tests/managers/user_tests.py
@@ -330,3 +330,7 @@ class UserManagerTests(testing.TestCase):
     def test_remove_dedicated(self):
         self.manager.remove_dedicated_access(123456, 369852)
         self.assert_called_with('SoftLayer_User_Customer', 'removeDedicatedHostAccess')
+
+    def test_update_vpn_password(self):
+        self.manager.update_vpn_password(123456, "Mypassword1.")
+        self.assert_called_with('SoftLayer_User_Customer', 'updateVpnPassword')


### PR DESCRIPTION
Related to: https://github.com/softlayer/softlayer-python/issues/1906, task 1 of 3
Issue: https://github.com/softlayer/softlayer-python/issues/1908
Observations: the new command and unit tests were added
```
slcli user vpn-password 7115248 --password=Mypassword1.2
Successfully updated user VPN password.
```