### PR TITLE
slcli search command help/abort message when no option provided

### DIFF
--- a/SoftLayer/CLI/search.py
+++ b/SoftLayer/CLI/search.py
@@ -24,6 +24,7 @@ object_types = {'ticket': 'SoftLayer_Ticket',
 @click.argument('query', nargs=-1)
 @click.option('--types', is_flag=True, default=False, is_eager=True, help="Display searchable types.")
 @click.option('--advanced', is_flag=True, help="Calls the AdvancedSearh API.")
+@click.help_option('--help', '-h')
 @environment.pass_env
 def cli(env, query, types, advanced):
     """Perform a query against the SoftLayer search database.
@@ -35,6 +36,23 @@ def cli(env, query, types, advanced):
         slcli search _objectType:SoftLayer_Virtual_Guest test.com
         slcli -vvv search _objectType:SoftLayer_Hardware hostname:testibm --advanced
     """
+
+    # Before any Search operation
+    def check_opt(list_opt=None):
+        check = False
+        for input_ in list_opt:
+            if input_ is True:
+                check = True
+                break
+        return check
+
+    list_opt = [query, types, advanced]
+
+    if check_opt(list_opt):
+        pass
+    else:
+        raise click.UsageError('Search query must be provided')
+
     search = SearchManager(env.client)
     # query is in array, so we need to convert it to a normal string for the API
     query = " ".join(query)

--- a/SoftLayer/CLI/search.py
+++ b/SoftLayer/CLI/search.py
@@ -48,9 +48,7 @@ def cli(env, query, types, advanced):
 
     list_opt = [query, types, advanced]
 
-    if check_opt(list_opt):
-        pass
-    else:
+    if not check_opt(list_opt):
         raise click.UsageError('Search query must be provided')
 
     search = SearchManager(env.client)

--- a/tests/CLI/modules/search_tests.py
+++ b/tests/CLI/modules/search_tests.py
@@ -17,3 +17,7 @@ class FindTests(testing.TestCase):
     def test_find_advanced(self):
         result = self.run_command(['search', 'hardware', '--advanced'])
         self.assert_no_fail(result)
+
+    def test_no_options(self):
+        result = self.run_command(['search'])
+        self.assertEqual(result.exit_code, 2)


### PR DESCRIPTION
slcli search command should work with options provided. 

Fixes: #1863

TODO:
If option is not provided, help/abort message should print on console and abort the search operation right away.

<img width="798" alt="Screenshot 2023-07-12 at 1 30 49 AM" src="https://github.com/softlayer/softlayer-python/assets/134699156/cd1eb676-dc09-4757-9658-aa562e28a7ff">


<img width="701" alt="Screenshot 2023-07-12 at 1 31 07 AM" src="https://github.com/softlayer/softlayer-python/assets/134699156/137bd02e-d096-4226-94b7-fb0c0f8c80d2">

@allmightyspiff, Please review this change.

Thanks,
Jayasilan