### PR TITLE
Update `slcli user detail` to display if user has API key 

### DIFF
--- a/SoftLayer/CLI/user/detail.py
+++ b/SoftLayer/CLI/user/detail.py
@@ -65,9 +65,14 @@ def basic_info(user, keys):
 
     table.add_row(['Id', user.get('id', '-')])
     table.add_row(['Username', user.get('username', '-')])
-    if keys:
-        for key in user.get('apiAuthenticationKeys'):
+    keys_array = user.get('apiAuthenticationKeys')
+    if keys and len(keys_array) != 0:
+        for key in keys_array:
             table.add_row(['APIKEY', key.get('authenticationKey')])
+    elif keys_array is not None and len(keys_array) != 0:
+        table.add_row(['APIKEY', 'Yes'])
+    else:
+        table.add_row(['APIKEY', 'No'])
     table.add_row(['Name', "%s %s" % (user.get('firstName', '-'), user.get('lastName', '-'))])
     table.add_row(['Email', user.get('email')])
     table.add_row(['OpenID', user.get('openIdConnectUserName')])


### PR DESCRIPTION
Related to: https://github.com/softlayer/softlayer-python/issues/1906
Issue: https://github.com/softlayer/softlayer-python/issues/1911
Observations: the command was updated to display if a user has or not  an API key
```
slcli user detail 9734826
┌──────────────┬───────────────────────────────────────────────┐
│        Title │ Basic Information                             │
├──────────────┼───────────────────────────────────────────────┤
│           Id │ 9734826                                       │
│     Username │ 307608_brian.flores@ibm.com                   │
│       APIKEY │ Yes                                           │
│         Name │ Brian Flores                                  │
│        Email │ Brian.Flores@ibm.com                          │
│       OpenID │ brian.flores@ibm.com                          │
│      Address │ 4849 Alpha Rd None Dallas TX US 75244-4608    │
│      Company │ SoftLayer Internal - Development Community    │
│      Created │ 2021-12-16T15:52:58-06:00                     │
│ Phone Number │                                               │
│  Parent User │ SL307608                                      │
│       Status │ Active                                        │
│      SSL VPN │ False                                         │
│   Last Login │ 2023-04-17T08:13:03-06:00 From: 52.117.153.78 │
└──────────────┴───────────────────────────────────────────────┘
```