### PR TITLE
Support Click 8.2+

### DIFF
--- a/SoftLayer/CLI/formatting.py
+++ b/SoftLayer/CLI/formatting.py
@@ -260,7 +260,10 @@ def no_going_back(confirmation):
 
     prompt = f"This action cannot be undone! Type '{confirmation}' or press Enter to abort"
 
-    ans = click.prompt(prompt, default='', show_default=False)
+    try:
+        ans = click.prompt(prompt, default='', show_default=False)
+    except click.exceptions.Abort:
+        return False
     if ans.lower() == str(confirmation).lower():
         return True
 


### PR DESCRIPTION
Click 8.2 and above will now force an abort if a confirmation prompt isn't answered, rather than raising the CLIAbort that is expected. Catch this exception so that our own exceptions are raised.