### PR TITLE
Added Example and some sub features in slcli file volume-cancel, slcli file volume-duplicate, slcli file volume-limits

### DIFF
--- a/SoftLayer/CLI/file/cancel.py
+++ b/SoftLayer/CLI/file/cancel.py
@@ -16,10 +16,11 @@ from SoftLayer.CLI import formatting
               is_flag=True,
               help="Cancels the file storage volume immediately instead "
                    "of on the billing anniversary")
+@click.option('--force', default=False, is_flag=True, help="Force modify")
 @environment.pass_env
-def cli(env, volume_id, reason, immediate):
+def cli(env, volume_id, reason, immediate, force):
     """Cancel an existing file storage volume.
-    
+
     EXAMPLE::
         slcli file volume-cancel 12345678 --immediate -f
         This command cancels volume with ID 12345678 immediately and without asking for confirmation.
@@ -27,8 +28,9 @@ def cli(env, volume_id, reason, immediate):
 
     file_storage_manager = SoftLayer.FileStorageManager(env.client)
 
-    if not (env.skip_confirmations or formatting.no_going_back(volume_id)):
-        raise exceptions.CLIAbort('Aborted')
+    if not force:
+        if not (env.skip_confirmations or formatting.no_going_back(volume_id)):
+            raise exceptions.CLIAbort('Aborted.')
 
     cancelled = file_storage_manager.cancel_file_volume(volume_id,
                                                         reason, immediate)

--- a/SoftLayer/CLI/file/cancel.py
+++ b/SoftLayer/CLI/file/cancel.py
@@ -18,7 +18,12 @@ from SoftLayer.CLI import formatting
                    "of on the billing anniversary")
 @environment.pass_env
 def cli(env, volume_id, reason, immediate):
-    """Cancel an existing file storage volume."""
+    """Cancel an existing file storage volume.
+    
+    EXAMPLE::
+        slcli file volume-cancel 12345678 --immediate -f
+        This command cancels volume with ID 12345678 immediately and without asking for confirmation.
+    """
 
     file_storage_manager = SoftLayer.FileStorageManager(env.client)
 

--- a/SoftLayer/CLI/file/duplicate.py
+++ b/SoftLayer/CLI/file/duplicate.py
@@ -62,7 +62,12 @@ CONTEXT_SETTINGS = {'token_normalize_func': lambda x: x.upper()}
 def cli(env, origin_volume_id, origin_snapshot_id, duplicate_size,
         duplicate_iops, duplicate_tier, duplicate_snapshot_size, billing,
         dependent_duplicate):
-    """Order a duplicate file storage volume."""
+    """Order a duplicate file storage volume.
+    
+    EXAMPLE::
+        slcli file volume-duplicate 12345678
+        This command shows order a new volume by duplicating the volume with ID 12345678.
+    """
     file_manager = SoftLayer.FileStorageManager(env.client)
 
     hourly_billing_flag = False

--- a/SoftLayer/CLI/file/limit.py
+++ b/SoftLayer/CLI/file/limit.py
@@ -18,7 +18,12 @@ DEFAULT_COLUMNS = [
 @click.option('--datacenter', '-d', help='Filter by datacenter')
 @environment.pass_env
 def cli(env, sortby, datacenter):
-    """List number of block storage volumes limit per datacenter."""
+    """List number of block storage volumes limit per datacenter.
+    
+    EXAMPLE:
+        slcli file volume-limits
+        This command lists the storage limits per datacenter for this account.
+    """
     file_manager = SoftLayer.FileStorageManager(env.client)
     file_volumes = file_manager.list_file_volume_limit()
 

--- a/SoftLayer/CLI/file/limit.py
+++ b/SoftLayer/CLI/file/limit.py
@@ -19,7 +19,7 @@ DEFAULT_COLUMNS = [
 @environment.pass_env
 def cli(env, sortby, datacenter):
     """List number of block storage volumes limit per datacenter.
-    
+
     EXAMPLE:
         slcli file volume-limits
         This command lists the storage limits per datacenter for this account.

--- a/tests/CLI/modules/file_tests.py
+++ b/tests/CLI/modules/file_tests.py
@@ -850,3 +850,17 @@ class FileTests(testing.TestCase):
         result = self.run_command(['file', 'snapshot-cancel', '4917309'])
         self.assertEqual(2, result.exit_code)
         self.assertEqual('Aborted.', result.exception.message)
+
+    @mock.patch('SoftLayer.CLI.formatting.confirm')
+    def test_file_volume_cancel_force(self, confirm_mock):
+        confirm_mock.return_value = False
+        result = self.run_command(['file', 'volume-cancel', '1234'])
+        self.assertEqual(2, result.exit_code)
+        self.assertEqual('Aborted.', result.exception.message)
+
+    @mock.patch('SoftLayer.CLI.formatting.confirm')
+    def test_file_volume_duplicate_force(self, confirm_mock):
+        confirm_mock.return_value = False
+        result = self.run_command(['file', 'volume-duplicate', '100'])
+        self.assertEqual(2, result.exit_code)
+        self.assertEqual('Aborted.', result.exception.message)


### PR DESCRIPTION
Hi @allmightyspiff,

Fixes: #2029 

Title:
Example and some sub features are missing in slcli file volume-cancel, slcli file volume-duplicate, slcli file volume-limits

Description:
I have added example for volume of limit, cancel and duplicate commands.
I have added force feature for volume of cancel and duplicate command.

Please review it.

Thanks,
Ramkishor Chaladi.