### PR TITLE
Example text added in slcli block access-authorise, slcli block access-list, slcli block access-revoke, slcli block disaster-recovery-failover

### DIFF
--- a/SoftLayer/CLI/block/access/authorize.py
+++ b/SoftLayer/CLI/block/access/authorize.py
@@ -22,7 +22,7 @@ MULTIPLE = '(Multiple allowed)'
 @environment.pass_env
 def cli(env, volume_id, hardware_id, virtual_id, ip_address_id, ip_address):
     """Authorize hosts to access a given volume.
-    
+
     EXAMPLE::
 
             slcli block access-authorize 12345678 --virtual-id 87654321

--- a/SoftLayer/CLI/block/access/authorize.py
+++ b/SoftLayer/CLI/block/access/authorize.py
@@ -21,7 +21,13 @@ MULTIPLE = '(Multiple allowed)'
               help='The ID of one virtual server to authorize. ' + MULTIPLE)
 @environment.pass_env
 def cli(env, volume_id, hardware_id, virtual_id, ip_address_id, ip_address):
-    """Authorize hosts to access a given volume."""
+    """Authorize hosts to access a given volume.
+    
+    EXAMPLE::
+
+            slcli block access-authorize 12345678 --virtual-id 87654321
+            This command authorizes virtual server with ID 87654321 to access volume with ID 12345678.
+    """
     block_manager = SoftLayer.BlockStorageManager(env.client)
     ip_address_id_list = list(ip_address_id)
 

--- a/SoftLayer/CLI/block/access/list.py
+++ b/SoftLayer/CLI/block/access/list.py
@@ -21,7 +21,13 @@ from SoftLayer.CLI import storage_utils
               default='name')
 @environment.pass_env
 def cli(env, columns, sortby, volume_id):
-    """List hosts that are authorized to access the volume."""
+    """List hosts that are authorized to access the volume.
+    
+    EXAMPLE::
+    
+            slcli block access-list 12345678 --sortby id 
+            This command lists all hosts that are authorized to access volume with ID 12345678 and sorts them by ID.
+    """
     block_manager = SoftLayer.BlockStorageManager(env.client)
     resolved_id = helpers.resolve_id(block_manager.resolve_ids, volume_id, 'Volume Id')
     access_list = block_manager.get_block_volume_access_list(

--- a/SoftLayer/CLI/block/access/list.py
+++ b/SoftLayer/CLI/block/access/list.py
@@ -22,10 +22,10 @@ from SoftLayer.CLI import storage_utils
 @environment.pass_env
 def cli(env, columns, sortby, volume_id):
     """List hosts that are authorized to access the volume.
-    
+
     EXAMPLE::
-    
-            slcli block access-list 12345678 --sortby id 
+
+            slcli block access-list 12345678 --sortby id
             This command lists all hosts that are authorized to access volume with ID 12345678 and sorts them by ID.
     """
     block_manager = SoftLayer.BlockStorageManager(env.client)

--- a/SoftLayer/CLI/block/access/revoke.py
+++ b/SoftLayer/CLI/block/access/revoke.py
@@ -18,7 +18,13 @@ from SoftLayer.CLI import environment
               help='The ID of one SoftLayer_Virtual_Guest to revoke authorization.')
 @environment.pass_env
 def cli(env, volume_id, hardware_id, virtual_id, ip_address_id, ip_address):
-    """Revoke authorization for hosts that are accessing a specific volume."""
+    """Revoke authorization for hosts that are accessing a specific volume.
+    
+    EXAMPLE::
+    
+            slcli block access-revoke 12345678 --virtual-id 87654321
+            This command revokes access of virtual server with ID 87654321 to volume with ID 12345678.
+    """
     block_manager = SoftLayer.BlockStorageManager(env.client)
     ip_address_id_list = list(ip_address_id)
 

--- a/SoftLayer/CLI/block/access/revoke.py
+++ b/SoftLayer/CLI/block/access/revoke.py
@@ -19,9 +19,9 @@ from SoftLayer.CLI import environment
 @environment.pass_env
 def cli(env, volume_id, hardware_id, virtual_id, ip_address_id, ip_address):
     """Revoke authorization for hosts that are accessing a specific volume.
-    
+
     EXAMPLE::
-    
+
             slcli block access-revoke 12345678 --virtual-id 87654321
             This command revokes access of virtual server with ID 87654321 to volume with ID 12345678.
     """

--- a/SoftLayer/CLI/block/duplicate_convert_status.py
+++ b/SoftLayer/CLI/block/duplicate_convert_status.py
@@ -7,12 +7,11 @@ from SoftLayer.CLI import environment
 from SoftLayer.CLI import formatting
 
 
-@click.command(cls=SoftLayer.CLI.command.SLCommand,
-               epilog="""Get status for split or move completed percentage of a given block duplicate volume.""")
+@click.command(cls=SoftLayer.CLI.command.SLCommand)
 @click.argument('volume-id')
 @environment.pass_env
 def cli(env, volume_id):
-    """Get status for split or move completed percentage of a given block duplicate volume."""
+    """Get status for split or move completed percentage of a given block storage duplicate volume."""
     table = formatting.Table(['Username', 'Active Conversion Start Timestamp', 'Completed Percentage'])
 
     block_manager = SoftLayer.BlockStorageManager(env.client)

--- a/SoftLayer/CLI/block/replication/disaster_recovery_failover.py
+++ b/SoftLayer/CLI/block/replication/disaster_recovery_failover.py
@@ -9,8 +9,7 @@ from SoftLayer.CLI import formatting
 
 
 @click.command(cls=SoftLayer.CLI.command.SLCommand,
-               epilog="""Failover an inaccessible block volume to its available replicant volume.
-If a volume (with replication) becomes inaccessible due to a disaster event, this method can be used to immediately
+               epilog="""If a volume (with replication) becomes inaccessible due to a disaster event, this method can be used to immediately
 failover to an available replica in another location. This method does not allow for failback via API.
 After using this method, to failback to the original volume, please open a support ticket.
 If you wish to test failover, please use replica-failover.""")
@@ -18,7 +17,12 @@ If you wish to test failover, please use replica-failover.""")
 @click.option('--replicant-id', help="ID of the replicant volume.")
 @environment.pass_env
 def cli(env, volume_id, replicant_id):
-    """Failover an inaccessible block volume to its available replicant volume."""
+    """Failover an inaccessible block volume to its available replicant volume.
+    
+    EXAMPLE::
+            slcli block disaster-recovery-failover 12345678 87654321
+            This command performs failover operation for volume with ID 12345678 to replica volume with ID 87654321.
+    """
     block_storage_manager = SoftLayer.BlockStorageManager(env.client)
 
     click.secho("""WARNING : Failover an inaccessible block volume to its available replicant volume."""

--- a/SoftLayer/CLI/block/replication/disaster_recovery_failover.py
+++ b/SoftLayer/CLI/block/replication/disaster_recovery_failover.py
@@ -9,7 +9,8 @@ from SoftLayer.CLI import formatting
 
 
 @click.command(cls=SoftLayer.CLI.command.SLCommand,
-               epilog="""If a volume (with replication) becomes inaccessible due to a disaster event, this method can be used to immediately
+               epilog="""If a volume (with replication) becomes inaccessible due to a disaster event,
+this method can be used to immediately
 failover to an available replica in another location. This method does not allow for failback via API.
 After using this method, to failback to the original volume, please open a support ticket.
 If you wish to test failover, please use replica-failover.""")
@@ -18,8 +19,9 @@ If you wish to test failover, please use replica-failover.""")
 @environment.pass_env
 def cli(env, volume_id, replicant_id):
     """Failover an inaccessible block volume to its available replicant volume.
-    
+
     EXAMPLE::
+
             slcli block disaster-recovery-failover 12345678 87654321
             This command performs failover operation for volume with ID 12345678 to replica volume with ID 87654321.
     """


### PR DESCRIPTION
Hi @allmightyspiff,

Fixes: #2012 

**Title:**
Example text was missing in slcli block access-authorise, slcli block access-list, slcli block access-revoke, slcli block disaster-recovery-failover

**Description:**
I have added Examples text in these commands.
1. ./slcli block access-authorize --help
2. ./slcli block access-list --help
3. ./slcli block access-revoke --help  
4. ./slcli block disaster-recovery-failover --help
5. ./slcli block duplicate-convert-status --help

Please **review** it.

Please find the screen shots.

**Screen Shot 1:**
<img width="1079" alt="Screenshot 2023-07-24 at 1 34 41 PM" src="https://github.com/softlayer/softlayer-python/assets/125332006/053ea41a-74af-4a99-aac9-b28b90c108ab">

**Screen Shot 2:**
<img width="1337" alt="Screenshot 2023-07-24 at 1 35 48 PM" src="https://github.com/softlayer/softlayer-python/assets/125332006/db5525c9-6aa8-42a2-aff4-2fef06a09ca4">

Thanks,
Ramkishor Chaladi.