### PR TITLE
Example for slcli dedicatedhost create-options, slcli dns import, slcli dns record-edit command #2021

### DIFF
--- a/SoftLayer/CLI/dedicatedhost/create_options.py
+++ b/SoftLayer/CLI/dedicatedhost/create_options.py
@@ -22,7 +22,7 @@ from SoftLayer.CLI import formatting
 def cli(env, **kwargs):
     """host order options for a given dedicated host.
 
-    Exmaple::
+    Example::
         To get a list of available backend routers see example:
         slcli dh create-options --datacenter dal05 --flavor 56_CORES_X_242_RAM_X_1_4_TB
 """

--- a/SoftLayer/CLI/dedicatedhost/create_options.py
+++ b/SoftLayer/CLI/dedicatedhost/create_options.py
@@ -22,9 +22,10 @@ from SoftLayer.CLI import formatting
 def cli(env, **kwargs):
     """host order options for a given dedicated host.
 
-    To get a list of available backend routers see example:
-    slcli dh create-options --datacenter dal05 --flavor 56_CORES_X_242_RAM_X_1_4_TB
-    """
+    Exmaple::
+        To get a list of available backend routers see example:
+        slcli dh create-options --datacenter dal05 --flavor 56_CORES_X_242_RAM_X_1_4_TB
+"""
 
     mgr = SoftLayer.DedicatedHostManager(env.client)
     tables = []

--- a/SoftLayer/CLI/dns/record_edit.py
+++ b/SoftLayer/CLI/dns/record_edit.py
@@ -19,7 +19,16 @@ from SoftLayer.CLI import helpers
               help='TTL value in seconds, such as 86400')
 @environment.pass_env
 def cli(env, zone_id, by_record, by_id, data, ttl):
-    """Update DNS record."""
+    """Update DNS record.
+
+    Example::
+        slcli dns record-edit ibm.com --by-id 12345678 --data 127.0.0.2 --ttl 3600
+        This command edits records under the zone: ibm.com, whose ID is 12345678, \
+and sets its data to "127.0.0.2" and ttl to 3600.
+
+        slcli dns record-edit ibm.com --by-record kibana --ttl 3600
+        This command edits records under the zone: ibm.com, whose host is "kibana", and sets their ttl all to 3600.
+"""
     manager = SoftLayer.DNSManager(env.client)
     zone_id = helpers.resolve_id(manager.resolve_ids, zone_id, name='zone')
 

--- a/SoftLayer/CLI/dns/zone_import.py
+++ b/SoftLayer/CLI/dns/zone_import.py
@@ -23,7 +23,12 @@ RECORD_FMT = "type={type}, record={record}, data={data}, ttl={ttl}"
 @click.option('--dry-run', is_flag=True, help="Don't actually create records")
 @environment.pass_env
 def cli(env, zonefile, dry_run):
-    """Import zone based off a BIND zone file."""
+    """Import zone based off a BIND zone file.
+
+    Example::
+        slcli dns import ~/ibm.com.txt
+        This command imports zone and its resource records from file: ~/ibm.com.txt
+"""
 
     manager = SoftLayer.DNSManager(env.client)
     with open(zonefile, encoding="utf-8") as zone_f:


### PR DESCRIPTION
Hi Chris,

Please review this PR.
Fixes: #2021

To Do:
Example for slcli dedicatedhost create-options, slcli dns import, slcli dns record-edit command

Completed the example addition.

Thanks,
Jayasilan