### PR TITLE
Enable all user permissions doesn't get all permissions

### DIFF
--- a/SoftLayer/CLI/user/permissions.py
+++ b/SoftLayer/CLI/user/permissions.py
@@ -45,7 +45,15 @@ def permission_table(user_permissions, all_permissions):
     table.align['Assigned'] = 'l'
     for perm in all_permissions:
         assigned = user_permissions.get(perm['keyName'], False)
-        table.add_row([perm['name'], perm['keyName'], assigned])
+        if (perm['keyName'] == 'ACCOUNT_SUMMARY_VIEW' or perm['keyName'] == 'REQUEST_COMPLIANCE_REPORT' or
+           perm['keyName'] == 'COMPANY_EDIT' or perm['keyName'] == 'ONE_TIME_PAYMENTS' or
+           perm['keyName'] == 'UPDATE_PAYMENT_DETAILS' or perm['keyName'] == 'EU_LIMITED_PROCESSING_MANAGE'
+           or perm['keyName'] == 'TICKET_ADD' or perm['keyName'] == 'TICKET_EDIT'
+           or perm['keyName'] == 'TICKET_SEARCH' or perm['keyName'] == 'TICKET_VIEW'
+           or perm['keyName'] == 'TICKET_VIEW_ALL'):
+            table.add_row(["", "", ""])
+        else:
+            table.add_row([perm['name'], perm['keyName'], assigned])
     return table
 
 

--- a/SoftLayer/CLI/user/permissions.py
+++ b/SoftLayer/CLI/user/permissions.py
@@ -49,9 +49,7 @@ def permission_table(user_permissions, all_permissions):
                                 'COMPANY_EDIT', 'ONE_TIME_PAYMENTS', 'UPDATE_PAYMENT_DETAILS',
                                 'EU_LIMITED_PROCESSING_MANAGE', 'TICKET_ADD', 'TICKET_EDIT',
                                 'TICKET_SEARCH', 'TICKET_VIEW', 'TICKET_VIEW_ALL']
-        if perm['keyName'] in hide_permission_list:
-            table.add_row(["", "", ""])
-        else:
+        if perm['keyName'] not in hide_permission_list:
             table.add_row([perm['name'], perm['keyName'], assigned])
     return table
 

--- a/SoftLayer/CLI/user/permissions.py
+++ b/SoftLayer/CLI/user/permissions.py
@@ -45,12 +45,11 @@ def permission_table(user_permissions, all_permissions):
     table.align['Assigned'] = 'l'
     for perm in all_permissions:
         assigned = user_permissions.get(perm['keyName'], False)
-        if (perm['keyName'] == 'ACCOUNT_SUMMARY_VIEW' or perm['keyName'] == 'REQUEST_COMPLIANCE_REPORT' or
-           perm['keyName'] == 'COMPANY_EDIT' or perm['keyName'] == 'ONE_TIME_PAYMENTS' or
-           perm['keyName'] == 'UPDATE_PAYMENT_DETAILS' or perm['keyName'] == 'EU_LIMITED_PROCESSING_MANAGE'
-           or perm['keyName'] == 'TICKET_ADD' or perm['keyName'] == 'TICKET_EDIT'
-           or perm['keyName'] == 'TICKET_SEARCH' or perm['keyName'] == 'TICKET_VIEW'
-           or perm['keyName'] == 'TICKET_VIEW_ALL'):
+        hide_permission_list = ['ACCOUNT_SUMMARY_VIEW', 'REQUEST_COMPLIANCE_REPORT',
+                                'COMPANY_EDIT', 'ONE_TIME_PAYMENTS', 'UPDATE_PAYMENT_DETAILS',
+                                'EU_LIMITED_PROCESSING_MANAGE', 'TICKET_ADD', 'TICKET_EDIT',
+                                'TICKET_SEARCH', 'TICKET_VIEW', 'TICKET_VIEW_ALL']
+        if perm['keyName'] in hide_permission_list:
             table.add_row(["", "", ""])
         else:
             table.add_row([perm['name'], perm['keyName'], assigned])

--- a/tests/managers/user_tests.py
+++ b/tests/managers/user_tests.py
@@ -183,6 +183,24 @@ class UserManagerTests(testing.TestCase):
         self.assert_called_with(service_name, 'getAllObjects')
         self.assertEqual(expected, result)
 
+    def test_hide_permissions(self):
+        result = self.manager.get_all_permissions()
+        hide_permissions = [
+            {'keyName': 'ACCOUNT_SUMMARY_VIEW'},
+            {'keyName': 'REQUEST_COMPLIANCE_REPORT'},
+            {'keyName': 'COMPANY_EDIT'},
+            {'keyName': 'ONE_TIME_PAYMENTS'},
+            {'keyName': 'UPDATE_PAYMENT_DETAILS'},
+            {'keyName': 'EU_LIMITED_PROCESSING_MANAGE'},
+            {'keyName': 'TICKET_ADD'},
+            {'keyName': 'TICKET_EDIT'},
+            {'keyName': 'TICKET_SEARCH'},
+            {'keyName': 'TICKET_VIEW'},
+            {'keyName': 'TICKET_VIEW_ALL'}
+        ]
+        self.assert_called_with('SoftLayer_User_Permission_Action', 'getAllObjects')
+        self.assertNotEqual(hide_permissions, result)
+
     def test_get_current_user(self):
         result = self.manager.get_current_user()
         self.assert_called_with('SoftLayer_Account', 'getCurrentUser', mask=mock.ANY)


### PR DESCRIPTION
Hi @allmightyspiff,

Fixes: #1956 

**Title:**
Enable all user permissions doesn't get all permissions

**Description:**
I have hidden permissions from permission list.

I have **tested** it, please find the screen shot.

Please **review** it.

**Screen Shot 1:**
<img width="809" alt="Screenshot 2023-08-08 at 12 08 12 AM" src="https://github.com/softlayer/softlayer-python/assets/125332006/4e450876-beb7-464b-99bc-82b48d5f302c">

**Screen Shot 2:**
<img width="931" alt="Screenshot 2023-08-08 at 12 11 08 AM" src="https://github.com/softlayer/softlayer-python/assets/125332006/999a9453-849b-4cdc-9749-3099993c077b">

Thanks,
Ramkishor Chaladi.