### PR TITLE
Remove unused dependency prettytable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,7 +173,6 @@ If you cannot install python 3.6+ for some reason, you will need to use a versio
 
 Python Packages
 ---------------
-* prettytable >= 2.5.0
 * click >= 8.0.4
 * requests >= 2.32.2
 * prompt_toolkit >= 2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,5 @@ sphinx_rtd_theme==3.0.2
 sphinx==8.2.3
 sphinx-click==6.0.0
 click
-prettytable
 rich
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
     },
     python_requires='>=3.7',
     install_requires=[
-        'prettytable >= 2.5.0',
         'click >= 8.0.4',
         'requests >= 2.32.2',
         'prompt_toolkit >= 2',

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,4 @@
-prettytable >= 2.5.0
+
 click >= 8.0.4
 requests >= 2.32.2
 prompt_toolkit >= 2

--- a/tools/test-requirements.txt
+++ b/tools/test-requirements.txt
@@ -4,7 +4,6 @@ pytest
 pytest-cov
 mock
 sphinx
-prettytable >= 2.5.0
 click >= 8.0.4
 requests >= 2.32.2
 prompt_toolkit >= 2


### PR DESCRIPTION
As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the dependency `prettytable` is specified as a requirement in the configuration files, when in reality it is not needed.

The dependency is unused since 1238377, where its import was removed.

Hope this is helpful!

Best regards