### PR TITLE
./slcli account cancel-item message/help text is added.

### DIFF
--- a/SoftLayer/CLI/account/cancel_item.py
+++ b/SoftLayer/CLI/account/cancel_item.py
@@ -11,7 +11,16 @@ from SoftLayer.managers.account import AccountManager as AccountManager
 @click.argument('identifier')
 @environment.pass_env
 def cli(env, identifier):
-    """Cancels a billing item."""
+    """Cancel the resource or service for a billing Item. By default the billing item will be canceled on
+
+    the next bill date and reclaim of the resource will begin shortly after the cancellation
+
+    in ./slcli account cancel-item command.
+
+
+    Cancels a billing item.
+
+    """
 
     manager = AccountManager(env.client)
     item = manager.cancel_item(identifier)


### PR DESCRIPTION
Hi @allmightyspiff,

Fixes: #2010 

**Title:**
./slcli account cancel-item message/help text was missing

**Description:**
I have added the text description in slcli account cancel-item.

Please find the screen shot.

Please review it.

**Screen Shot:**
<img width="765" alt="Screenshot 2023-08-01 at 1 02 13 PM" src="https://github.com/softlayer/softlayer-python/assets/125332006/0af7d50f-c4b9-456b-a6fa-1ed0e500bfcf">


Thanks,
Ramkishor Chaladi.